### PR TITLE
chore: Lerna-Lite 2.0 publish & version are becoming optional commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
 		"vitest": "0.25.8"
 	},
 	"optionalDependencies": {
-		"@lerna-lite/cli": "latest"
+		"@lerna-lite/cli": "latest",
+		"@lerna-lite/publish": "latest"
 	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,9 @@ importers:
       '@lerna-lite/cli':
         specifier: latest
         version: 1.17.0
+      '@lerna-lite/publish':
+        specifier: latest
+        version: 1.17.0
     devDependencies:
       '@types/node':
         specifier: latest
@@ -29,7 +32,7 @@ importers:
     devDependencies:
       coc.nvim:
         specifier: latest
-        version: 0.0.83-next.9(@types/node@18.15.11)
+        version: 0.0.83-next.9
 
   packages/kit:
     dependencies:
@@ -1389,13 +1392,11 @@ packages:
     dev: false
     optional: true
 
-  /coc.nvim@0.0.83-next.9(@types/node@18.15.11):
+  /coc.nvim@0.0.83-next.9:
     resolution: {integrity: sha512-ek5+EgA9N92/6Wt07TAYpavmBgXZto4Dmwmm56oyBl/w4wy3Tod7LfpCp4k9M4xCxhxPtrflIcxvhdDUPIeMuw==}
     engines: {node: '>=14.14.0'}
     peerDependencies:
       '@types/node': ^14.14.0
-    dependencies:
-      '@types/node': 18.15.11
     dev: true
 
   /color-convert@1.9.3:


### PR DESCRIPTION
- same as https://github.com/vuejs/language-tools/pull/2597
- in the next Lerna-Lite v2.0.0, I made `version` and `publish` as optional commands since it was requested by some users. So Lerna-Lite is now entirely modular and the user will need to manually install the command(s) he want to use (plus the CLI)