### PR TITLE
feat: Integrate Monaco

### DIFF
--- a/packages/monaco/LICENSE
+++ b/packages/monaco/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2021-present Johnson Chu
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/monaco/README.md
+++ b/packages/monaco/README.md
@@ -1,0 +1,97 @@
+# @volar/monaco
+
+`@volar/monaco` is used to bridge the language capabilities implemented based on Volar.js to Monaco Editor, you can expect:
+
+- Support IntelliSense, Diagnosis, Formatting
+- Language behavior is consistent with regular IDEs
+- Optimized Performance
+- Missing package types are automatically fetched from CDN
+
+It should be noted that this package does not participate in syntax highlighting support and language configuration.
+
+We assume you already know:
+
+- How to create a Monaco Editor
+- How to work with Web Worker
+
+## Usage
+
+### Setup worker
+
+```ts
+// my-lang.worker.ts
+import * as worker from 'monaco-editor-core/esm/vs/editor/editor.worker';
+import type * as monaco from 'monaco-editor-core';
+import { createLanguageService } from '@volar/monaco/worker';
+
+self.onmessage = () => {
+	worker.initialize((ctx: monaco.worker.IWorkerContext) => {
+		return createLanguageService({
+			workerContext: ctx,
+			config: {
+				// ...Language Service Config of my-lang language support
+			},
+		});
+	});
+};
+```
+
+#### TypeScript Support
+
+```ts
+import { createLanguageService } from '@volar/monaco/worker';
+import * as ts from 'typescript';
+
+createLanguageService({
+	// ...
+	typescript: {
+		module: ts as any,
+		compilerOptions: {
+			// ...tsconfig options
+		},
+		// Enable auto fetch node_modules types
+		autoFetchTypes: true,
+	},
+});
+```
+
+### Add worker loader to global env
+
+```ts
+import editorWorker from 'monaco-editor-core/esm/vs/editor/editor.worker?worker';
+import myWorker from './my-lang.worker?worker';
+
+(self as any).MonacoEnvironment = {
+	getWorker(_: any, label: string) {
+		if (label === 'my-lang') {
+			return new myWorker();
+		}
+		return new editorWorker();
+	}
+}
+```
+
+### Setup Language Features and Diagnostics
+
+```ts
+import type { LanguageService } from '@volar/language-service';
+import { editor, languages } from 'monaco-editor-core';
+import * as VolarMonaco from '@volar/monaco';
+
+languages.register({ id: 'my-lang', extensions: ['.my-lang'] });
+
+languages.onLanguage('my-lang', () => {
+	const worker = editor.createWebWorker<LanguageService>({
+		moduleId: 'vs/language/my-lang/myLangWorker',
+		label: 'my-lang',
+	});
+	VolarMonaco.editor.activateMarkers(worker, ['my-lang'], 'my-lang-markers-owner', editor);
+	VolarMonaco.languages.registerProvides(worker, ['my-lang'], languages)
+});
+```
+
+
+## Samples
+
+- Implementation for Vue:\
+  https://github.com/Kingwl/monaco-volar

--- a/packages/monaco/package.json
+++ b/packages/monaco/package.json
@@ -1,0 +1,24 @@
+{
+	"name": "@volar/monaco",
+	"version": "1.2.0-alpha.19",
+	"main": "out/index.js",
+	"license": "MIT",
+	"files": [
+		"*.js",
+		"*.d.ts",
+		"out/**/*.js",
+		"out/**/*.d.ts"
+	],
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/volarjs/volar.js.git",
+		"directory": "packages/monaco"
+	},
+	"dependencies": {
+		"@volar/language-service": "1.2.0-alpha.19",
+		"axios": "^1.3.4",
+		"monaco-editor-core": "^0.36.0",
+		"vscode-languageserver-protocol": "^3.17.3",
+		"vscode-uri": "^3.0.7"
+	}
+}

--- a/packages/monaco/src/editor.ts
+++ b/packages/monaco/src/editor.ts
@@ -1,0 +1,110 @@
+import type { LanguageService } from '@volar/language-service';
+import type { editor as _editor, IDisposable, Uri } from 'monaco-editor-core';
+import { markers } from './utils/markers';
+import * as protocol2monaco from './utils/protocol2monaco';
+
+interface IInternalEditorModel extends _editor.IModel {
+	onDidChangeAttached(listener: () => void): IDisposable;
+	isAttachedToEditor(): boolean;
+}
+
+export namespace editor {
+
+	export function activateMarkers(
+		worker: _editor.MonacoWebWorker<LanguageService>,
+		languages: string[],
+		markersOwn: string,
+		editor: typeof import('monaco-editor-core').editor,
+	): IDisposable {
+
+		const disposables: IDisposable[] = [];
+		const listener = new Map<string, IDisposable>();
+
+		disposables.push(
+			editor.onDidCreateModel((model) => hostingMarkers(model)),
+			editor.onWillDisposeModel(stopHostingMarkers),
+			editor.onDidChangeModelLanguage((event) => {
+				stopHostingMarkers(event.model);
+				hostingMarkers(event.model);
+			}),
+			{
+				dispose: () => {
+					for (const model of editor.getModels()) {
+						stopHostingMarkers(model);
+					}
+				}
+			},
+		);
+
+		for (const model of editor.getModels()) {
+			hostingMarkers(model);
+		}
+
+		return { dispose: () => disposables.forEach((d) => d.dispose()) };
+
+		function stopHostingMarkers(model: _editor.IModel): void {
+			editor.setModelMarkers(model, markersOwn, []);
+			const key = model.uri.toString();
+			if (listener.has(key)) {
+				listener.get(key)?.dispose();
+				listener.delete(key);
+			}
+		}
+
+		function hostingMarkers(model: IInternalEditorModel): void {
+			if (!languages.includes(model.getLanguageId())) {
+				return;
+			}
+
+			let timer: NodeJS.Timeout | undefined;
+			const changeSubscription = model.onDidChangeContent(() => {
+				clearTimeout(timer);
+				timer = setTimeout(() => doValidation(model), 200);
+			});
+			const visibleSubscription = model.onDidChangeAttached(() => {
+				if (model.isAttachedToEditor()) {
+					doValidation(model);
+				} else {
+					editor.setModelMarkers(model, markersOwn, []);
+				}
+			});
+
+			listener.set(
+				model.uri.toString(),
+				{
+					dispose: () => {
+						changeSubscription.dispose();
+						visibleSubscription.dispose();
+						clearTimeout(timer);
+					}
+				},
+			);
+
+			doValidation(model);
+		}
+
+		async function doValidation(model: _editor.ITextModel) {
+			if (model.isDisposed()) {
+				return;
+			}
+			if (!model.isAttachedToEditor()) {
+				return;
+			}
+
+			const languageService = await getLanguageService(model.uri);
+			const diagnostics = await languageService.doValidation(model.uri.toString());
+			const result = diagnostics.map(error => {
+				const marker = protocol2monaco.asMarkerData(error);
+				markers.set(marker, error);
+				return marker;
+			});
+
+			editor.setModelMarkers(model, markersOwn, result);
+		}
+
+		async function getLanguageService(...uris: Uri[]) {
+			await worker.withSyncedResources(uris);
+			return worker.getProxy();
+		}
+	}
+}

--- a/packages/monaco/src/index.ts
+++ b/packages/monaco/src/index.ts
@@ -1,0 +1,2 @@
+export * from './languages';
+export * from './editor';

--- a/packages/monaco/src/languages.ts
+++ b/packages/monaco/src/languages.ts
@@ -1,0 +1,45 @@
+import type {
+	editor,
+	languages as _languages,
+	IDisposable,
+} from 'monaco-editor-core';
+import type { LanguageService } from '@volar/language-service';
+import { createLanguageFeaturesProvider } from './utils/provider';
+
+export namespace languages {
+
+	export async function registerProvides(
+		worker: editor.MonacoWebWorker<LanguageService>,
+		language: _languages.LanguageSelector,
+		languages: typeof import('monaco-editor-core').languages,
+	): Promise<IDisposable> {
+
+		const provider = await createLanguageFeaturesProvider(worker);
+		const disposables: IDisposable[] = [
+			languages.registerHoverProvider(language, provider),
+			languages.registerReferenceProvider(language, provider),
+			languages.registerRenameProvider(language, provider),
+			languages.registerSignatureHelpProvider(language, provider),
+			languages.registerDocumentSymbolProvider(language, provider),
+			languages.registerDocumentHighlightProvider(language, provider),
+			languages.registerLinkedEditingRangeProvider(language, provider),
+			languages.registerDefinitionProvider(language, provider),
+			languages.registerImplementationProvider(language, provider),
+			languages.registerTypeDefinitionProvider(language, provider),
+			languages.registerCodeLensProvider(language, provider),
+			languages.registerCodeActionProvider(language, provider),
+			languages.registerDocumentFormattingEditProvider(language, provider),
+			languages.registerDocumentRangeFormattingEditProvider(language, provider),
+			languages.registerOnTypeFormattingEditProvider(language, provider),
+			languages.registerLinkProvider(language, provider),
+			languages.registerCompletionItemProvider(language, provider),
+			languages.registerColorProvider(language, provider),
+			languages.registerFoldingRangeProvider(language, provider),
+			languages.registerDeclarationProvider(language, provider),
+			languages.registerSelectionRangeProvider(language, provider),
+			languages.registerInlayHintsProvider(language, provider),
+		];
+
+		return { dispose: () => disposables.forEach((d) => d.dispose()) };
+	}
+}

--- a/packages/monaco/src/utils/autoFetchTypes.ts
+++ b/packages/monaco/src/utils/autoFetchTypes.ts
@@ -1,0 +1,71 @@
+import axios from 'axios';
+
+export function createAutoTypesFetchingHost(cdn: string) {
+
+	const fetchTasks: [string, Promise<void>][] = [];
+	const files = new Map<string, string | undefined>();
+
+	let fetching: Promise<void> | undefined;
+
+	return {
+		fileExists,
+		readFile,
+		files,
+		wait: async () => await fetching,
+	};
+
+	function fileExists(fileName: string): boolean {
+		return readFile(fileName) !== undefined;
+	}
+
+	function readFile(fileName: string) {
+		if (!files.has(fileName)) {
+			files.set(fileName, undefined);
+			fetch(fileName);
+		}
+		return files.get(fileName);
+	}
+
+	async function readFileAsync(fileName: string) {
+		if (fileName.startsWith('/node_modules/')) {
+			const url = cdn + fileName.slice('/node_modules/'.length);
+			const text = await readWebFile(url);
+			files.set(fileName, text);
+		}
+	}
+
+	async function readWebFile(uri: string) {
+		// ignore .js because it's no help for intellisense
+		if (uri.endsWith('.d.ts') || uri.endsWith('.json')) {
+			try {
+				return (await axios.get(uri, {
+					transformResponse: (res) => {
+						// avoid parse to json object
+						return res;
+					},
+				})).data as string ?? undefined;
+			} catch {
+				// ignore
+			}
+		}
+	}
+
+	async function fetch(fileName: string) {
+
+		fetchTasks.push([fileName, readFileAsync(fileName)]);
+
+		if (!fetching) {
+			fetching = fetchWorker();
+			await fetching;
+			fetching = undefined;
+		}
+	}
+
+	async function fetchWorker() {
+		while (fetchTasks.length) {
+			const tasks = fetchTasks.map(([_, task]) => task);
+			fetchTasks.length = 0;
+			await Promise.all(tasks);
+		}
+	}
+}

--- a/packages/monaco/src/utils/markers.ts
+++ b/packages/monaco/src/utils/markers.ts
@@ -1,0 +1,4 @@
+import * as vscode from 'vscode-languageserver-protocol';
+import type { editor } from 'monaco-editor-core';
+
+export const markers = new WeakMap<editor.IMarkerData, vscode.Diagnostic>();

--- a/packages/monaco/src/utils/monaco2protocol.ts
+++ b/packages/monaco/src/utils/monaco2protocol.ts
@@ -1,0 +1,40 @@
+import { IRange, languages, Position } from 'monaco-editor-core';
+import * as protocol from 'vscode-languageserver-protocol';
+
+export function asPosition(position: Position): protocol.Position {
+	return protocol.Position.create(position.lineNumber - 1, position.column - 1);
+}
+
+export function asRange(range: IRange): protocol.Range {
+	return protocol.Range.create(
+		range.startLineNumber - 1,
+		range.startColumn - 1,
+		range.endLineNumber - 1,
+		range.endColumn - 1
+	);
+}
+
+export function asCompletionContext(context: languages.CompletionContext): protocol.CompletionContext {
+	return {
+		triggerKind: asTriggerKind(context.triggerKind),
+		triggerCharacter: context.triggerCharacter,
+	};
+}
+
+export function asTriggerKind(kind: languages.CompletionTriggerKind): protocol.CompletionTriggerKind {
+	switch (kind) {
+		case languages.CompletionTriggerKind.Invoke:
+			return protocol.CompletionTriggerKind.Invoked;
+		case languages.CompletionTriggerKind.TriggerCharacter:
+			return protocol.CompletionTriggerKind.TriggerCharacter;
+		case languages.CompletionTriggerKind.TriggerForIncompleteCompletions:
+			return protocol.CompletionTriggerKind.TriggerForIncompleteCompletions;
+	}
+}
+
+export function asFormattingOptions(options: languages.FormattingOptions): protocol.FormattingOptions {
+	return {
+		tabSize: options.tabSize,
+		insertSpaces: options.insertSpaces,
+	};
+}

--- a/packages/monaco/src/utils/protocol2monaco.ts
+++ b/packages/monaco/src/utils/protocol2monaco.ts
@@ -1,0 +1,490 @@
+import { editor, IMarkdownString, IRange, languages, MarkerSeverity, MarkerTag, Position, Uri } from 'monaco-editor-core';
+import * as protocol from 'vscode-languageserver-protocol';
+
+export function asCompletionList(list: protocol.CompletionList, range: protocol.Range): languages.CompletionList {
+	return {
+		incomplete: list.isIncomplete,
+		suggestions: list.items.map(item => asCompletionItem(item, range)),
+	};
+}
+
+export function asCompletionItemKind(kind: protocol.CompletionItemKind | undefined): languages.CompletionItemKind {
+	switch (kind) {
+		case protocol.CompletionItemKind.Method:
+			return languages.CompletionItemKind.Method;
+		case protocol.CompletionItemKind.Function:
+			return languages.CompletionItemKind.Function;
+		case protocol.CompletionItemKind.Constructor:
+			return languages.CompletionItemKind.Constructor;
+		case protocol.CompletionItemKind.Field:
+			return languages.CompletionItemKind.Field;
+		case protocol.CompletionItemKind.Variable:
+			return languages.CompletionItemKind.Variable;
+		case protocol.CompletionItemKind.Class:
+			return languages.CompletionItemKind.Class;
+		case protocol.CompletionItemKind.Interface:
+			return languages.CompletionItemKind.Interface;
+		case protocol.CompletionItemKind.Module:
+			return languages.CompletionItemKind.Module;
+		case protocol.CompletionItemKind.Property:
+			return languages.CompletionItemKind.Property;
+		case protocol.CompletionItemKind.Unit:
+			return languages.CompletionItemKind.Unit;
+		case protocol.CompletionItemKind.Value:
+			return languages.CompletionItemKind.Value;
+		case protocol.CompletionItemKind.Enum:
+			return languages.CompletionItemKind.Enum;
+		case protocol.CompletionItemKind.Keyword:
+			return languages.CompletionItemKind.Keyword;
+		case protocol.CompletionItemKind.Snippet:
+			return languages.CompletionItemKind.Snippet;
+		case protocol.CompletionItemKind.Text:
+			return languages.CompletionItemKind.Text;
+		case protocol.CompletionItemKind.Color:
+			return languages.CompletionItemKind.Color;
+		case protocol.CompletionItemKind.File:
+			return languages.CompletionItemKind.File;
+		case protocol.CompletionItemKind.Reference:
+			return languages.CompletionItemKind.Reference;
+		case protocol.CompletionItemKind.Folder:
+			return languages.CompletionItemKind.Folder;
+		case protocol.CompletionItemKind.EnumMember:
+			return languages.CompletionItemKind.EnumMember;
+		case protocol.CompletionItemKind.Constant:
+			return languages.CompletionItemKind.Constant;
+		case protocol.CompletionItemKind.Struct:
+			return languages.CompletionItemKind.Struct;
+		case protocol.CompletionItemKind.Event:
+			return languages.CompletionItemKind.Event;
+		case protocol.CompletionItemKind.Operator:
+			return languages.CompletionItemKind.Operator;
+		case protocol.CompletionItemKind.TypeParameter:
+			return languages.CompletionItemKind.TypeParameter;
+		default:
+			return languages.CompletionItemKind.Text;
+	}
+}
+
+export function asCompletionItem(item: protocol.CompletionItem, range: protocol.Range): languages.CompletionItem {
+	return {
+		label: item.label,
+		kind: asCompletionItemKind(item.kind),
+		tags: item.tags,
+		detail: item.detail,
+		documentation: item.documentation,
+		sortText: item.sortText,
+		filterText: item.filterText,
+		preselect: item.preselect,
+		insertText: item.textEdit?.newText ?? item.insertText ?? item.label,
+		insertTextRules: languages.CompletionItemInsertTextRule.InsertAsSnippet,
+		range: item.textEdit ? asCompletionItemRange(item.textEdit) : asRange(range),
+		commitCharacters: item.commitCharacters,
+		additionalTextEdits: item.additionalTextEdits?.map(asTextEdit),
+		command: item.command ? asCommand(item.command) : undefined,
+	};
+}
+
+export function asCommand(command: protocol.Command): languages.Command {
+	return {
+		id: command.command,
+		title: command.title,
+		arguments: command.arguments,
+	};
+}
+
+export function asTextEdit(edit: protocol.TextEdit): languages.TextEdit {
+	return {
+		range: asRange(edit.range),
+		text: edit.newText,
+	};
+}
+
+export function asCompletionItemRange(textEdit: NonNullable<protocol.CompletionItem['textEdit']>): languages.CompletionItem['range'] {
+	if (protocol.InsertReplaceEdit.is(textEdit)) {
+		const result: languages.CompletionItemRanges = {
+			insert: asRange(textEdit.insert),
+			replace: asRange(textEdit.replace),
+		};
+		return result;
+	}
+	return asRange(textEdit.range);
+}
+
+export function asRange(range: protocol.Range): IRange {
+	return {
+		startLineNumber: range.start.line + 1,
+		startColumn: range.start.character + 1,
+		endLineNumber: range.end.line + 1,
+		endColumn: range.end.character + 1,
+	};
+}
+
+export function asHover(hover: protocol.Hover): languages.Hover {
+	return {
+		contents: asMarkdownString(hover.contents),
+		range: hover.range ? asRange(hover.range) : undefined,
+	};
+}
+
+export function asMarkdownString(markdownString: protocol.Hover['contents']): IMarkdownString[] {
+	if (typeof markdownString === 'string') {
+		return [{ value: markdownString }];
+	} else if (Array.isArray(markdownString)) {
+		return markdownString.map(asMarkdownString).flat();
+	} else {
+		return [markdownString];
+	}
+}
+
+export function asLocation(definition: protocol.LocationLink | protocol.Location): languages.Location {
+	if (protocol.LocationLink.is(definition)) {
+		return {
+			uri: asUri(definition.targetUri),
+			range: asRange(definition.targetSelectionRange),
+		};
+	} else {
+		return {
+			uri: asUri(definition.uri),
+			range: asRange(definition.range),
+		};
+	}
+}
+
+export function asUri(uri: protocol.URI): Uri {
+	return Uri.parse(uri);
+}
+
+export function asSignatureHelp(signatureHelp: protocol.SignatureHelp): languages.SignatureHelp {
+	return {
+		signatures: signatureHelp.signatures.map(asSignatureInformation),
+		activeSignature: signatureHelp.activeSignature ?? 0,
+		activeParameter: signatureHelp.activeParameter ?? 0,
+	};
+}
+
+export function asSignatureInformation(signatureInformation: protocol.SignatureInformation): languages.SignatureInformation {
+	return {
+		label: signatureInformation.label,
+		documentation: signatureInformation.documentation,
+		parameters: signatureInformation.parameters
+			? signatureInformation.parameters.map(asParameterInformation)
+			: [],
+		activeParameter: signatureInformation.activeParameter,
+	};
+}
+
+export function asParameterInformation(parameterInformation: protocol.ParameterInformation): languages.ParameterInformation {
+	return {
+		label: parameterInformation.label,
+		documentation: parameterInformation.documentation,
+	};
+}
+
+export function asMarkerData(diagnostic: protocol.Diagnostic): editor.IMarkerData {
+	return {
+		code: diagnostic.code?.toString(),
+		severity: asMarkerSeverity(diagnostic.severity),
+		message: diagnostic.message,
+		source: diagnostic.source,
+		...asRange(diagnostic.range),
+		relatedInformation:
+			diagnostic.relatedInformation?.map(asRelatedInformation),
+		tags: diagnostic.tags?.map(asMarkerTag),
+	};
+}
+
+export function asMarkerTag(tag: protocol.DiagnosticTag): MarkerTag {
+	switch (tag) {
+		case protocol.DiagnosticTag.Unnecessary:
+			return MarkerTag.Unnecessary;
+		case protocol.DiagnosticTag.Deprecated:
+			return MarkerTag.Deprecated;
+	}
+}
+
+export function asRelatedInformation(relatedInformation: protocol.DiagnosticRelatedInformation): editor.IRelatedInformation {
+	return {
+		resource: asUri(relatedInformation.location.uri),
+		message: relatedInformation.message,
+		...asRange(relatedInformation.location.range),
+	};
+}
+
+export function asMarkerSeverity(severity: protocol.DiagnosticSeverity | undefined): MarkerSeverity {
+	switch (severity) {
+		case protocol.DiagnosticSeverity.Error:
+			return MarkerSeverity.Error;
+		case protocol.DiagnosticSeverity.Warning:
+			return MarkerSeverity.Warning;
+		case protocol.DiagnosticSeverity.Information:
+			return MarkerSeverity.Info;
+		case protocol.DiagnosticSeverity.Hint:
+			return MarkerSeverity.Hint;
+		default:
+			return MarkerSeverity.Info;
+	}
+}
+
+export function asWorkspaceEdit(workspaceEdit: protocol.WorkspaceEdit): languages.WorkspaceEdit {
+	const result: languages.WorkspaceEdit = {
+		edits: [],
+	};
+	if (workspaceEdit.changes) {
+		for (const uri in workspaceEdit.changes) {
+			const edits = workspaceEdit.changes[uri];
+			for (const edit of edits) {
+				result.edits.push({
+					resource: asUri(uri),
+					textEdit: asTextEdit(edit),
+					versionId: undefined,
+				});
+			}
+		}
+	}
+	if (workspaceEdit.documentChanges) {
+		for (const documentChange of workspaceEdit.documentChanges) {
+			if (protocol.TextDocumentEdit.is(documentChange)) {
+				for (const edit of documentChange.edits) {
+					result.edits.push({
+						resource: asUri(documentChange.textDocument.uri),
+						textEdit: asTextEdit(edit),
+						versionId: documentChange.textDocument.version ?? undefined,
+					});
+				}
+			} else if (protocol.CreateFile.is(documentChange)) {
+				result.edits.push({
+					newResource: asUri(documentChange.uri),
+					options: {
+						overwrite: documentChange.options?.overwrite ?? false,
+						ignoreIfExists: documentChange.options?.ignoreIfExists ?? false,
+					},
+				});
+			} else if (protocol.RenameFile.is(documentChange)) {
+				result.edits.push({
+					oldResource: asUri(documentChange.oldUri),
+					newResource: asUri(documentChange.newUri),
+					options: {
+						overwrite: documentChange.options?.overwrite ?? false,
+						ignoreIfExists: documentChange.options?.ignoreIfExists ?? false,
+					},
+				});
+			} else if (protocol.DeleteFile.is(documentChange)) {
+				result.edits.push({
+					oldResource: asUri(documentChange.uri),
+					options: {
+						recursive: documentChange.options?.recursive ?? false,
+						ignoreIfNotExists:
+							documentChange.options?.ignoreIfNotExists ?? false,
+					},
+				});
+			}
+		}
+	}
+	return result;
+}
+
+export function asDocumentSymbol(symbol: protocol.DocumentSymbol): languages.DocumentSymbol {
+	return {
+		name: symbol.name,
+		detail: '',
+		kind: asSymbolKind(symbol.kind),
+		tags: symbol.tags?.map(asSymbolTag) ?? [],
+		range: asRange(symbol.range),
+		selectionRange: asRange(symbol.selectionRange),
+		children: symbol.children
+			? symbol.children.map(asDocumentSymbol)
+			: undefined,
+	};
+}
+
+export function asSymbolTag(tag: protocol.SymbolTag): languages.SymbolTag {
+	switch (tag) {
+		case protocol.SymbolTag.Deprecated:
+			return languages.SymbolTag.Deprecated;
+	}
+}
+
+export function asSymbolKind(kind: protocol.SymbolKind): languages.SymbolKind {
+	switch (kind) {
+		case protocol.SymbolKind.File:
+			return languages.SymbolKind.File;
+		case protocol.SymbolKind.Module:
+			return languages.SymbolKind.Module;
+		case protocol.SymbolKind.Namespace:
+			return languages.SymbolKind.Namespace;
+		case protocol.SymbolKind.Package:
+			return languages.SymbolKind.Package;
+		case protocol.SymbolKind.Class:
+			return languages.SymbolKind.Class;
+		case protocol.SymbolKind.Method:
+			return languages.SymbolKind.Method;
+		case protocol.SymbolKind.Property:
+			return languages.SymbolKind.Property;
+		case protocol.SymbolKind.Field:
+			return languages.SymbolKind.Field;
+		case protocol.SymbolKind.Constructor:
+			return languages.SymbolKind.Constructor;
+		case protocol.SymbolKind.Enum:
+			return languages.SymbolKind.Enum;
+		case protocol.SymbolKind.Interface:
+			return languages.SymbolKind.Interface;
+		case protocol.SymbolKind.Function:
+			return languages.SymbolKind.Function;
+		case protocol.SymbolKind.Variable:
+			return languages.SymbolKind.Variable;
+		case protocol.SymbolKind.Constant:
+			return languages.SymbolKind.Constant;
+		case protocol.SymbolKind.String:
+			return languages.SymbolKind.String;
+		case protocol.SymbolKind.Number:
+			return languages.SymbolKind.Number;
+		case protocol.SymbolKind.Boolean:
+			return languages.SymbolKind.Boolean;
+		case protocol.SymbolKind.Array:
+			return languages.SymbolKind.Array;
+		case protocol.SymbolKind.Object:
+			return languages.SymbolKind.Object;
+		case protocol.SymbolKind.Key:
+			return languages.SymbolKind.Key;
+		case protocol.SymbolKind.Null:
+			return languages.SymbolKind.Null;
+		case protocol.SymbolKind.EnumMember:
+			return languages.SymbolKind.EnumMember;
+		case protocol.SymbolKind.Struct:
+			return languages.SymbolKind.Struct;
+		case protocol.SymbolKind.Event:
+			return languages.SymbolKind.Event;
+		case protocol.SymbolKind.Operator:
+			return languages.SymbolKind.Operator;
+		case protocol.SymbolKind.TypeParameter:
+			return languages.SymbolKind.TypeParameter;
+		default:
+			return languages.SymbolKind.File;
+	}
+}
+
+export function asDocumentHighlight(highlight: protocol.DocumentHighlight): languages.DocumentHighlight {
+	return {
+		range: asRange(highlight.range),
+		kind: asDocumentHighlightKind(highlight.kind),
+	};
+}
+
+export function asDocumentHighlightKind(kind: protocol.DocumentHighlightKind | undefined): languages.DocumentHighlightKind {
+	switch (kind) {
+		case protocol.DocumentHighlightKind.Text:
+			return languages.DocumentHighlightKind.Text;
+		case protocol.DocumentHighlightKind.Read:
+			return languages.DocumentHighlightKind.Read;
+		case protocol.DocumentHighlightKind.Write:
+			return languages.DocumentHighlightKind.Write;
+		default:
+			return languages.DocumentHighlightKind.Text;
+	}
+}
+
+export function asCodeLens(item: protocol.CodeLens): languages.CodeLens {
+	return {
+		range: asRange(item.range),
+		command: item.command ? asCommand(item.command) : undefined,
+	};
+}
+
+export function asCodeAction(item: protocol.CodeAction): languages.CodeAction {
+	return {
+		title: item.title,
+		command: item.command ? asCommand(item.command) : undefined,
+		edit: item.edit ? asWorkspaceEdit(item.edit) : undefined,
+		diagnostics: item.diagnostics
+			? item.diagnostics.map(asMarkerData)
+			: undefined,
+		kind: item.kind,
+		isPreferred: item.isPreferred,
+		disabled: item.disabled?.reason,
+	};
+}
+
+export function asLink(item: protocol.DocumentLink): languages.ILink {
+	return {
+		range: asRange(item.range),
+		url: item.target,
+		tooltip: item.tooltip,
+	};
+}
+
+export function asColorInformation(item: protocol.ColorInformation): languages.IColorInformation {
+	return {
+		range: asRange(item.range),
+		color: item.color,
+	};
+}
+
+export function asColorPresentation(item: protocol.ColorPresentation): languages.IColorPresentation {
+	return {
+		label: item.label,
+		textEdit: item.textEdit ? asTextEdit(item.textEdit) : undefined,
+		additionalTextEdits: item.additionalTextEdits
+			? item.additionalTextEdits.map(asTextEdit)
+			: undefined,
+	};
+}
+
+export function asFoldingRange(item: protocol.FoldingRange): languages.FoldingRange {
+	return {
+		start: item.startLine + 1,
+		end: item.endLine + 1,
+		kind: {
+			value: item.kind ?? '',
+		},
+	};
+}
+
+export function asSelectionRange(item: protocol.SelectionRange): languages.SelectionRange {
+	return {
+		range: asRange(item.range),
+	};
+}
+
+export function asInlayHint(item: protocol.InlayHint): languages.InlayHint {
+	return {
+		label: asInlayHintLabel(item.label),
+		tooltip: item.tooltip,
+		position: asPosition(item.position),
+		kind: item.kind ? asInlayHintKind(item.kind) : undefined,
+		paddingLeft: item.paddingLeft,
+		paddingRight: item.paddingRight,
+	};
+}
+
+export function asInlayHintKind(kind: protocol.InlayHintKind): languages.InlayHintKind {
+	switch (kind) {
+		case protocol.InlayHintKind.Parameter:
+			return languages.InlayHintKind.Parameter;
+		case protocol.InlayHintKind.Type:
+			return languages.InlayHintKind.Type;
+	}
+}
+
+export function asInlayHintLabel(label: protocol.InlayHint['label']): languages.InlayHint['label'] {
+	if (typeof label === 'string') {
+		return label;
+	} else {
+		return label.map(asInlayHintLabelPart);
+	}
+}
+
+export function asInlayHintLabelPart(part: protocol.InlayHintLabelPart): languages.InlayHintLabelPart {
+	return {
+		label: part.value,
+		tooltip: part.tooltip,
+		command: part.command ? asCommand(part.command) : undefined,
+		location: part.location ? asLocation(part.location) : undefined,
+	};
+}
+
+export function asPosition(position: protocol.Position): Position {
+	return new Position(
+		position.line + 1,
+		position.character + 1,
+	);
+}

--- a/packages/monaco/src/utils/provider.ts
+++ b/packages/monaco/src/utils/provider.ts
@@ -1,0 +1,375 @@
+import type { LanguageService } from '@volar/language-service';
+import type { editor, languages, Uri } from 'monaco-editor-core';
+import * as vscode from 'vscode-languageserver-protocol';
+import { markers } from './markers';
+import * as monaco2protocol from './monaco2protocol';
+import * as protocol2monaco from './protocol2monaco';
+
+export async function createLanguageFeaturesProvider(worker: editor.MonacoWebWorker<LanguageService>): Promise<
+	languages.HoverProvider &
+	languages.DocumentSymbolProvider &
+	languages.DocumentHighlightProvider &
+	languages.LinkedEditingRangeProvider &
+	languages.DefinitionProvider &
+	languages.ImplementationProvider &
+	languages.TypeDefinitionProvider &
+	languages.CodeLensProvider &
+	languages.CodeActionProvider &
+	Omit<languages.DocumentFormattingEditProvider, 'displayName'> &
+	Omit<languages.DocumentRangeFormattingEditProvider, 'displayName'> &
+	languages.OnTypeFormattingEditProvider &
+	languages.LinkProvider &
+	languages.CompletionItemProvider &
+	languages.DocumentColorProvider &
+	languages.FoldingRangeProvider &
+	languages.DeclarationProvider &
+	languages.SignatureHelpProvider &
+	languages.RenameProvider &
+	languages.ReferenceProvider &
+	languages.SelectionRangeProvider &
+	languages.InlayHintsProvider> {
+
+	const completionItems = new WeakMap<languages.CompletionItem, vscode.CompletionItem>();
+	const codeLens = new WeakMap<languages.CodeLens, vscode.CodeLens>();
+	const codeActions = new WeakMap<languages.CodeAction, vscode.CodeAction>();
+	const colorInfos = new WeakMap<languages.IColorInformation, vscode.ColorInformation>();
+	const languageService = await worker.getProxy();
+
+	return {
+
+		triggerCharacters: await (languageService.triggerCharacters as unknown as () => Promise<string[]>)(),
+		// TODO
+		autoFormatTriggerCharacters: ['}', ';', '\n'],
+		signatureHelpTriggerCharacters: ['(', ','],
+
+		async provideDocumentSymbols(model, _token) {
+			const worker = await getLanguageService(model.uri);
+			const codeResult = await worker.findDocumentSymbols(model.uri.toString());
+			if (codeResult) {
+				return codeResult.map(protocol2monaco.asDocumentSymbol);
+			}
+		},
+		async provideDocumentHighlights(model, position, _token) {
+			const worker = await getLanguageService(model.uri);
+			const codeResult = await worker.findDocumentHighlights(
+				model.uri.toString(),
+				monaco2protocol.asPosition(position)
+			);
+			if (codeResult) {
+				return codeResult.map(protocol2monaco.asDocumentHighlight);
+			}
+		},
+		async provideLinkedEditingRanges(model, position, _token) {
+			const worker = await getLanguageService(model.uri);
+			const codeResult = await worker.findLinkedEditingRanges(
+				model.uri.toString(),
+				monaco2protocol.asPosition(position)
+			);
+			if (codeResult) {
+				return {
+					ranges: codeResult.ranges.map(protocol2monaco.asRange),
+					wordPattern: codeResult.wordPattern
+						? new RegExp(codeResult.wordPattern)
+						: undefined,
+				};
+			}
+		},
+		async provideDefinition(model, position, _token) {
+			const worker = await getLanguageService(model.uri);
+			const codeResult = await worker.findDefinition(
+				model.uri.toString(),
+				monaco2protocol.asPosition(position)
+			);
+			// TODO: can't show if only one result from libs
+			if (codeResult) {
+				return codeResult.map(protocol2monaco.asLocation);
+			}
+		},
+		async provideImplementation(model, position, _token) {
+			const worker = await getLanguageService(model.uri);
+			const codeResult = await worker.findImplementations(
+				model.uri.toString(),
+				monaco2protocol.asPosition(position)
+			);
+			if (codeResult) {
+				return codeResult.map(protocol2monaco.asLocation);
+			}
+		},
+		async provideTypeDefinition(model, position, _token) {
+			const worker = await getLanguageService(model.uri);
+			const codeResult = await worker.findTypeDefinition(
+				model.uri.toString(),
+				monaco2protocol.asPosition(position)
+			);
+			if (codeResult) {
+				return codeResult.map(protocol2monaco.asLocation);
+			}
+		},
+		async provideCodeLenses(model, _token) {
+			const worker = await getLanguageService(model.uri);
+			const codeResult = await worker.doCodeLens(model.uri.toString());
+			if (codeResult) {
+				const monacoResult = codeResult.map(protocol2monaco.asCodeLens);
+				for (let i = 0; i < monacoResult.length; i++) {
+					codeLens.set(monacoResult[i], codeResult[i]);
+				}
+				return {
+					lenses: monacoResult,
+					dispose: () => { },
+				};
+			}
+		},
+		async resolveCodeLens(model, monacoResult) {
+			let codeResult = codeLens.get(monacoResult);
+			if (codeResult) {
+				const worker = await getLanguageService(model.uri);
+				codeResult = await worker.doCodeLensResolve(codeResult);
+				if (codeResult) {
+					monacoResult = protocol2monaco.asCodeLens(codeResult);
+					codeLens.set(monacoResult, codeResult);
+				}
+			}
+			return monacoResult;
+		},
+		async provideCodeActions(model, range, context, _token) {
+			const diagnostics: vscode.Diagnostic[] = [];
+
+			for (const marker of context.markers) {
+				const diagnostic = markers.get(marker);
+				if (diagnostic) {
+					diagnostics.push(diagnostic);
+				}
+			}
+
+			const worker = await getLanguageService(model.uri);
+			const codeResult = await worker.doCodeActions(
+				model.uri.toString(),
+				monaco2protocol.asRange(range),
+				{
+					diagnostics: diagnostics,
+					only: context.only ? [context.only] : undefined,
+				}
+			);
+
+			if (codeResult) {
+				const monacoResult = codeResult.map(protocol2monaco.asCodeAction);
+				for (let i = 0; i < monacoResult.length; i++) {
+					codeActions.set(monacoResult[i], codeResult[i]);
+				}
+				return {
+					actions: monacoResult,
+					dispose: () => { },
+				};
+			}
+		},
+		async resolveCodeAction(monacoResult) {
+			let codeResult = codeActions.get(monacoResult);
+			if (codeResult) {
+				const worker = await getLanguageService();
+				codeResult = await worker.doCodeActionResolve(codeResult);
+				if (codeResult) {
+					monacoResult = protocol2monaco.asCodeAction(codeResult);
+					codeActions.set(monacoResult, codeResult);
+				}
+			}
+			return monacoResult;
+		},
+		async provideDocumentFormattingEdits(model, options, _token) {
+			const worker = await getLanguageService(model.uri);
+			const codeResult = await worker.format(
+				model.uri.toString(),
+				monaco2protocol.asFormattingOptions(options)
+			);
+			if (codeResult) {
+				return codeResult.map(protocol2monaco.asTextEdit);
+			}
+		},
+		async provideDocumentRangeFormattingEdits(model, range, options, _token) {
+			const worker = await getLanguageService(model.uri);
+			const codeResult = await worker.format(
+				model.uri.toString(),
+				monaco2protocol.asFormattingOptions(options),
+				monaco2protocol.asRange(range)
+			);
+			if (codeResult) {
+				return codeResult.map(protocol2monaco.asTextEdit);
+			}
+		},
+		async provideOnTypeFormattingEdits(model, position, ch, options, _token) {
+			const worker = await getLanguageService(model.uri);
+			const codeResult = await worker.format(
+				model.uri.toString(),
+				monaco2protocol.asFormattingOptions(options),
+				undefined,
+				{
+					ch: ch,
+					position: monaco2protocol.asPosition(position),
+				}
+			);
+			if (codeResult) {
+				return codeResult.map(protocol2monaco.asTextEdit);
+			}
+		},
+		async provideLinks(model, _token) {
+			const worker = await getLanguageService(model.uri);
+			const codeResult = await worker.findDocumentLinks(model.uri.toString());
+			if (codeResult) {
+				return {
+					links: codeResult.map(protocol2monaco.asLink),
+				};
+			}
+		},
+		async provideCompletionItems(model, position, context, _token) {
+			const worker = await getLanguageService(model.uri);
+			const codeResult = await worker.doComplete(
+				model.uri.toString(),
+				monaco2protocol.asPosition(position),
+				monaco2protocol.asCompletionContext(context)
+			);
+			const fallbackRange = {
+				start: monaco2protocol.asPosition(position),
+				end: monaco2protocol.asPosition(position),
+			};
+			const monacoResult = protocol2monaco.asCompletionList(codeResult, fallbackRange);
+			for (let i = 0; i < codeResult.items.length; i++) {
+				completionItems.set(
+					monacoResult.suggestions[i],
+					codeResult.items[i]
+				);
+			}
+			return monacoResult;
+		},
+		async resolveCompletionItem(monacoItem, _token) {
+			let codeItem = completionItems.get(monacoItem);
+			if (codeItem) {
+				const worker = await getLanguageService();
+				codeItem = await worker.doCompletionResolve(codeItem);
+				const fallbackRange = 'replace' in monacoItem.range
+					? monaco2protocol.asRange(monacoItem.range.replace)
+					: monaco2protocol.asRange(monacoItem.range);
+				monacoItem = protocol2monaco.asCompletionItem(codeItem, fallbackRange);
+				completionItems.set(monacoItem, codeItem);
+			}
+			return monacoItem;
+		},
+		async provideDocumentColors(model, _token) {
+			const worker = await getLanguageService(model.uri);
+			const codeResult = await worker.findDocumentColors(model.uri.toString());
+			if (codeResult) {
+				return codeResult.map(protocol2monaco.asColorInformation);
+			}
+		},
+		async provideColorPresentations(model, monacoResult) {
+			const worker = await getLanguageService(model.uri);
+			const codeResult = colorInfos.get(monacoResult);
+			if (codeResult) {
+				const codeColors = await worker.getColorPresentations(
+					model.uri.toString(),
+					codeResult.color,
+					{
+						start: monaco2protocol.asPosition(model.getPositionAt(0)),
+						end: monaco2protocol.asPosition(
+							model.getPositionAt(model.getValueLength())
+						),
+					}
+				);
+				if (codeColors) {
+					return codeColors.map(protocol2monaco.asColorPresentation);
+				}
+			}
+		},
+		async provideFoldingRanges(model, _context, _token) {
+			const worker = await getLanguageService(model.uri);
+			const codeResult = await worker.getFoldingRanges(model.uri.toString());
+			if (codeResult) {
+				return codeResult.map(protocol2monaco.asFoldingRange);
+			}
+		},
+		async provideDeclaration(model, position, _token) {
+			const worker = await getLanguageService(model.uri);
+			const codeResult = await worker.findDefinition(
+				model.uri.toString(),
+				monaco2protocol.asPosition(position)
+			);
+			if (codeResult) {
+				return codeResult.map(protocol2monaco.asLocation);
+			}
+		},
+		async provideSelectionRanges(model, positions, _token) {
+			const worker = await getLanguageService(model.uri);
+			const codeResults = await Promise.all(
+				positions.map((position) =>
+					worker.getSelectionRanges(model.uri.toString(), [
+						monaco2protocol.asPosition(position),
+					])
+				)
+			);
+			return codeResults.map(
+				(codeResult) => codeResult?.map(protocol2monaco.asSelectionRange) ?? []
+			);
+		},
+		async provideSignatureHelp(model, position, _token, _context) {
+			const worker = await getLanguageService(model.uri);
+			const codeResult = await worker.getSignatureHelp(
+				model.uri.toString(),
+				monaco2protocol.asPosition(position)
+			);
+			if (codeResult) {
+				return {
+					value: protocol2monaco.asSignatureHelp(codeResult),
+					dispose: () => { },
+				};
+			}
+		},
+		async provideRenameEdits(model, position, newName, _token) {
+			const worker = await getLanguageService(model.uri);
+			const codeResult = await worker.doRename(
+				model.uri.toString(),
+				monaco2protocol.asPosition(position),
+				newName
+			);
+			if (codeResult) {
+				return protocol2monaco.asWorkspaceEdit(codeResult);
+			}
+		},
+		async provideReferences(model, position, _context, _token) {
+			const worker = await getLanguageService(model.uri);
+			const codeResult = await worker.findReferences(
+				model.uri.toString(),
+				monaco2protocol.asPosition(position)
+			);
+			// TODO: can't show if only one result from libs
+			if (codeResult) {
+				return codeResult.map(protocol2monaco.asLocation);
+			}
+		},
+		async provideInlayHints(model, range, _token) {
+			const worker = await getLanguageService(model.uri);
+			const codeResult = await worker.getInlayHints(
+				model.uri.toString(),
+				monaco2protocol.asRange(range)
+			);
+			if (codeResult) {
+				return {
+					hints: codeResult.map(protocol2monaco.asInlayHint),
+					dispose: () => { },
+				};
+			}
+		},
+		async provideHover(model, position, _token) {
+			const worker = await getLanguageService(model.uri);
+			const codeResult = await worker.doHover(
+				model.uri.toString(),
+				monaco2protocol.asPosition(position)
+			);
+			if (codeResult) {
+				return protocol2monaco.asHover(codeResult);
+			}
+		},
+	};
+
+	async function getLanguageService(...uris: Uri[]) {
+		await worker.withSyncedResources(uris);
+		return worker.getProxy();
+	}
+}

--- a/packages/monaco/src/worker.ts
+++ b/packages/monaco/src/worker.ts
@@ -1,0 +1,203 @@
+import {
+	createLanguageService as _createLanguageService,
+	type Config,
+	type LanguageServiceHost
+} from '@volar/language-service';
+import type * as monaco from 'monaco-editor-core';
+import type * as ts from 'typescript/lib/tsserverlibrary';
+import { URI } from 'vscode-uri';
+import { createAutoTypesFetchingHost } from './utils/autoFetchTypes';
+
+export function createLanguageService(options: {
+	workerContext: monaco.worker.IWorkerContext<any>,
+	config: Config,
+	typescript?: {
+		module: typeof import('typescript/lib/tsserverlibrary'),
+		compilerOptions: ts.CompilerOptions,
+		autoFetchTypes?: boolean | {
+			onFetchTypesFiles?(files: Record<string, string>): void,
+			cdn?: string,
+		},
+	},
+}) {
+
+	const ts: typeof import('typescript/lib/tsserverlibrary') | undefined = options.typescript ? options.typescript.module : undefined;
+	const config = options.config ?? {};
+	const compilerOptions = options.typescript?.compilerOptions ?? {};
+
+	let autoFetchTypesCdn = 'https://unpkg.com/';
+	if (typeof options.typescript?.autoFetchTypes === 'object' && options.typescript.autoFetchTypes.cdn) {
+		autoFetchTypesCdn = options.typescript.autoFetchTypes.cdn;
+	}
+	const autoTypeFetchHost = options.typescript?.autoFetchTypes ? createAutoTypesFetchingHost(autoFetchTypesCdn) : undefined;
+
+	let host = createLanguageServiceHost();
+	let languageService = _createLanguageService(
+		host,
+		config,
+		{ rootUri: URI.file('/') },
+	);
+	let webFilesNumOfLanguageService = autoTypeFetchHost?.files.size ?? 0;
+	const syncedFiles = new Set<string>();
+
+	class InnocentRabbit { };
+
+	for (const api in languageService) {
+
+		const isFunction = typeof (languageService as any)[api] === 'function';;
+		if (!isFunction) {
+			(InnocentRabbit.prototype as any)[api] = () => (languageService as any)[api];
+			continue;
+		}
+
+		(InnocentRabbit.prototype as any)[api] = async (...args: any[]) => {
+
+			if (!autoTypeFetchHost) {
+				return (languageService as any)[api](...args);
+			}
+
+			let shouldSync = false;
+			let webFilesNumOfThisCall = autoTypeFetchHost.files.size;
+			let result = await (languageService as any)[api](...args);
+			await autoTypeFetchHost.wait();
+
+			while (autoTypeFetchHost.files.size > webFilesNumOfThisCall) {
+				shouldSync = true;
+				webFilesNumOfThisCall = autoTypeFetchHost.files.size;
+				if (autoTypeFetchHost.files.size > webFilesNumOfLanguageService) {
+					webFilesNumOfLanguageService = autoTypeFetchHost.files.size;
+					languageService.dispose();
+					languageService = _createLanguageService(
+						host,
+						config,
+						{ rootUri: URI.file('/') },
+					);
+				}
+				result = await (languageService as any)[api](...args);
+				await autoTypeFetchHost.wait();
+			}
+
+			if (shouldSync && typeof options.typescript?.autoFetchTypes === 'object' && options.typescript.autoFetchTypes.onFetchTypesFiles) {
+				const files = autoTypeFetchHost.files;
+				const syncFiles: Record<string, string> = {};
+				for (const [fileName, text] of files) {
+					if (!syncedFiles.has(fileName) && text !== undefined) {
+						syncFiles[fileName] = text;
+						syncedFiles.add(fileName);
+					}
+				}
+				options.typescript.autoFetchTypes.onFetchTypesFiles(syncFiles);
+			}
+
+			return result;
+		};
+	}
+
+	return new InnocentRabbit();
+
+	function createLanguageServiceHost() {
+
+		let projectVersion = 0;
+
+		const modelSnapshot = new WeakMap<monaco.worker.IMirrorModel, readonly [number, ts.IScriptSnapshot]>();
+		const webFileSnapshot = new Map<string, ts.IScriptSnapshot>();
+		const modelVersions = new Map<monaco.worker.IMirrorModel, number>();
+		const host: LanguageServiceHost = {
+			getProjectVersion() {
+				const models = options.workerContext.getMirrorModels();
+				if (modelVersions.size === options.workerContext.getMirrorModels().length) {
+					if (models.every(model => modelVersions.get(model) === model.version)) {
+						return projectVersion.toString();
+					}
+				}
+				modelVersions.clear();
+				for (const model of options.workerContext.getMirrorModels()) {
+					modelVersions.set(model, model.version);
+				}
+				projectVersion++;
+				return projectVersion.toString();
+			},
+			getScriptFileNames() {
+				const models = options.workerContext.getMirrorModels();
+				return models.map(model => model.uri.fsPath);
+			},
+			getScriptVersion(fileName) {
+				const model = options.workerContext.getMirrorModels().find(model => model.uri.fsPath === fileName);
+				if (model) {
+					return model.version.toString();
+				}
+				if (autoTypeFetchHost) {
+					const dts = autoTypeFetchHost.readFile(fileName);
+					if (dts) {
+						return dts.length.toString();
+					}
+				}
+				return '';
+			},
+			getScriptSnapshot(fileName) {
+				const model = options.workerContext.getMirrorModels().find(model => model.uri.fsPath === fileName);
+				if (model) {
+					const cache = modelSnapshot.get(model);
+					if (cache && cache[0] === model.version) {
+						return cache[1];
+					}
+					const text = model.getValue();
+					modelSnapshot.set(model, [model.version, {
+						getText: (start, end) => text.substring(start, end),
+						getLength: () => text.length,
+						getChangeRange: () => undefined,
+					}]);
+					return modelSnapshot.get(model)?.[1];
+				}
+				if (webFileSnapshot.has(fileName)) {
+					return webFileSnapshot.get(fileName);
+				}
+				if (autoTypeFetchHost) {
+					const webFileText = autoTypeFetchHost.readFile(fileName);
+					if (webFileText !== undefined) {
+						webFileSnapshot.set(fileName, {
+							getText: (start, end) => webFileText.substring(start, end),
+							getLength: () => webFileText.length,
+							getChangeRange: () => undefined,
+						});
+						return webFileSnapshot.get(fileName);
+					}
+				}
+			},
+			getCompilationSettings() {
+				return compilerOptions;
+			},
+			getCurrentDirectory() {
+				return '/';
+			},
+			getDefaultLibFileName(options) {
+				if (ts) {
+					return '/node_modules/typescript/lib/' + ts.getDefaultLibFileName(options);
+				}
+				return '';
+			},
+			readFile(fileName) {
+				const model = options.workerContext.getMirrorModels().find(model => model.uri.fsPath === fileName);
+				if (model) {
+					return model.getValue();
+				}
+				if (autoTypeFetchHost) {
+					return autoTypeFetchHost.readFile(fileName);
+				}
+			},
+			fileExists(fileName) {
+				const model = options.workerContext.getMirrorModels().find(model => model.uri.fsPath === fileName);
+				if (model) {
+					return true;
+				}
+				if (autoTypeFetchHost) {
+					return autoTypeFetchHost.fileExists(fileName);
+				}
+				return false;
+			},
+			getTypeScriptModule: ts ? (() => ts) : undefined,
+		};
+
+		return host;
+	}
+}

--- a/packages/monaco/tsconfig.build.json
+++ b/packages/monaco/tsconfig.build.json
@@ -1,0 +1,16 @@
+{
+	"extends": "../../tsconfig.json",
+	"compilerOptions": {
+		"noEmit": false,
+		"outDir": "out",
+		"rootDir": "src",
+	},
+	"include": [
+		"src"
+	],
+	"references": [
+		{
+			"path": "../language-service/tsconfig.build.json"
+		}
+	]
+}

--- a/packages/monaco/worker.d.ts
+++ b/packages/monaco/worker.d.ts
@@ -1,0 +1,1 @@
+export * from './out/worker';

--- a/packages/monaco/worker.js
+++ b/packages/monaco/worker.js
@@ -1,0 +1,1 @@
+module.exports = require('./out/worker');

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,9 +12,9 @@ importers:
     optionalDependencies:
       '@lerna-lite/cli': 1.15.1
     devDependencies:
-      '@types/node': 18.14.0
+      '@types/node': 18.14.1
       typescript: 4.9.5
-      vite: 4.1.4_@types+node@18.14.0
+      vite: 4.1.4_@types+node@18.14.1
       vitest: 0.25.8
 
   packages/kit:
@@ -81,6 +81,20 @@ importers:
       vscode-json-languageservice: 5.2.0
       vscode-languageserver-protocol: 3.17.3
       vscode-languageserver-textdocument: 1.0.8
+      vscode-uri: 3.0.7
+
+  packages/monaco:
+    specifiers:
+      '@volar/language-service': 1.2.0-alpha.19
+      axios: ^1.3.4
+      monaco-editor-core: ^0.36.0
+      vscode-languageserver-protocol: ^3.17.3
+      vscode-uri: ^3.0.7
+    dependencies:
+      '@volar/language-service': link:../language-service
+      axios: 1.3.4
+      monaco-editor-core: 0.36.0
+      vscode-languageserver-protocol: 3.17.3
       vscode-uri: 3.0.7
 
   packages/shared:
@@ -904,8 +918,8 @@ packages:
     dev: false
     optional: true
 
-  /@types/node/18.14.0:
-    resolution: {integrity: sha512-5EWrvLmglK+imbCJY0+INViFWUHg1AHel1sq4ZVSfdcNqGy9Edv3UB9IIzzg+xPaUcAgZYcfVs2fBcwDeZzU0A==}
+  /@types/node/18.14.1:
+    resolution: {integrity: sha512-QH+37Qds3E0eDlReeboBxfHbX9omAcBCXEzswCu6jySP642jiM3cYSIkU/REqwhCUqXdonHFuBfJDiAJxMNhaQ==}
     dev: true
 
   /@types/normalize-package-data/2.4.1:
@@ -1078,6 +1092,20 @@ packages:
   /assertion-error/1.1.0:
     resolution: {integrity: sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==}
     dev: true
+
+  /asynckit/0.4.0:
+    resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
+    dev: false
+
+  /axios/1.3.4:
+    resolution: {integrity: sha512-toYm+Bsyl6VC5wSkfkbbNB6ROv7KY93PEBBL6xyDczaIHasAiv4wPqQ/c4RjoQzipxRD2W5g21cOqQulZ7rHwQ==}
+    dependencies:
+      follow-redirects: 1.15.2
+      form-data: 4.0.0
+      proxy-from-env: 1.1.0
+    transitivePeerDependencies:
+      - debug
+    dev: false
 
   /balanced-match/1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
@@ -1398,6 +1426,13 @@ packages:
     dev: false
     optional: true
 
+  /combined-stream/1.0.8:
+    resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
+    engines: {node: '>= 0.8'}
+    dependencies:
+      delayed-stream: 1.0.0
+    dev: false
+
   /common-ancestor-path/1.0.1:
     resolution: {integrity: sha512-L3sHRo1pXXEqX8VU28kfgUY+YGsk09hPqZiZmLacNib6XNTCM8ubYeT7ryXQw8asB1sKgcU5lkB7ONug08aB8w==}
     dev: false
@@ -1621,6 +1656,11 @@ packages:
     dev: false
     optional: true
 
+  /delayed-stream/1.0.0:
+    resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
+    engines: {node: '>=0.4.0'}
+    dev: false
+
   /delegates/1.0.0:
     resolution: {integrity: sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==}
     dev: false
@@ -1843,6 +1883,25 @@ packages:
       path-exists: 4.0.0
     dev: false
     optional: true
+
+  /follow-redirects/1.15.2:
+    resolution: {integrity: sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==}
+    engines: {node: '>=4.0'}
+    peerDependencies:
+      debug: '*'
+    peerDependenciesMeta:
+      debug:
+        optional: true
+    dev: false
+
+  /form-data/4.0.0:
+    resolution: {integrity: sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==}
+    engines: {node: '>= 6'}
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      mime-types: 2.1.35
+    dev: false
 
   /fs-extra/11.1.0:
     resolution: {integrity: sha512-0rcTq621PD5jM/e0a3EJoGC/1TC5ZBCERW82LQuwfGnCa1V8w7dpYH1yNu+SLb6E5dkeCBzKEyLGlFrnr+dUyw==}
@@ -2723,6 +2782,18 @@ packages:
     dev: false
     optional: true
 
+  /mime-db/1.52.0:
+    resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
+    engines: {node: '>= 0.6'}
+    dev: false
+
+  /mime-types/2.1.35:
+    resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
+    engines: {node: '>= 0.6'}
+    dependencies:
+      mime-db: 1.52.0
+    dev: false
+
   /mimic-fn/2.1.0:
     resolution: {integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==}
     engines: {node: '>=6'}
@@ -2872,6 +2943,10 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: false
     optional: true
+
+  /monaco-editor-core/0.36.0:
+    resolution: {integrity: sha512-d0559W7eAJUAIUYZxVNwvjRTnBux1UXnT5FP94Fmq2w6aNG4/xPQkis5E9+AoPF5hVoNXkQMP5aYnPyogoOR/w==}
+    dev: false
 
   /ms/2.1.2:
     resolution: {integrity: sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==}
@@ -3470,6 +3545,10 @@ packages:
     resolution: {integrity: sha512-/XJ368cyBJ7fzLMwLKv1e4vLxOju2MNAIokcr7meSaNcVbWz/CPcW22cP04mwxOErdA5mwjA8Q6w/cdAQxVn7Q==}
     dev: false
     optional: true
+
+  /proxy-from-env/1.1.0:
+    resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
+    dev: false
 
   /q/1.5.1:
     resolution: {integrity: sha512-kV/CThkXo6xyFEZUugw/+pIOywXcDbFYgSct5cT3gqlbkBE1SJdwy6UQoZvodiWF/ckQLZyDE/Bu1M6gVu5lVw==}
@@ -4212,7 +4291,7 @@ packages:
     dev: false
     optional: true
 
-  /vite/4.1.4_@types+node@18.14.0:
+  /vite/4.1.4_@types+node@18.14.1:
     resolution: {integrity: sha512-3knk/HsbSTKEin43zHu7jTwYWv81f8kgAL99G5NWBcA1LKvtvcVAC4JjBH1arBunO9kQka+1oGbrMKOjk4ZrBg==}
     engines: {node: ^14.18.0 || >=16.0.0}
     hasBin: true
@@ -4237,7 +4316,7 @@ packages:
       terser:
         optional: true
     dependencies:
-      '@types/node': 18.14.0
+      '@types/node': 18.14.1
       esbuild: 0.16.15
       postcss: 8.4.21
       resolve: 1.22.1
@@ -4270,7 +4349,7 @@ packages:
     dependencies:
       '@types/chai': 4.3.4
       '@types/chai-subset': 1.3.3
-      '@types/node': 18.14.0
+      '@types/node': 18.14.1
       acorn: 8.8.1
       acorn-walk: 8.2.0
       chai: 4.3.7
@@ -4281,7 +4360,7 @@ packages:
       tinybench: 2.3.1
       tinypool: 0.3.0
       tinyspy: 1.0.2
-      vite: 4.1.4_@types+node@18.14.0
+      vite: 4.1.4_@types+node@18.14.1
     transitivePeerDependencies:
       - less
       - sass

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -12,6 +12,9 @@
 		{
 			"path": "./packages/vscode-language-client/tsconfig.build.json"
 		},
+		{
+			"path": "./packages/monaco/tsconfig.build.json"
+		},
 		// IDE / tests
 		{
 			"path": "./tsconfig.json"


### PR DESCRIPTION
Implements 3 APIs for integrating Monaco:

- `import(@volar/monaco/worker).createLanguageService()`
- `import(@volar/monaco).languages.registerProvides()`
- `import(@volar/monaco).editor.activateMarkers()`

For more detail please see readme and reference to https://github.com/Kingwl/monaco-volar.

Closes #2