### PR TITLE
Declare workspaceFolders support in server capabilities

### DIFF
--- a/packages/language-server/src/common/server.ts
+++ b/packages/language-server/src/common/server.ts
@@ -54,6 +54,7 @@ export function startCommonLanguageServer(connection: vscode.Connection, getCtx:
 			capabilities: {
 				textDocumentSync: (options.textDocumentSync as vscode.TextDocumentSyncKind) ?? vscode.TextDocumentSyncKind.Incremental,
 				workspace: {
+					// #18
 					workspaceFolders: {
 						supported: true,
 						changeNotifications: true,

--- a/packages/language-server/src/common/server.ts
+++ b/packages/language-server/src/common/server.ts
@@ -53,6 +53,12 @@ export function startCommonLanguageServer(connection: vscode.Connection, getCtx:
 		const result: vscode.InitializeResult = {
 			capabilities: {
 				textDocumentSync: (options.textDocumentSync as vscode.TextDocumentSyncKind) ?? vscode.TextDocumentSyncKind.Incremental,
+				workspace: {
+					workspaceFolders: {
+						supported: true,
+						changeNotifications: true,
+					},
+				},
 			},
 		};
 


### PR DESCRIPTION
This is the [recommended way](https://github.com/microsoft/vscode-languageserver-node/issues/713#issuecomment-754551117) to declare up-front that the server supports workspace folders and is interested in change notifications. Without this server capability set, the vscode-languageserver-node dependency tries to register for workspace change notifications dynamically with a 'client/registerCapability' request. If the client doesn't support dynamic capability registration and responds to that request with a MethodNotHandled JSONRPC error, the promise for the request is rejected which causes the server to exit.

Also see this similar change in pyright https://github.com/microsoft/pyright/pull/4666