### PR TITLE
feat(language-service): support auto imports and project references

### DIFF
--- a/packages/language-server/src/common/project.ts
+++ b/packages/language-server/src/common/project.ts
@@ -218,15 +218,6 @@ export async function createProject(context: ProjectContext) {
 			},
 		};
 
-		if (context.workspace.workspaces.initOptions.noProjectReferences) {
-			host.getProjectReferences = undefined;
-			host.getCompilationSettings = () => ({
-				...parsedCommandLine.options,
-				rootDir: undefined,
-				composite: false,
-			});
-		}
-
 		if (context.workspace.workspaces.tsLocalized) {
 			host.getLocalizedDiagnosticMessages = () => context.workspace.workspaces.tsLocalized;
 		}

--- a/packages/language-server/src/types.ts
+++ b/packages/language-server/src/types.ts
@@ -116,7 +116,6 @@ export interface LanguageServerInitializationOptions {
 	 * https://github.com/Microsoft/TypeScript/wiki/Standalone-Server-%28tsserver%29#cancellation
 	 */
 	cancellationPipeName?: string;
-	noProjectReferences?: boolean;
 	reverseConfigFilePriority?: boolean;
 	disableFileWatcher?: boolean;
 	maxFileSize?: number;

--- a/packages/language-service/package.json
+++ b/packages/language-service/package.json
@@ -15,7 +15,7 @@
 	"dependencies": {
 		"@volar/language-core": "1.4.0-alpha.5",
 		"@volar/source-map": "1.4.0-alpha.5",
-		"typescript-auto-import-cache": "^0.0.1",
+		"typescript-auto-import-cache": "^0.1.0",
 		"vscode-html-languageservice": "^5.0.4",
 		"vscode-json-languageservice": "^5.2.0",
 		"vscode-languageserver-protocol": "^3.17.3",

--- a/packages/language-service/package.json
+++ b/packages/language-service/package.json
@@ -15,7 +15,7 @@
 	"dependencies": {
 		"@volar/language-core": "1.4.0-alpha.6",
 		"@volar/source-map": "1.4.0-alpha.6",
-		"typescript-auto-import-cache": "^0.0.1",
+		"typescript-auto-import-cache": "^0.1.0",
 		"vscode-html-languageservice": "^5.0.4",
 		"vscode-json-languageservice": "^5.2.0",
 		"vscode-languageserver-protocol": "^3.17.3",

--- a/packages/language-service/src/baseLanguageService.ts
+++ b/packages/language-service/src/baseLanguageService.ts
@@ -55,13 +55,16 @@ function createLanguageServiceContext(
 	languageContext: ReturnType<typeof createLanguageContext>,
 	documentRegistry?: ts.DocumentRegistry,
 ) {
-
 	const ts = ctx.host.getTypeScriptModule?.();
-	const tsLs = ts?.createLanguageService(languageContext.typescript.languageServiceHost, documentRegistry);
-
-	if (ts && tsLs) {
-		tsFaster.decorate(ts, languageContext.typescript.languageServiceHost, tsLs);
-	}
+	const tsLs = ts ? tsFaster.createLanguageService(
+		ts,
+		languageContext.typescript.languageServiceHost, 
+		(proxiedHost) => {
+			languageContext.typescript.languageServiceHost = proxiedHost
+			return ts.createLanguageService(proxiedHost, documentRegistry)
+		}, 
+		ctx.rootUri.path
+	) : undefined
 
 	const textDocumentMapper = createDocumentsAndSourceMaps(ctx, languageContext.virtualFiles);
 	const documents = new WeakMap<ts.IScriptSnapshot, TextDocument>();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -94,8 +94,8 @@ importers:
         specifier: 1.4.0-alpha.6
         version: link:../source-map
       typescript-auto-import-cache:
-        specifier: ^0.0.1
-        version: 0.0.1
+        specifier: ^0.1.0
+        version: 0.1.0
       vscode-html-languageservice:
         specifier: ^5.0.4
         version: 5.0.4
@@ -4209,8 +4209,8 @@ packages:
     resolution: {integrity: sha512-OJabfkAg1WLZSqJAJ0Z6Sdt3utnbzr/jh+NAHoyWHJe8CMSy79Gm085094M9nvTPy22KzTVn5Zq5mbapCI/hPA==}
     dev: false
 
-  /typescript-auto-import-cache@0.0.1:
-    resolution: {integrity: sha512-8gOZHgm/o05PDzvpJvIuqDN0xwQttawz9uFSJwWE0UtKeST7zJi5Ik94L2y7QaM3qD3WGhvuJVGUd+dOx9gFLw==}
+  /typescript-auto-import-cache@0.1.0:
+    resolution: {integrity: sha512-lzBAiBPthEDU12dM+h+nDUJbjOinn9v7XqDgicj8Ki8+boXEI/Jbs45J6iilnUoQKQM7OiaQALPrmWhXyH1ptA==}
     dependencies:
       semver: 7.3.8
     dev: false

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,7 +38,7 @@ importers:
         version: link:../language-service
       typescript:
         specifier: '*'
-        version: 5.0.2
+        version: 5.0.3
       vscode-languageserver-textdocument:
         specifier: ^1.0.8
         version: 1.0.8
@@ -4215,17 +4215,10 @@ packages:
       semver: 7.3.8
     dev: false
 
-  /typescript@5.0.2:
-    resolution: {integrity: sha512-wVORMBGO/FAs/++blGNeAVdbNKtIh1rbBL2EyQ1+J9lClJ93KiiKe8PmFIVdXhHcyv44SL9oglmfeSsndo0jRw==}
-    engines: {node: '>=12.20'}
-    hasBin: true
-    dev: false
-
   /typescript@5.0.3:
     resolution: {integrity: sha512-xv8mOEDnigb/tN9PSMTwSEqAnUvkoXMQlicOb0IUVDBSQCgBSaAAROUZYy2IcUy5qU6XajK5jjjO7TMWqBTKZA==}
     engines: {node: '>=12.20'}
     hasBin: true
-    dev: true
 
   /uglify-js@3.17.4:
     resolution: {integrity: sha512-T9q82TJI9e/C1TAxYvfb16xO120tMVFZrGA3f9/P4424DNu6ypK103y0GPFVa17yotwSyZW5iYXgjYHkGrJW/g==}


### PR DESCRIPTION
Update `typescrpt-auto-import-cache` which now handles creating language service with the proxied host for auto completes and project reference support.

relates to: https://github.com/volarjs/typescript-auto-import-cache/pull/1