### PR TITLE
refactor: remove a few settings

### DIFF
--- a/packages/language-server/src/common/features/languageFeatures.ts
+++ b/packages/language-server/src/common/features/languageFeatures.ts
@@ -307,11 +307,6 @@ export function register(
 	});
 	connection.workspace.onWillRenameFiles(async (params, token) => {
 
-		const config = await connection.workspace.getConfiguration('volar.updateImportsOnFileMove.enabled');
-		if (!config) {
-			return null;
-		}
-
 		const _edits = await Promise.all(params.files.map(async (file) => {
 			return await worker(file.oldUri, token, service => {
 				return service.getEditsForFileRename(file.oldUri, file.newUri, token) ?? null;

--- a/packages/language-server/src/common/server.ts
+++ b/packages/language-server/src/common/server.ts
@@ -126,7 +126,6 @@ export function startCommonLanguageServer(connection: vscode.Connection, getCtx:
 
 		if (
 			options.serverMode !== ServerMode.Syntactic
-			&& !options.disableFileWatcher
 			&& initParams.capabilities.workspace?.didChangeWatchedFiles?.dynamicRegistration
 		) {
 			const exts = plugins.map(plugin => plugin.watchFileExtensions).flat();

--- a/packages/language-server/src/common/workspaces.ts
+++ b/packages/language-server/src/common/workspaces.ts
@@ -99,7 +99,7 @@ export function createWorkspaces(context: WorkspacesContext) {
 
 		await updateDiagnostics();
 
-		const delay = await context.configurationHost?.getConfiguration<number>('volar.diagnostics.delay') ?? 200;
+		const delay = 250;
 		await sleep(delay);
 
 		if (req === semanticTokensReq) {
@@ -118,7 +118,7 @@ export function createWorkspaces(context: WorkspacesContext) {
 			return;
 
 		const req = ++documentUpdatedReq;
-		const delay = await context.configurationHost?.getConfiguration<number>('volar.diagnostics.delay') ?? 200;
+		const delay = 250;
 		const cancel = context.cancelTokenHost.createCancellationToken({
 			get isCancellationRequested() {
 				return req !== documentUpdatedReq;

--- a/packages/language-server/src/types.ts
+++ b/packages/language-server/src/types.ts
@@ -116,7 +116,6 @@ export interface LanguageServerInitializationOptions {
 	 */
 	cancellationPipeName?: string;
 	reverseConfigFilePriority?: boolean;
-	disableFileWatcher?: boolean;
 	maxFileSize?: number;
 	configFilePath?: string;
 	/**


### PR DESCRIPTION
Remove some settings usage for better compatibility with future Monoserver. This does not mean losing control, we just will control it in the language client.

Removed IDE settings:

- `volar.diagnostics.delay`
- `volar.codeLens.references`
- `volar.updateImportsOnFileMove.enabled`

Removed server init options:

- `disableFileWatcher`