### PR TITLE
fix(typescript): typescript build info

### DIFF
--- a/packages/typescript/src/getProgram.ts
+++ b/packages/typescript/src/getProgram.ts
@@ -28,12 +28,12 @@ export function getProgram(
 			}
 			return target[property];
 		},
-		// commented out because it causes https://github.com/vuejs/language-tools/issues/2403
-		// set: (_target, property, newValue) => {
-		// 	const program = getProgram();
-		// 	(program as any)[property] = newValue;
-		// 	return true;
-		// },
+		
+		set: (target, property, newValue) => {
+			const program = getProgram() as any;
+			target[property] = program[property] = newValue;
+			return true;
+		},
 	});
 
 	function getProgram() {


### PR DESCRIPTION
getProgramBuildInfo is set to program in createBuilderProgram https://github.com/microsoft/TypeScript/blob/v4.9.4/src/compiler/builder.ts#L1147 but with proxy don't have setter function it won't work. Set the property on the target to prevent __vue being undefined.

fix: vuejs/language-tools#2138
resolve: vuejs/language-tools#2403

---

This reproduction shows the changes with fix working and with previous breakages.

https://github.com/blake-newman/vue-tsc-incremental

`main` branch (fix) reproduction: 
1) `yarn install`
2) `yarn vue-tsc -w`
3) change `*.vue` file 
4) no error


`broken` branch reproduction: 
1) `yarn install`
2) `yarn vue-tsc -w`
3) change `*.vue` file 
4) errors on recompile
