### PR TITLE
refactor: framework API update

### DIFF
--- a/packages/kit/src/index.ts
+++ b/packages/kit/src/index.ts
@@ -39,13 +39,16 @@ export function create(
 			return scriptSnapshots.get(fileName);
 		},
 	};
-	const service = createLanguageService({ typescript: ts }, {
-		host,
+	const service = createLanguageService(
+		{ typescript: ts },
+		{
+			uriToFileName,
+			fileNameToUri,
+			rootUri: URI.file(path.dirname(tsConfigPath)),
+		},
 		config,
-		uriToFileName,
-		fileNameToUri,
-		rootUri: URI.file(path.dirname(tsConfigPath)),
-	});
+		host,
+	);
 	const formatHost: ts.FormatDiagnosticsHost = {
 		getCurrentDirectory: () => host.getCurrentDirectory(),
 		getCanonicalFileName: (fileName) => host.useCaseSensitiveFileNames?.() ? fileName : fileName.toLowerCase(),

--- a/packages/kit/src/index.ts
+++ b/packages/kit/src/index.ts
@@ -39,8 +39,7 @@ export function create(
 			return scriptSnapshots.get(fileName);
 		},
 	};
-	const service = createLanguageService({
-		modules: { typescript: ts },
+	const service = createLanguageService({ typescript: ts }, {
 		host,
 		config,
 		uriToFileName,

--- a/packages/language-core/src/languageContext.ts
+++ b/packages/language-core/src/languageContext.ts
@@ -6,10 +6,8 @@ import { Language, LanguageServiceHost, FileKind } from './types';
 export type LanguageContext = ReturnType<typeof createLanguageContext>;
 
 export function createLanguageContext(
+	modules: { typescript?: typeof import('typescript/lib/tsserverlibrary'); },
 	host: LanguageServiceHost,
-	modules: {
-		typescript?: typeof import('typescript/lib/tsserverlibrary'),
-	},
 	languages: Language[],
 ) {
 

--- a/packages/language-core/src/languageContext.ts
+++ b/packages/language-core/src/languageContext.ts
@@ -1,7 +1,7 @@
 import { posix as path } from 'path';
 import type * as ts from 'typescript/lib/tsserverlibrary';
 import { createVirtualFiles, forEachEmbeddedFile } from './virtualFiles';
-import { LanguageModule, LanguageServiceHost, FileKind } from './types';
+import { Language, LanguageServiceHost, FileKind } from './types';
 
 export type LanguageContext = ReturnType<typeof createLanguageContext>;
 
@@ -10,12 +10,12 @@ export function createLanguageContext(
 	modules: {
 		typescript?: typeof import('typescript/lib/tsserverlibrary'),
 	},
-	languageModules: LanguageModule[],
+	languages: Language[],
 ) {
 
-	for (const languageModule of languageModules.reverse()) {
-		if (languageModule.proxyLanguageServiceHost) {
-			const proxyApis = languageModule.proxyLanguageServiceHost(host);
+	for (const language of languages.reverse()) {
+		if (language.proxyLanguageServiceHost) {
+			const proxyApis = language.proxyLanguageServiceHost(host);
 			host = new Proxy(host, {
 				get(target, key: keyof ts.LanguageServiceHost) {
 					if (key in proxyApis) {
@@ -30,7 +30,7 @@ export function createLanguageContext(
 	let lastProjectVersion: string | undefined;
 	let tsProjectVersion = 0;
 
-	const virtualFiles = createVirtualFiles(languageModules);
+	const virtualFiles = createVirtualFiles(languages);
 	const ts = modules.typescript;
 	const scriptSnapshots = new Map<string, [string, ts.IScriptSnapshot]>();
 	const sourceTsFileVersions = new Map<string, string>();

--- a/packages/language-core/src/languageContext.ts
+++ b/packages/language-core/src/languageContext.ts
@@ -12,16 +12,8 @@ export function createLanguageContext(
 ) {
 
 	for (const language of languages.reverse()) {
-		if (language.proxyLanguageServiceHost) {
-			const proxyApis = language.proxyLanguageServiceHost(host);
-			host = new Proxy(host, {
-				get(target, key: keyof ts.LanguageServiceHost) {
-					if (key in proxyApis) {
-						return proxyApis[key];
-					}
-					return target[key];
-				},
-			});
+		if (language.resolveHost) {
+			host = language.resolveHost(host);
 		}
 	}
 

--- a/packages/language-core/src/types.ts
+++ b/packages/language-core/src/types.ts
@@ -92,4 +92,4 @@ export interface Language<T extends VirtualFile = VirtualFile> {
 export interface LanguageServiceHost extends ts.LanguageServiceHost {
 	getScriptLanguageId?(fileName: string): string | undefined;
 	isTsc?: boolean,
-};
+}

--- a/packages/language-core/src/types.ts
+++ b/packages/language-core/src/types.ts
@@ -83,10 +83,10 @@ export interface VirtualFile {
 }
 
 export interface Language<T extends VirtualFile = VirtualFile> {
-	createFile(fileName: string, snapshot: ts.IScriptSnapshot, languageId: string | undefined): T | undefined;
-	updateFile(virtualFile: T, snapshot: ts.IScriptSnapshot): void;
-	deleteFile?(virtualFile: T): void;
-	proxyLanguageServiceHost?(host: LanguageServiceHost): Partial<LanguageServiceHost>;
+	resolveHost?(host: LanguageServiceHost): LanguageServiceHost;
+	createVirtualFile(fileName: string, snapshot: ts.IScriptSnapshot, languageId: string | undefined): T | undefined;
+	updateVirtualFile(virtualFile: T, snapshot: ts.IScriptSnapshot): void;
+	deleteVirtualFile?(virtualFile: T): void;
 }
 
 export interface LanguageServiceHost extends ts.LanguageServiceHost {

--- a/packages/language-core/src/types.ts
+++ b/packages/language-core/src/types.ts
@@ -82,7 +82,7 @@ export interface VirtualFile {
 	embeddedFiles: VirtualFile[],
 }
 
-export interface LanguageModule<T extends VirtualFile = VirtualFile> {
+export interface Language<T extends VirtualFile = VirtualFile> {
 	createFile(fileName: string, snapshot: ts.IScriptSnapshot, languageId: string | undefined): T | undefined;
 	updateFile(virtualFile: T, snapshot: ts.IScriptSnapshot): void;
 	deleteFile?(virtualFile: T): void;

--- a/packages/language-core/src/virtualFiles.ts
+++ b/packages/language-core/src/virtualFiles.ts
@@ -30,12 +30,12 @@ export function createVirtualFiles(languages: Language[]) {
 			const value = sourceFiles.get(key);
 			if (value) {
 				value.snapshot = snapshot;
-				value.language.updateFile(value.root, snapshot);
+				value.language.updateVirtualFile(value.root, snapshot);
 				sourceFilesDirty = true;
 				return value.root; // updated
 			}
 			for (const language of languages) {
-				const virtualFile = language.createFile(fileName, snapshot, languageId);
+				const virtualFile = language.createVirtualFile(fileName, snapshot, languageId);
 				if (virtualFile) {
 					sourceFiles.set(key, { fileName, snapshot, root: virtualFile, language });
 					sourceFilesDirty = true;
@@ -47,7 +47,7 @@ export function createVirtualFiles(languages: Language[]) {
 			const key = normalizePath(fileName);
 			const value = sourceFiles.get(key);
 			if (value) {
-				value.language.deleteFile?.(value.root);
+				value.language.deleteVirtualFile?.(value.root);
 				sourceFiles.delete(key); // deleted
 				sourceFilesDirty = true;
 			}

--- a/packages/language-core/src/virtualFiles.ts
+++ b/packages/language-core/src/virtualFiles.ts
@@ -1,7 +1,7 @@
 import { SourceMap } from '@volar/source-map';
 import type * as ts from 'typescript/lib/tsserverlibrary';
 import { MirrorMap } from './sourceMaps';
-import type { FileRangeCapabilities, LanguageModule, VirtualFile } from './types';
+import type { FileRangeCapabilities, Language, VirtualFile } from './types';
 
 export type VirtualFiles = ReturnType<typeof createVirtualFiles>;
 
@@ -9,10 +9,10 @@ export interface Source {
 	fileName: string;
 	snapshot: ts.IScriptSnapshot;
 	root: VirtualFile;
-	languageModule: LanguageModule;
+	language: Language;
 }
 
-export function createVirtualFiles(languageModules: LanguageModule[]) {
+export function createVirtualFiles(languages: Language[]) {
 
 	const sourceFiles = new Map<string, Source>();
 	const virtualFiles = new Map<string, { virtualFile: VirtualFile, source: Source; }>();
@@ -30,14 +30,14 @@ export function createVirtualFiles(languageModules: LanguageModule[]) {
 			const value = sourceFiles.get(key);
 			if (value) {
 				value.snapshot = snapshot;
-				value.languageModule.updateFile(value.root, snapshot);
+				value.language.updateFile(value.root, snapshot);
 				sourceFilesDirty = true;
 				return value.root; // updated
 			}
-			for (const languageModule of languageModules) {
-				const virtualFile = languageModule.createFile(fileName, snapshot, languageId);
+			for (const language of languages) {
+				const virtualFile = language.createFile(fileName, snapshot, languageId);
 				if (virtualFile) {
-					sourceFiles.set(key, { fileName, snapshot, root: virtualFile, languageModule });
+					sourceFiles.set(key, { fileName, snapshot, root: virtualFile, language });
 					sourceFilesDirty = true;
 					return virtualFile; // created
 				}
@@ -47,7 +47,7 @@ export function createVirtualFiles(languageModules: LanguageModule[]) {
 			const key = normalizePath(fileName);
 			const value = sourceFiles.get(key);
 			if (value) {
-				value.languageModule.deleteFile?.(value.root);
+				value.language.deleteFile?.(value.root);
 				sourceFiles.delete(key); // deleted
 				sourceFilesDirty = true;
 			}

--- a/packages/language-server/src/browser/fileSystems.ts
+++ b/packages/language-server/src/browser/fileSystems.ts
@@ -3,7 +3,7 @@ import { FileType } from 'vscode-html-languageservice';
 import * as vscode from 'vscode-languageserver';
 import { URI } from 'vscode-uri';
 import { FsReadDirectoryRequest, FsReadFileRequest } from '../protocol';
-import { FileSystem, FileSystemHost, LanguageServerInitializationOptions, RuntimeEnvironment } from '../types';
+import { FileSystem, FileSystemHost, InitializationOptions, RuntimeEnvironment } from '../types';
 import { matchFiles } from './typescript/utilities';
 import { createUriMap } from '../common/utils/uriMap';
 
@@ -24,7 +24,7 @@ export function createWebFileSystemHost(
 	_0: any,
 	_1: any,
 	env: RuntimeEnvironment,
-	initOptions: LanguageServerInitializationOptions,
+	initOptions: InitializationOptions,
 ): FileSystemHost {
 
 	const instances = createUriMap<FileSystem>(env.fileNameToUri);

--- a/packages/language-server/src/common/configurationHost.ts
+++ b/packages/language-server/src/common/configurationHost.ts
@@ -1,7 +1,7 @@
-import { ServiceContext } from '@volar/language-service';
+import { ServiceEnvironment } from '@volar/language-service';
 import * as vscode from 'vscode-languageserver';
 
-export function createConfigurationHost(params: vscode.InitializeParams, connection: vscode.Connection): Pick<ServiceContext, 'getConfiguration' | 'onDidChangeConfiguration'> & { ready(): void; } {
+export function createConfigurationHost(params: vscode.InitializeParams, connection: vscode.Connection): Pick<ServiceEnvironment, 'getConfiguration' | 'onDidChangeConfiguration'> & { ready(): void; } {
 
 	const callbacks: (() => void)[] = [];
 	const cache = new Map<string, any>();

--- a/packages/language-server/src/common/configurationHost.ts
+++ b/packages/language-server/src/common/configurationHost.ts
@@ -1,7 +1,7 @@
-import { ConfigurationHost } from '@volar/language-service';
+import { ServiceContext } from '@volar/language-service';
 import * as vscode from 'vscode-languageserver';
 
-export function createConfigurationHost(params: vscode.InitializeParams, connection: vscode.Connection): ConfigurationHost & { ready(): void; } {
+export function createConfigurationHost(params: vscode.InitializeParams, connection: vscode.Connection): Pick<ServiceContext, 'getConfiguration' | 'onDidChangeConfiguration'> & { ready(): void; } {
 
 	const callbacks: (() => void)[] = [];
 	const cache = new Map<string, any>();

--- a/packages/language-server/src/common/features/customFeatures.ts
+++ b/packages/language-server/src/common/features/customFeatures.ts
@@ -116,9 +116,9 @@ export function register(
 		if (project) {
 			const ls = (await project.project)?.getLanguageServiceDontCreate();
 			if (ls) {
-				const sourceFiles = new Set(ls.context.env.host.getScriptFileNames());
+				const sourceFiles = new Set(ls.context.host.getScriptFileNames());
 				for (const virtualFile of ls.context.core.typescript.languageServiceHost.getScriptFileNames()) {
-					if (virtualFile.startsWith(ls.context.env.host.getCurrentDirectory()) && !sourceFiles.has(virtualFile)) {
+					if (virtualFile.startsWith(ls.context.host.getCurrentDirectory()) && !sourceFiles.has(virtualFile)) {
 						const snapshot = ls.context.core.typescript.languageServiceHost.getScriptSnapshot(virtualFile);
 						if (snapshot) {
 							fs.writeFile(virtualFile, snapshot.getText(0, snapshot.getLength()), () => { });

--- a/packages/language-server/src/common/features/customFeatures.ts
+++ b/packages/language-server/src/common/features/customFeatures.ts
@@ -116,9 +116,9 @@ export function register(
 		if (project) {
 			const ls = (await project.project)?.getLanguageServiceDontCreate();
 			if (ls) {
-				const sourceFiles = new Set(ls.context.host.getScriptFileNames());
+				const sourceFiles = new Set(ls.context.env.host.getScriptFileNames());
 				for (const virtualFile of ls.context.core.typescript.languageServiceHost.getScriptFileNames()) {
-					if (virtualFile.startsWith(ls.context.host.getCurrentDirectory()) && !sourceFiles.has(virtualFile)) {
+					if (virtualFile.startsWith(ls.context.env.host.getCurrentDirectory()) && !sourceFiles.has(virtualFile)) {
 						const snapshot = ls.context.core.typescript.languageServiceHost.getScriptSnapshot(virtualFile);
 						if (snapshot) {
 							fs.writeFile(virtualFile, snapshot.getText(0, snapshot.getLength()), () => { });

--- a/packages/language-server/src/common/features/languageFeatures.ts
+++ b/packages/language-server/src/common/features/languageFeatures.ts
@@ -3,14 +3,14 @@ import * as vscode from 'vscode-languageserver';
 import { AutoInsertRequest, FindFileReferenceRequest } from '../../protocol';
 import { CancellationTokenHost } from '../cancellationPipe';
 import type { Workspaces } from '../workspaces';
-import { RuntimeEnvironment, LanguageServerInitializationOptions, ServerMode } from '../../types';
+import { RuntimeEnvironment, InitializationOptions, ServerMode } from '../../types';
 import { createDocuments } from '../documents';
 
 export function register(
 	connection: vscode.Connection,
 	projects: Workspaces,
 	initParams: vscode.InitializeParams,
-	initOptions: LanguageServerInitializationOptions,
+	initOptions: InitializationOptions,
 	cancelHost: CancellationTokenHost,
 	semanticTokensLegend: vscode.SemanticTokensLegend,
 	runtime: RuntimeEnvironment,

--- a/packages/language-server/src/common/project.ts
+++ b/packages/language-server/src/common/project.ts
@@ -84,6 +84,26 @@ export async function createProject(context: ProjectContext) {
 
 	function getLanguageService() {
 		if (!languageService) {
+			const env: ServiceEnvironment = {
+				uriToFileName,
+				fileNameToUri,
+				locale: context.workspace.workspaces.initParams.locale,
+				rootUri: context.rootUri,
+				clientCapabilities: context.workspace.workspaces.initParams.capabilities,
+				getConfiguration: context.workspace.workspaces.configurationHost?.getConfiguration,
+				onDidChangeConfiguration: context.workspace.workspaces.configurationHost?.onDidChangeConfiguration,
+				fileSystemProvider: context.workspace.workspaces.server.runtimeEnv.fileSystemProvide,
+				onDidChangeWatchedFiles: context.workspace.workspaces.fileSystemHost?.onDidChangeWatchedFiles,
+				documentContext: getDocumentContext(fileNameToUri, uriToFileName, context.workspace.workspaces.ts, languageServiceHost, context.rootUri.toString()),
+				schemaRequestService: async uri => {
+					const protocol = uri.substring(0, uri.indexOf(':'));
+					const builtInHandler = context.workspace.workspaces.server.runtimeEnv.schemaRequestHandlers[protocol];
+					if (builtInHandler) {
+						return await builtInHandler(uri) ?? '';
+					}
+					return '';
+				},
+			};
 			let config = (
 				context.workspace.rootUri.scheme === 'file' ? loadConfig(
 					context.workspace.rootUri.path,
@@ -93,6 +113,7 @@ export async function createProject(context: ProjectContext) {
 			for (const plugin of context.workspace.workspaces.plugins) {
 				if (plugin.resolveConfig) {
 					config = plugin.resolveConfig(config, {
+						env,
 						project: context,
 						sys,
 						host: languageServiceHost,
@@ -101,26 +122,7 @@ export async function createProject(context: ProjectContext) {
 			}
 			languageService = embeddedLS.createLanguageService(
 				{ typescript: context.workspace.workspaces.ts },
-				{
-					uriToFileName,
-					fileNameToUri,
-					locale: context.workspace.workspaces.initParams.locale,
-					rootUri: context.rootUri,
-					clientCapabilities: context.workspace.workspaces.initParams.capabilities,
-					getConfiguration: context.workspace.workspaces.configurationHost?.getConfiguration,
-					onDidChangeConfiguration: context.workspace.workspaces.configurationHost?.onDidChangeConfiguration,
-					fileSystemProvider: context.workspace.workspaces.server.runtimeEnv.fileSystemProvide,
-					onDidChangeWatchedFiles: context.workspace.workspaces.fileSystemHost?.onDidChangeWatchedFiles,
-					documentContext: getDocumentContext(fileNameToUri, uriToFileName, context.workspace.workspaces.ts, languageServiceHost, context.rootUri.toString()),
-					schemaRequestService: async uri => {
-						const protocol = uri.substring(0, uri.indexOf(':'));
-						const builtInHandler = context.workspace.workspaces.server.runtimeEnv.schemaRequestHandlers[protocol];
-						if (builtInHandler) {
-							return await builtInHandler(uri) ?? '';
-						}
-						return '';
-					},
-				},
+				env,
 				config,
 				languageServiceHost,
 				context.documentRegistry,

--- a/packages/language-server/src/common/project.ts
+++ b/packages/language-server/src/common/project.ts
@@ -6,7 +6,7 @@ import type * as ts from 'typescript/lib/tsserverlibrary';
 import * as html from 'vscode-html-languageservice';
 import * as vscode from 'vscode-languageserver';
 import { URI, Utils } from 'vscode-uri';
-import { FileSystem, LanguageServerPlugin, LanguageServiceContext, ServerMode } from '../types';
+import { FileSystem, LanguageServerPlugin, ServerMode } from '../types';
 import { loadConfig } from './utils/serverConfig';
 import { createUriMap } from './utils/uriMap';
 import { WorkspaceContext } from './workspace';
@@ -115,15 +115,14 @@ export async function createProject(context: ProjectContext) {
 					return '';
 				},
 			};
-			const lsCtx: LanguageServiceContext = {
-				project: context,
-				options,
-				sys,
-				host: languageServiceHost,
-			};
 			for (const plugin of context.workspace.workspaces.plugins) {
 				if (plugin.resolveConfig) {
-					config = plugin.resolveConfig(config, lsCtx);
+					config = plugin.resolveConfig(config, {
+						project: context,
+						options,
+						sys,
+						host: languageServiceHost,
+					});
 				}
 			}
 			languageService = embeddedLS.createLanguageService(options, context.documentRegistry);

--- a/packages/language-server/src/common/project.ts
+++ b/packages/language-server/src/common/project.ts
@@ -99,28 +99,32 @@ export async function createProject(context: ProjectContext) {
 					});
 				}
 			}
-			languageService = embeddedLS.createLanguageService({ typescript: context.workspace.workspaces.ts }, {
-				uriToFileName,
-				fileNameToUri,
-				locale: context.workspace.workspaces.initParams.locale,
-				rootUri: context.rootUri,
-				clientCapabilities: context.workspace.workspaces.initParams.capabilities,
-				host: languageServiceHost,
-				config,
-				getConfiguration: context.workspace.workspaces.configurationHost?.getConfiguration,
-				onDidChangeConfiguration: context.workspace.workspaces.configurationHost?.onDidChangeConfiguration,
-				fileSystemProvider: context.workspace.workspaces.server.runtimeEnv.fileSystemProvide,
-				onDidChangeWatchedFiles: context.workspace.workspaces.fileSystemHost?.onDidChangeWatchedFiles,
-				documentContext: getDocumentContext(fileNameToUri, uriToFileName, context.workspace.workspaces.ts, languageServiceHost, context.rootUri.toString()),
-				schemaRequestService: async uri => {
-					const protocol = uri.substring(0, uri.indexOf(':'));
-					const builtInHandler = context.workspace.workspaces.server.runtimeEnv.schemaRequestHandlers[protocol];
-					if (builtInHandler) {
-						return await builtInHandler(uri) ?? '';
-					}
-					return '';
+			languageService = embeddedLS.createLanguageService(
+				{ typescript: context.workspace.workspaces.ts },
+				{
+					uriToFileName,
+					fileNameToUri,
+					locale: context.workspace.workspaces.initParams.locale,
+					rootUri: context.rootUri,
+					clientCapabilities: context.workspace.workspaces.initParams.capabilities,
+					getConfiguration: context.workspace.workspaces.configurationHost?.getConfiguration,
+					onDidChangeConfiguration: context.workspace.workspaces.configurationHost?.onDidChangeConfiguration,
+					fileSystemProvider: context.workspace.workspaces.server.runtimeEnv.fileSystemProvide,
+					onDidChangeWatchedFiles: context.workspace.workspaces.fileSystemHost?.onDidChangeWatchedFiles,
+					documentContext: getDocumentContext(fileNameToUri, uriToFileName, context.workspace.workspaces.ts, languageServiceHost, context.rootUri.toString()),
+					schemaRequestService: async uri => {
+						const protocol = uri.substring(0, uri.indexOf(':'));
+						const builtInHandler = context.workspace.workspaces.server.runtimeEnv.schemaRequestHandlers[protocol];
+						if (builtInHandler) {
+							return await builtInHandler(uri) ?? '';
+						}
+						return '';
+					},
 				},
-			}, context.documentRegistry);
+				config,
+				languageServiceHost,
+				context.documentRegistry,
+			);
 		}
 		return languageService;
 	}

--- a/packages/language-server/src/common/project.ts
+++ b/packages/language-server/src/common/project.ts
@@ -1,6 +1,6 @@
 import * as embedded from '@volar/language-core';
 import * as embeddedLS from '@volar/language-service';
-import { LanguageServiceOptions } from '@volar/language-service';
+import { ServiceOptions } from '@volar/language-service';
 import * as path from 'typesafe-path';
 import type * as ts from 'typescript/lib/tsserverlibrary';
 import * as html from 'vscode-html-languageservice';
@@ -90,7 +90,7 @@ export async function createProject(context: ProjectContext) {
 					context.workspace.workspaces.initOptions.configFilePath,
 				) : {}
 			) ?? {};
-			const options: LanguageServiceOptions = {
+			const options: ServiceOptions = {
 				modules: { typescript: context.workspace.workspaces.ts },
 				uriToFileName,
 				fileNameToUri,
@@ -318,8 +318,8 @@ function createParsedCommandLine(
 }
 
 function getDocumentContext(
-	fileNameToUri: LanguageServiceOptions['fileNameToUri'],
-	uriToFileName: LanguageServiceOptions['uriToFileName'],
+	fileNameToUri: ServiceOptions['fileNameToUri'],
+	uriToFileName: ServiceOptions['uriToFileName'],
 	ts: typeof import('typescript/lib/tsserverlibrary') | undefined,
 	host: ts.LanguageServiceHost | undefined,
 	rootUri: string,

--- a/packages/language-server/src/common/project.ts
+++ b/packages/language-server/src/common/project.ts
@@ -101,7 +101,8 @@ export async function createProject(context: ProjectContext) {
 				get config() {
 					return config;
 				},
-				configurationHost: context.workspace.workspaces.configurationHost,
+				getConfiguration: context.workspace.workspaces.configurationHost?.getConfiguration,
+				onDidChangeConfiguration: context.workspace.workspaces.configurationHost?.onDidChangeConfiguration,
 				fileSystemProvider: context.workspace.workspaces.server.runtimeEnv.fileSystemProvide,
 				fileSystemHost: context.workspace.workspaces.fileSystemHost,
 				documentContext: getDocumentContext(fileNameToUri, uriToFileName, context.workspace.workspaces.ts, languageServiceHost, context.rootUri.toString()),

--- a/packages/language-server/src/common/project.ts
+++ b/packages/language-server/src/common/project.ts
@@ -99,8 +99,7 @@ export async function createProject(context: ProjectContext) {
 					});
 				}
 			}
-			languageService = embeddedLS.createLanguageService({
-				modules: { typescript: context.workspace.workspaces.ts },
+			languageService = embeddedLS.createLanguageService({ typescript: context.workspace.workspaces.ts }, {
 				uriToFileName,
 				fileNameToUri,
 				locale: context.workspace.workspaces.initParams.locale,

--- a/packages/language-server/src/common/server.ts
+++ b/packages/language-server/src/common/server.ts
@@ -67,7 +67,7 @@ export function startCommonLanguageServer(connection: vscode.Connection, getCtx:
 
 		configurationHost = initParams.capabilities.workspace?.configuration ? createConfigurationHost(initParams, connection) : undefined;
 
-		let lsPlugins: Config['plugins'] = {};
+		let services: Config['services'] = {};
 		for (const root of roots) {
 			if (root.scheme === 'file') {
 				let config = loadConfig(root.path, options.configFilePath) ?? {};
@@ -76,10 +76,10 @@ export function startCommonLanguageServer(connection: vscode.Connection, getCtx:
 						config = plugin.resolveConfig(config, undefined);
 					}
 				}
-				if (config.plugins) {
-					lsPlugins = {
-						...lsPlugins,
-						...config.plugins,
+				if (config.services) {
+					services = {
+						...services,
+						...config.services,
 					};
 				}
 			}
@@ -90,7 +90,7 @@ export function startCommonLanguageServer(connection: vscode.Connection, getCtx:
 			options,
 			plugins,
 			getSemanticTokensLegend(),
-			lsPlugins,
+			services,
 		);
 
 		await createLanguageServiceHost();

--- a/packages/language-server/src/common/server.ts
+++ b/packages/language-server/src/common/server.ts
@@ -2,7 +2,7 @@ import { Config, standardSemanticTokensLegend } from '@volar/language-service';
 import * as l10n from '@vscode/l10n';
 import * as vscode from 'vscode-languageserver';
 import { URI } from 'vscode-uri';
-import { FileSystemHost, LanguageServerInitializationOptions, LanguageServerPlugin, RuntimeEnvironment, ServerMode } from '../types';
+import { FileSystemHost, InitializationOptions, LanguageServerPlugin, RuntimeEnvironment, ServerMode } from '../types';
 import { createCancellationTokenHost } from './cancellationPipe';
 import { createConfigurationHost } from './configurationHost';
 import { createDocuments } from './documents';
@@ -16,10 +16,10 @@ export interface ServerContext {
 	plugins: LanguageServerPlugin[],
 }
 
-export function startCommonLanguageServer(connection: vscode.Connection, getCtx: (initOptions: LanguageServerInitializationOptions) => ServerContext) {
+export function startCommonLanguageServer(connection: vscode.Connection, getCtx: (initOptions: InitializationOptions) => ServerContext) {
 
 	let initParams: vscode.InitializeParams;
-	let options: LanguageServerInitializationOptions;
+	let options: InitializationOptions;
 	let roots: URI[] = [];
 	let fsHost: FileSystemHost | undefined;
 	let projects: ReturnType<typeof createWorkspaces> | undefined;

--- a/packages/language-server/src/common/server.ts
+++ b/packages/language-server/src/common/server.ts
@@ -156,19 +156,19 @@ export function startCommonLanguageServer(connection: vscode.Connection, getCtx:
 
 		const tsLocalized = options.typescript && initParams.locale ? await context.runtimeEnv.loadTypescriptLocalized(options.typescript.tsdk, initParams.locale) : undefined;
 		const cancelTokenHost = createCancellationTokenHost(options.cancellationPipeName);
-		const _projects = createWorkspaces({
+
+		projects = createWorkspaces({
 			server: context,
 			fileSystemHost: fsHost,
 			configurationHost,
 			ts,
 			tsLocalized,
-			initParams: initParams,
+			initParams,
 			initOptions: options,
 			documents,
 			cancelTokenHost,
 			plugins,
 		});
-		projects = _projects;
 
 		for (const root of roots) {
 			projects.add(root);

--- a/packages/language-server/src/common/utils/inferredCompilerOptions.ts
+++ b/packages/language-server/src/common/utils/inferredCompilerOptions.ts
@@ -1,11 +1,11 @@
-import { ConfigurationHost } from '@volar/language-service';
+import { ServiceContext } from '@volar/language-service';
 import type * as ts from 'typescript/lib/tsserverlibrary';
 
-export async function getInferredCompilerOptions(configurationHost: ConfigurationHost | undefined) {
+export async function getInferredCompilerOptions(ctx: Pick<ServiceContext, 'getConfiguration' | 'onDidChangeConfiguration'> | undefined) {
 
 	let [implicitProjectConfig_1, implicitProjectConfig_2] = await Promise.all([
-		configurationHost?.getConfiguration<any>('js/ts.implicitProjectConfig'),
-		configurationHost?.getConfiguration<any>('javascript.implicitProjectConfig'),
+		ctx?.getConfiguration?.<any>('js/ts.implicitProjectConfig'),
+		ctx?.getConfiguration?.<any>('javascript.implicitProjectConfig'),
 	]);
 
 	implicitProjectConfig_1 = implicitProjectConfig_1 ?? {};

--- a/packages/language-server/src/common/utils/inferredCompilerOptions.ts
+++ b/packages/language-server/src/common/utils/inferredCompilerOptions.ts
@@ -1,7 +1,7 @@
-import { ServiceContext } from '@volar/language-service';
+import { ServiceEnvironment } from '@volar/language-service';
 import type * as ts from 'typescript/lib/tsserverlibrary';
 
-export async function getInferredCompilerOptions(ctx: Pick<ServiceContext, 'getConfiguration' | 'onDidChangeConfiguration'> | undefined) {
+export async function getInferredCompilerOptions(ctx: Pick<ServiceEnvironment, 'getConfiguration' | 'onDidChangeConfiguration'> | undefined) {
 
 	let [implicitProjectConfig_1, implicitProjectConfig_2] = await Promise.all([
 		ctx?.getConfiguration?.<any>('js/ts.implicitProjectConfig'),

--- a/packages/language-server/src/common/utils/registerFeatures.ts
+++ b/packages/language-server/src/common/utils/registerFeatures.ts
@@ -7,10 +7,10 @@ export function setupCapabilities(
 	initOptions: LanguageServerInitializationOptions,
 	plugins: ReturnType<LanguageServerPlugin>[],
 	semanticTokensLegend: vscode.SemanticTokensLegend,
-	lsPlugins: NonNullable<Config['plugins']>,
+	services: NonNullable<Config['services']>,
 ) {
 
-	const lsPluginInstances = Object.values(lsPlugins)
+	const lsPluginInstances = Object.values(services)
 		.map(plugin => typeof plugin === 'function' ? plugin() : plugin)
 		.filter((plugin): plugin is NonNullable<typeof plugin> => !!plugin);
 	const serverMode = initOptions.serverMode ?? ServerMode.Semantic;

--- a/packages/language-server/src/common/utils/registerFeatures.ts
+++ b/packages/language-server/src/common/utils/registerFeatures.ts
@@ -1,10 +1,10 @@
-import { DiagnosticModel, LanguageServerPlugin, LanguageServerInitializationOptions, ServerMode } from '../../types';
+import { DiagnosticModel, LanguageServerPlugin, InitializationOptions, ServerMode } from '../../types';
 import * as vscode from 'vscode-languageserver';
 import { Config } from '@volar/language-service';
 
 export function setupCapabilities(
 	server: vscode.ServerCapabilities,
-	initOptions: LanguageServerInitializationOptions,
+	initOptions: InitializationOptions,
 	plugins: ReturnType<LanguageServerPlugin>[],
 	semanticTokensLegend: vscode.SemanticTokensLegend,
 	services: NonNullable<Config['services']>,

--- a/packages/language-server/src/common/utils/registerFeatures.ts
+++ b/packages/language-server/src/common/utils/registerFeatures.ts
@@ -11,7 +11,7 @@ export function setupCapabilities(
 ) {
 
 	const lsPluginInstances = Object.values(services)
-		.map(plugin => typeof plugin === 'function' ? plugin() : plugin)
+		.map(plugin => typeof plugin === 'function' ? plugin(undefined, undefined) : plugin)
 		.filter((plugin): plugin is NonNullable<typeof plugin> => !!plugin);
 	const serverMode = initOptions.serverMode ?? ServerMode.Semantic;
 

--- a/packages/language-server/src/common/workspaces.ts
+++ b/packages/language-server/src/common/workspaces.ts
@@ -2,7 +2,7 @@ import { ServiceContext } from '@volar/language-service';
 import type * as ts from 'typescript/lib/tsserverlibrary';
 import * as vscode from 'vscode-languageserver';
 import { URI } from 'vscode-uri';
-import { DiagnosticModel, FileSystemHost, LanguageServerInitializationOptions, LanguageServerPlugin, ServerMode } from '../types';
+import { DiagnosticModel, FileSystemHost, InitializationOptions, LanguageServerPlugin, ServerMode } from '../types';
 import { CancellationTokenHost } from './cancellationPipe';
 import { createDocuments } from './documents';
 import { ServerContext } from './server';
@@ -13,7 +13,7 @@ import * as path from 'typesafe-path';
 export interface WorkspacesContext {
 	server: ServerContext;
 	initParams: vscode.InitializeParams,
-	initOptions: LanguageServerInitializationOptions,
+	initOptions: InitializationOptions,
 	plugins: ReturnType<LanguageServerPlugin>[],
 	ts: typeof import('typescript/lib/tsserverlibrary') | undefined,
 	tsLocalized: ts.MapLike<string> | undefined,

--- a/packages/language-server/src/common/workspaces.ts
+++ b/packages/language-server/src/common/workspaces.ts
@@ -1,4 +1,4 @@
-import { ConfigurationHost } from '@volar/language-service';
+import { ServiceContext } from '@volar/language-service';
 import type * as ts from 'typescript/lib/tsserverlibrary';
 import * as vscode from 'vscode-languageserver';
 import { URI } from 'vscode-uri';
@@ -18,7 +18,7 @@ export interface WorkspacesContext {
 	ts: typeof import('typescript/lib/tsserverlibrary') | undefined,
 	tsLocalized: ts.MapLike<string> | undefined,
 	fileSystemHost: FileSystemHost | undefined,
-	configurationHost: ConfigurationHost | undefined,
+	configurationHost: Pick<ServiceContext, 'getConfiguration' | 'onDidChangeConfiguration'> | undefined,
 	documents: ReturnType<typeof createDocuments>,
 	cancelTokenHost: CancellationTokenHost,
 }

--- a/packages/language-server/src/common/workspaces.ts
+++ b/packages/language-server/src/common/workspaces.ts
@@ -1,4 +1,4 @@
-import { ServiceContext } from '@volar/language-service';
+import { ServiceEnvironment } from '@volar/language-service';
 import type * as ts from 'typescript/lib/tsserverlibrary';
 import * as vscode from 'vscode-languageserver';
 import { URI } from 'vscode-uri';
@@ -18,7 +18,7 @@ export interface WorkspacesContext {
 	ts: typeof import('typescript/lib/tsserverlibrary') | undefined,
 	tsLocalized: ts.MapLike<string> | undefined,
 	fileSystemHost: FileSystemHost | undefined,
-	configurationHost: Pick<ServiceContext, 'getConfiguration' | 'onDidChangeConfiguration'> | undefined,
+	configurationHost: Pick<ServiceEnvironment, 'getConfiguration' | 'onDidChangeConfiguration'> | undefined,
 	documents: ReturnType<typeof createDocuments>,
 	cancelTokenHost: CancellationTokenHost,
 }

--- a/packages/language-server/src/node/fileSystem.ts
+++ b/packages/language-server/src/node/fileSystem.ts
@@ -2,7 +2,7 @@ import type * as ts from 'typescript/lib/tsserverlibrary';
 import * as vscode from 'vscode-languageserver';
 import { URI } from 'vscode-uri';
 import { createUriMap } from '../common/utils/uriMap';
-import { FileSystem, FileSystemHost, LanguageServerInitializationOptions, RuntimeEnvironment } from '../types';
+import { FileSystem, FileSystemHost, InitializationOptions, RuntimeEnvironment } from '../types';
 
 let currentCwd = '';
 
@@ -10,7 +10,7 @@ export function createNodeFileSystemHost(
 	ts: typeof import('typescript/lib/tsserverlibrary'),
 	capabilities: vscode.ClientCapabilities,
 	env: RuntimeEnvironment,
-	_initOptions: LanguageServerInitializationOptions,
+	_initOptions: InitializationOptions,
 ): FileSystemHost {
 
 	const instances = createUriMap<[FileSystem, Map<string, any>[]]>(env.fileNameToUri);

--- a/packages/language-server/src/types.ts
+++ b/packages/language-server/src/types.ts
@@ -47,20 +47,18 @@ export interface RuntimeEnvironment {
 	};
 }
 
-export interface LanguageServiceContext {
-	project: ProjectContext;
-	options: ServiceOptions;
-	host: embedded.LanguageServiceHost;
-	sys: FileSystem;
-}
-
 export interface LanguageServerPlugin {
 	(initOptions: LanguageServerInitializationOptions, modules: { typescript?: typeof import('typescript/lib/tsserverlibrary'); }): {
 		extraFileExtensions?: ts.FileExtensionInfo[];
 		watchFileExtensions?: string[];
 		resolveConfig?(
 			config: Config,
-			ctx: LanguageServiceContext | undefined,
+			ctx: {
+				project: ProjectContext;
+				options: ServiceOptions;
+				host: embedded.LanguageServiceHost;
+				sys: FileSystem;
+			} | undefined,
 		): Config;
 		onInitialized?(getLanguageService: (uri: string) => Promise<LanguageService | undefined>, env: RuntimeEnvironment): void;
 	};

--- a/packages/language-server/src/types.ts
+++ b/packages/language-server/src/types.ts
@@ -1,4 +1,4 @@
-import { LanguageService, LanguageServiceOptions } from '@volar/language-service';
+import { LanguageService, ServiceOptions } from '@volar/language-service';
 import * as embedded from '@volar/language-core';
 import type { FileSystemProvider } from 'vscode-html-languageservice';
 import type * as ts from 'typescript/lib/tsserverlibrary';
@@ -49,7 +49,7 @@ export interface RuntimeEnvironment {
 
 export interface LanguageServiceContext {
 	project: ProjectContext;
-	options: LanguageServiceOptions;
+	options: ServiceOptions;
 	host: embedded.LanguageServiceHost;
 	sys: FileSystem;
 }

--- a/packages/language-server/src/types.ts
+++ b/packages/language-server/src/types.ts
@@ -1,4 +1,4 @@
-import { LanguageService } from '@volar/language-service';
+import { LanguageService, ServiceEnvironment } from '@volar/language-service';
 import * as embedded from '@volar/language-core';
 import type { FileSystemProvider } from 'vscode-html-languageservice';
 import type * as ts from 'typescript/lib/tsserverlibrary';
@@ -54,6 +54,7 @@ export interface LanguageServerPlugin {
 		resolveConfig?(
 			config: Config,
 			ctx: {
+				env: ServiceEnvironment;
 				project: ProjectContext;
 				host: embedded.LanguageServiceHost;
 				sys: FileSystem;

--- a/packages/language-server/src/types.ts
+++ b/packages/language-server/src/types.ts
@@ -1,4 +1,4 @@
-import { LanguageService, ServiceOptions } from '@volar/language-service';
+import { LanguageService } from '@volar/language-service';
 import * as embedded from '@volar/language-core';
 import type { FileSystemProvider } from 'vscode-html-languageservice';
 import type * as ts from 'typescript/lib/tsserverlibrary';
@@ -55,7 +55,6 @@ export interface LanguageServerPlugin {
 			config: Config,
 			ctx: {
 				project: ProjectContext;
-				options: ServiceOptions;
 				host: embedded.LanguageServiceHost;
 				sys: FileSystem;
 			} | undefined,

--- a/packages/language-server/src/types.ts
+++ b/packages/language-server/src/types.ts
@@ -37,7 +37,7 @@ export interface RuntimeEnvironment {
 		ts: typeof import('typescript/lib/tsserverlibrary'),
 		capabilities: vscode.ClientCapabilities,
 		env: RuntimeEnvironment,
-		initOptions: LanguageServerInitializationOptions,
+		initOptions: InitializationOptions,
 	) => FileSystemHost,
 	// https://github.com/microsoft/vscode/blob/7927075f89db213bc6e2182fa684d514d69e2359/extensions/html-language-features/server/src/htmlServer.ts#L53-L56
 	readonly timer: {
@@ -48,7 +48,7 @@ export interface RuntimeEnvironment {
 }
 
 export interface LanguageServerPlugin {
-	(initOptions: LanguageServerInitializationOptions, modules: { typescript?: typeof import('typescript/lib/tsserverlibrary'); }): {
+	(initOptions: InitializationOptions, modules: { typescript?: typeof import('typescript/lib/tsserverlibrary'); }): {
 		extraFileExtensions?: ts.FileExtensionInfo[];
 		watchFileExtensions?: string[];
 		resolveConfig?(
@@ -76,7 +76,7 @@ export enum DiagnosticModel {
 	Pull = 2,
 }
 
-export interface LanguageServerInitializationOptions {
+export interface InitializationOptions {
 	typescript?: {
 		/**
 		 * Absolute path to node_modules/typescript/lib

--- a/packages/language-service/src/baseLanguageService.ts
+++ b/packages/language-service/src/baseLanguageService.ts
@@ -26,7 +26,7 @@ import * as renamePrepare from './languageFeatures/renamePrepare';
 import * as signatureHelp from './languageFeatures/signatureHelp';
 import * as diagnostics from './languageFeatures/validation';
 import * as workspaceSymbol from './languageFeatures/workspaceSymbols';
-import { LanguageServicePluginContext, LanguageServiceOptions } from './types';
+import { ServiceContext, LanguageServiceOptions } from './types';
 import type * as ts from 'typescript/lib/tsserverlibrary';
 
 import * as colorPresentations from './documentFeatures/colorPresentations';
@@ -103,7 +103,7 @@ function createLanguageServicePluginContext(
 	const textDocumentMapper = createDocumentsAndSourceMaps(ctx, languageContext.virtualFiles);
 	const documents = new WeakMap<ts.IScriptSnapshot, TextDocument>();
 	const documentVersions = new Map<string, number>();
-	const context: LanguageServicePluginContext = {
+	const context: ServiceContext = {
 		...ctx,
 		core: languageContext,
 		plugins: {},
@@ -227,7 +227,7 @@ function createLanguageServicePluginContext(
 	}
 }
 
-function createLanguageServiceBase(context: LanguageServicePluginContext) {
+function createLanguageServiceBase(context: ServiceContext) {
 
 	return {
 

--- a/packages/language-service/src/baseLanguageService.ts
+++ b/packages/language-service/src/baseLanguageService.ts
@@ -26,7 +26,7 @@ import * as renamePrepare from './languageFeatures/renamePrepare';
 import * as signatureHelp from './languageFeatures/signatureHelp';
 import * as diagnostics from './languageFeatures/validation';
 import * as workspaceSymbol from './languageFeatures/workspaceSymbols';
-import { ServiceContext, LanguageServiceOptions } from './types';
+import { ServiceContext, ServiceOptions } from './types';
 import type * as ts from 'typescript/lib/tsserverlibrary';
 
 import * as colorPresentations from './documentFeatures/colorPresentations';
@@ -44,7 +44,7 @@ import { notEmpty, resolveCommonLanguageId } from './utils/common';
 export type LanguageService = ReturnType<typeof createLanguageServiceBase>;
 
 export function createLanguageService(
-	ctx: LanguageServiceOptions,
+	ctx: ServiceOptions,
 	documentRegistry?: ts.DocumentRegistry,
 ) {
 	const languageContext = createLanguageContext(ctx.host, ctx.modules, Object.values(ctx.config.languages ?? {}).filter(notEmpty));
@@ -53,7 +53,7 @@ export function createLanguageService(
 }
 
 function createLanguageServicePluginContext(
-	ctx: LanguageServiceOptions,
+	ctx: ServiceOptions,
 	languageContext: ReturnType<typeof createLanguageContext>,
 	documentRegistry?: ts.DocumentRegistry,
 ) {

--- a/packages/language-service/src/baseLanguageService.ts
+++ b/packages/language-service/src/baseLanguageService.ts
@@ -106,7 +106,6 @@ function createLanguageServicePluginContext(
 		core: languageContext,
 		plugins: {},
 		typescript: ts && tsLs ? {
-			module: ts,
 			languageServiceHost: languageContext.typescript.languageServiceHost,
 			languageService: tsLs,
 		} : undefined,

--- a/packages/language-service/src/baseLanguageService.ts
+++ b/packages/language-service/src/baseLanguageService.ts
@@ -171,14 +171,10 @@ function createLanguageServicePluginContext(
 		getTextDocument,
 	};
 
-	for (const pluginId in ctx.config.plugins ?? {}) {
-		const plugin = ctx.config.plugins?.[pluginId];
-		if (plugin instanceof Function) {
-			const _plugin = plugin(context);
-			context.plugins[pluginId] = _plugin;
-		}
-		else if (plugin) {
-			context.plugins[pluginId] = plugin;
+	for (const serviceId in ctx.config.services ?? {}) {
+		const service = ctx.config.services?.[serviceId];
+		if (service) {
+			context.plugins[serviceId] = service(context);
 		}
 	}
 

--- a/packages/language-service/src/baseLanguageService.ts
+++ b/packages/language-service/src/baseLanguageService.ts
@@ -44,11 +44,11 @@ import { notEmpty, resolveCommonLanguageId } from './utils/common';
 export type LanguageService = ReturnType<typeof createLanguageServiceBase>;
 
 export function createLanguageService(
-	ctx: ServiceEnvironment,
+	env: ServiceEnvironment,
 	documentRegistry?: ts.DocumentRegistry,
 ) {
-	const languageContext = createLanguageContext(ctx.host, ctx.modules, Object.values(ctx.config.languages ?? {}).filter(notEmpty));
-	const context = createLanguageServicePluginContext(ctx, languageContext, documentRegistry);
+	const languageContext = createLanguageContext(env.host, env.modules, Object.values(env.config.languages ?? {}).filter(notEmpty));
+	const context = createLanguageServicePluginContext(env, languageContext, documentRegistry);
 	return createLanguageServiceBase(context);
 }
 

--- a/packages/language-service/src/baseLanguageService.ts
+++ b/packages/language-service/src/baseLanguageService.ts
@@ -44,20 +44,22 @@ import { notEmpty, resolveCommonLanguageId } from './utils/common';
 export type LanguageService = ReturnType<typeof createLanguageServiceBase>;
 
 export function createLanguageService(
+	modules: { typescript?: typeof import('typescript/lib/tsserverlibrary'); },
 	env: ServiceEnvironment,
 	documentRegistry?: ts.DocumentRegistry,
 ) {
-	const languageContext = createLanguageContext(env.host, env.modules, Object.values(env.config.languages ?? {}).filter(notEmpty));
-	const context = createLanguageServicePluginContext(env, languageContext, documentRegistry);
+	const languageContext = createLanguageContext(modules, env.host, Object.values(env.config.languages ?? {}).filter(notEmpty));
+	const context = createLanguageServicePluginContext(modules, env, languageContext, documentRegistry);
 	return createLanguageServiceBase(context);
 }
 
 function createLanguageServicePluginContext(
+	modules: { typescript?: typeof import('typescript/lib/tsserverlibrary'); },
 	env: ServiceEnvironment,
 	languageContext: ReturnType<typeof createLanguageContext>,
 	documentRegistry?: ts.DocumentRegistry,
 ) {
-	const ts = env.modules.typescript;
+	const ts = modules.typescript;
 	let tsLs: ts.LanguageService | undefined;
 
 	if (ts) {

--- a/packages/language-service/src/baseLanguageService.ts
+++ b/packages/language-service/src/baseLanguageService.ts
@@ -69,15 +69,13 @@ function createLanguageServicePluginContext(
 		);
 		tsLs = created.languageService;
 
-		if (created.setPreferences && ctx.configurationHost) {
-
-			const configHost = ctx.configurationHost;
+		if (created.setPreferences && ctx.getConfiguration) {
 
 			updatePreferences();
-			ctx.configurationHost?.onDidChangeConfiguration?.(updatePreferences);
+			ctx.onDidChangeConfiguration?.(updatePreferences);
 
 			async function updatePreferences() {
-				const preferences = await configHost.getConfiguration<ts.UserPreferences>('typescript.preferences');
+				const preferences = await ctx.getConfiguration?.<ts.UserPreferences>('typescript.preferences');
 				if (preferences) {
 					created.setPreferences?.(preferences);
 				}

--- a/packages/language-service/src/baseLanguageService.ts
+++ b/packages/language-service/src/baseLanguageService.ts
@@ -112,58 +112,73 @@ function createLanguageServicePluginContext(
 		} : undefined,
 		documents: textDocumentMapper,
 		commands: {
-			createRenameCommand(uri, position) {
-				const source = toSourceLocation(uri, position, data => typeof data.rename === 'object' ? !!data.rename.normalize : !!data.rename);
-				if (!source) {
-					return;
-				}
-				return vscode.Command.create(
-					'',
-					'editor.action.rename',
-					source.uri,
-					source.position,
-				);
+			rename: {
+				create(uri, position) {
+					const source = toSourceLocation(uri, position, data => typeof data.rename === 'object' ? !!data.rename.normalize : !!data.rename);
+					if (!source) {
+						return;
+					}
+					return vscode.Command.create(
+						'',
+						'editor.action.rename',
+						source.uri,
+						source.position,
+					);
+				},
+				is(command) {
+					return command.command === 'editor.action.rename';
+				},
 			},
-			createShowReferencesCommand(uri, position, locations) {
-				const source = toSourceLocation(uri, position);
-				if (!source) {
-					return;
-				}
-				const sourceReferences: vscode.Location[] = [];
-				for (const reference of locations) {
-					if (context.documents.isVirtualFileUri(reference.uri)) {
-						for (const [_, map] of context.documents.getMapsByVirtualFileUri(reference.uri)) {
-							const range = map.toSourceRange(reference.range);
-							if (range) {
-								sourceReferences.push({ uri: map.sourceFileDocument.uri, range });
+			showReferences: {
+				create(uri, position, locations) {
+					const source = toSourceLocation(uri, position);
+					if (!source) {
+						return;
+					}
+					const sourceReferences: vscode.Location[] = [];
+					for (const reference of locations) {
+						if (context.documents.isVirtualFileUri(reference.uri)) {
+							for (const [_, map] of context.documents.getMapsByVirtualFileUri(reference.uri)) {
+								const range = map.toSourceRange(reference.range);
+								if (range) {
+									sourceReferences.push({ uri: map.sourceFileDocument.uri, range });
+								}
 							}
 						}
+						else {
+							sourceReferences.push(reference);
+						}
 					}
-					else {
-						sourceReferences.push(reference);
-					}
-				}
-				return vscode.Command.create(
-					locations.length === 1 ? '1 reference' : `${locations.length} references`,
-					'editor.action.showReferences',
-					source.uri,
-					source.position,
-					sourceReferences,
-				);
+					return vscode.Command.create(
+						locations.length === 1 ? '1 reference' : `${locations.length} references`,
+						'editor.action.showReferences',
+						source.uri,
+						source.position,
+						sourceReferences,
+					);
+				},
+				is(command) {
+					return command.command === 'editor.action.showReferences';
+				},
 			},
-			createSetSelectionCommand(position: vscode.Position) {
-				return vscode.Command.create(
-					'',
-					'setSelection',
-					{
-						selection: {
-							selectionStartLineNumber: position.line + 1,
-							positionLineNumber: position.line + 1,
-							selectionStartColumn: position.character + 1,
-							positionColumn: position.character + 1,
+			setSelection: {
+				create(position: vscode.Position) {
+					return vscode.Command.create(
+						'',
+						'setSelection',
+						{
+							selection: {
+								selectionStartLineNumber: position.line + 1,
+								positionLineNumber: position.line + 1,
+								selectionStartColumn: position.character + 1,
+								positionColumn: position.character + 1,
+							},
 						},
-					},
-				);
+					);
+				},
+				is(command) {
+					return command.command === 'setSelection';
+				}
 			},
 		},
 		getTextDocument,

--- a/packages/language-service/src/baseLanguageService.ts
+++ b/packages/language-service/src/baseLanguageService.ts
@@ -188,7 +188,7 @@ function createLanguageServicePluginContext(
 	for (const serviceId in env.config.services ?? {}) {
 		const service = env.config.services?.[serviceId];
 		if (service) {
-			context.plugins[serviceId] = service(context);
+			context.plugins[serviceId] = service(context, modules);
 		}
 	}
 

--- a/packages/language-service/src/documentFeatures/colorPresentations.ts
+++ b/packages/language-service/src/documentFeatures/colorPresentations.ts
@@ -1,9 +1,9 @@
-import type { LanguageServicePluginContext } from '../types';
+import type { ServiceContext } from '../types';
 import { languageFeatureWorker } from '../utils/featureWorkers';
 import * as vscode from 'vscode-languageserver-protocol';
 import { notEmpty } from '../utils/common';
 
-export function register(context: LanguageServicePluginContext) {
+export function register(context: ServiceContext) {
 
 	return (uri: string, color: vscode.Color, range: vscode.Range, token = vscode.CancellationToken.None) => {
 

--- a/packages/language-service/src/documentFeatures/documentColors.ts
+++ b/packages/language-service/src/documentFeatures/documentColors.ts
@@ -1,9 +1,9 @@
-import type { LanguageServicePluginContext } from '../types';
+import type { ServiceContext } from '../types';
 import { documentFeatureWorker } from '../utils/featureWorkers';
 import * as vscode from 'vscode-languageserver-protocol';
 import { notEmpty } from '../utils/common';
 
-export function register(context: LanguageServicePluginContext) {
+export function register(context: ServiceContext) {
 
 	return (uri: string, token = vscode.CancellationToken.None) => {
 

--- a/packages/language-service/src/documentFeatures/documentSymbols.ts
+++ b/packages/language-service/src/documentFeatures/documentSymbols.ts
@@ -1,10 +1,10 @@
-import type { LanguageServicePluginContext } from '../types';
+import type { ServiceContext } from '../types';
 import { documentFeatureWorker } from '../utils/featureWorkers';
 import * as transformer from '../transformer';
 import * as vscode from 'vscode-languageserver-protocol';
 import { isInsideRange, notEmpty } from '../utils/common';
 
-export function register(context: LanguageServicePluginContext) {
+export function register(context: ServiceContext) {
 
 	return (uri: string, token = vscode.CancellationToken.None): Promise<vscode.DocumentSymbol[] | undefined> => {
 

--- a/packages/language-service/src/documentFeatures/foldingRanges.ts
+++ b/packages/language-service/src/documentFeatures/foldingRanges.ts
@@ -1,9 +1,9 @@
-import type { LanguageServicePluginContext } from '../types';
+import type { ServiceContext } from '../types';
 import { documentFeatureWorker } from '../utils/featureWorkers';
 import * as transformer from '../transformer';
 import * as vscode from 'vscode-languageserver-protocol';
 
-export function register(context: LanguageServicePluginContext) {
+export function register(context: ServiceContext) {
 
 	return (uri: string, token = vscode.CancellationToken.None) => {
 

--- a/packages/language-service/src/documentFeatures/format.ts
+++ b/packages/language-service/src/documentFeatures/format.ts
@@ -1,7 +1,7 @@
 import type { VirtualFile } from '@volar/language-core';
 import * as vscode from 'vscode-languageserver-protocol';
 import { TextDocument } from 'vscode-languageserver-textdocument';
-import type { LanguageServicePluginContext, LanguageServicePluginInstance } from '../types';
+import type { LanguageServicePluginContext, Service } from '../types';
 import { SourceMap } from '@volar/source-map';
 import { isInsideRange, stringToSnapshot } from '../utils/common';
 
@@ -48,7 +48,7 @@ export function register(context: LanguageServicePluginContext) {
 			const toPatchIndentUris: {
 				uri: string;
 				isCodeBlock: boolean;
-				plugin: LanguageServicePluginInstance;
+				service: ReturnType<Service>;
 			}[] = [];
 
 			for (const embedded of embeddedFiles) {
@@ -92,7 +92,7 @@ export function register(context: LanguageServicePluginContext) {
 				toPatchIndentUris.push({
 					uri: map.virtualFileDocument.uri,
 					isCodeBlock,
-					plugin: embeddedCodeResult.plugin,
+					service: embeddedCodeResult.plugin,
 				});
 
 				for (const textEdit of embeddedCodeResult.edits) {
@@ -134,7 +134,7 @@ export function register(context: LanguageServicePluginContext) {
 
 						const indentSensitiveLines = new Set<number>();
 
-						for (const plugin of toPatchIndentUri.plugin.provideFormattingIndentSensitiveLines ? [toPatchIndentUri.plugin] : Object.values(context.plugins)) {
+						for (const plugin of toPatchIndentUri.service.provideFormattingIndentSensitiveLines ? [toPatchIndentUri.service] : Object.values(context.plugins)) {
 
 							if (token.isCancellationRequested)
 								break;

--- a/packages/language-service/src/documentFeatures/format.ts
+++ b/packages/language-service/src/documentFeatures/format.ts
@@ -1,11 +1,11 @@
 import type { VirtualFile } from '@volar/language-core';
 import * as vscode from 'vscode-languageserver-protocol';
 import { TextDocument } from 'vscode-languageserver-textdocument';
-import type { LanguageServicePluginContext, Service } from '../types';
+import type { ServiceContext, Service } from '../types';
 import { SourceMap } from '@volar/source-map';
 import { isInsideRange, stringToSnapshot } from '../utils/common';
 
-export function register(context: LanguageServicePluginContext) {
+export function register(context: ServiceContext) {
 
 	return async (
 		uri: string,

--- a/packages/language-service/src/documentFeatures/format.ts
+++ b/packages/language-service/src/documentFeatures/format.ts
@@ -30,7 +30,7 @@ export function register(context: ServiceContext) {
 				: (await tryFormat(document, range, undefined))?.edits;
 		}
 
-		const initialIndentLanguageId = await context.configurationHost?.getConfiguration<Record<string, boolean>>('volar.format.initialIndent') ?? { html: true };
+		const initialIndentLanguageId = await context.getConfiguration?.<Record<string, boolean>>('volar.format.initialIndent') ?? { html: true };
 		const originalSnapshot = source.snapshot;
 		const rootVirtualFile = source.root;
 		const originalDocument = document;

--- a/packages/language-service/src/documentFeatures/format.ts
+++ b/packages/language-service/src/documentFeatures/format.ts
@@ -30,7 +30,7 @@ export function register(context: ServiceContext) {
 				: (await tryFormat(document, range, undefined))?.edits;
 		}
 
-		const initialIndentLanguageId = await context.getConfiguration?.<Record<string, boolean>>('volar.format.initialIndent') ?? { html: true };
+		const initialIndentLanguageId = await context.env.getConfiguration?.<Record<string, boolean>>('volar.format.initialIndent') ?? { html: true };
 		const originalSnapshot = source.snapshot;
 		const rootVirtualFile = source.root;
 		const originalDocument = document;
@@ -111,7 +111,7 @@ export function register(context: ServiceContext) {
 			if (edits.length > 0) {
 				const newText = TextDocument.applyEdits(document, edits);
 				document = TextDocument.create(document.uri, document.languageId, document.version + 1, newText);
-				context.core.virtualFiles.updateSource(context.uriToFileName(document.uri), stringToSnapshot(document.getText()), undefined);
+				context.core.virtualFiles.updateSource(context.env.uriToFileName(document.uri), stringToSnapshot(document.getText()), undefined);
 				edited = true;
 			}
 
@@ -177,7 +177,7 @@ export function register(context: ServiceContext) {
 						if (indentEdits.length > 0) {
 							const newText = TextDocument.applyEdits(document, indentEdits);
 							document = TextDocument.create(document.uri, document.languageId, document.version + 1, newText);
-							context.core.virtualFiles.updateSource(context.uriToFileName(document.uri), stringToSnapshot(document.getText()), undefined);
+							context.core.virtualFiles.updateSource(context.env.uriToFileName(document.uri), stringToSnapshot(document.getText()), undefined);
 							edited = true;
 						}
 					}
@@ -187,7 +187,7 @@ export function register(context: ServiceContext) {
 
 		if (edited) {
 			// recover
-			context.core.virtualFiles.updateSource(context.uriToFileName(document.uri), originalSnapshot, undefined);
+			context.core.virtualFiles.updateSource(context.env.uriToFileName(document.uri), originalSnapshot, undefined);
 		}
 
 		if (document.getText() === originalDocument.getText())

--- a/packages/language-service/src/documentFeatures/linkedEditingRanges.ts
+++ b/packages/language-service/src/documentFeatures/linkedEditingRanges.ts
@@ -1,9 +1,9 @@
-import type { LanguageServicePluginContext } from '../types';
+import type { ServiceContext } from '../types';
 import { languageFeatureWorker } from '../utils/featureWorkers';
 import * as vscode from 'vscode-languageserver-protocol';
 import { notEmpty } from '../utils/common';
 
-export function register(context: LanguageServicePluginContext) {
+export function register(context: ServiceContext) {
 
 	return (uri: string, position: vscode.Position, token = vscode.CancellationToken.None) => {
 

--- a/packages/language-service/src/documentFeatures/selectionRanges.ts
+++ b/packages/language-service/src/documentFeatures/selectionRanges.ts
@@ -1,10 +1,10 @@
-import type { LanguageServicePluginContext } from '../types';
+import type { ServiceContext } from '../types';
 import { languageFeatureWorker } from '../utils/featureWorkers';
 import * as transformer from '../transformer';
 import * as vscode from 'vscode-languageserver-protocol';
 import { isInsideRange, notEmpty } from '../utils/common';
 
-export function register(context: LanguageServicePluginContext) {
+export function register(context: ServiceContext) {
 
 	return (uri: string, positions: vscode.Position[], token = vscode.CancellationToken.None) => {
 

--- a/packages/language-service/src/documents.ts
+++ b/packages/language-service/src/documents.ts
@@ -3,7 +3,7 @@ import { Mapping, SourceMap } from '@volar/source-map';
 import * as vscode from 'vscode-languageserver-protocol';
 import { TextDocument } from 'vscode-languageserver-textdocument';
 import type * as ts from 'typescript/lib/tsserverlibrary';
-import { ServiceOptions } from './types';
+import { ServiceEnvironment } from './types';
 import { resolveCommonLanguageId } from './utils/common';
 
 export type DocumentsAndSourceMaps = ReturnType<typeof createDocumentsAndSourceMaps>;
@@ -167,7 +167,7 @@ export class MirrorMapWithDocument extends SourceMapWithDocuments<[MirrorBehavio
 }
 
 export function createDocumentsAndSourceMaps(
-	ctx: ServiceOptions,
+	ctx: ServiceEnvironment,
 	mapper: VirtualFiles,
 ) {
 

--- a/packages/language-service/src/documents.ts
+++ b/packages/language-service/src/documents.ts
@@ -3,7 +3,7 @@ import { Mapping, SourceMap } from '@volar/source-map';
 import * as vscode from 'vscode-languageserver-protocol';
 import { TextDocument } from 'vscode-languageserver-textdocument';
 import type * as ts from 'typescript/lib/tsserverlibrary';
-import { LanguageServiceOptions } from './types';
+import { ServiceOptions } from './types';
 import { resolveCommonLanguageId } from './utils/common';
 
 export type DocumentsAndSourceMaps = ReturnType<typeof createDocumentsAndSourceMaps>;
@@ -167,7 +167,7 @@ export class MirrorMapWithDocument extends SourceMapWithDocuments<[MirrorBehavio
 }
 
 export function createDocumentsAndSourceMaps(
-	ctx: LanguageServiceOptions,
+	ctx: ServiceOptions,
 	mapper: VirtualFiles,
 ) {
 

--- a/packages/language-service/src/documents.ts
+++ b/packages/language-service/src/documents.ts
@@ -1,4 +1,4 @@
-import { VirtualFiles, VirtualFile, FileRangeCapabilities, MirrorBehaviorCapabilities, MirrorMap, forEachEmbeddedFile } from '@volar/language-core';
+import { VirtualFiles, VirtualFile, FileRangeCapabilities, MirrorBehaviorCapabilities, MirrorMap, forEachEmbeddedFile, LanguageServiceHost } from '@volar/language-core';
 import { Mapping, SourceMap } from '@volar/source-map';
 import * as vscode from 'vscode-languageserver-protocol';
 import { TextDocument } from 'vscode-languageserver-textdocument';
@@ -168,6 +168,7 @@ export class MirrorMapWithDocument extends SourceMapWithDocuments<[MirrorBehavio
 
 export function createDocumentsAndSourceMaps(
 	env: ServiceEnvironment,
+	host: LanguageServiceHost,
 	mapper: VirtualFiles,
 ) {
 
@@ -273,7 +274,7 @@ export function createDocumentsAndSourceMaps(
 			const uri = env.fileNameToUri(fileName);
 			map.set(fileName, TextDocument.create(
 				uri,
-				env.host.getScriptLanguageId?.(fileName) ?? resolveCommonLanguageId(uri),
+				host.getScriptLanguageId?.(fileName) ?? resolveCommonLanguageId(uri),
 				version++,
 				snapshot.getText(0, snapshot.getLength()),
 			));

--- a/packages/language-service/src/documents.ts
+++ b/packages/language-service/src/documents.ts
@@ -167,7 +167,7 @@ export class MirrorMapWithDocument extends SourceMapWithDocuments<[MirrorBehavio
 }
 
 export function createDocumentsAndSourceMaps(
-	ctx: ServiceEnvironment,
+	env: ServiceEnvironment,
 	mapper: VirtualFiles,
 ) {
 
@@ -179,16 +179,16 @@ export function createDocumentsAndSourceMaps(
 
 	return {
 		getSourceByUri(sourceFileUri: string) {
-			return mapper.getSource(ctx.uriToFileName(sourceFileUri));
+			return mapper.getSource(env.uriToFileName(sourceFileUri));
 		},
 		isVirtualFileUri(virtualFileUri: string) {
-			return mapper.hasVirtualFile(ctx.uriToFileName(virtualFileUri));
+			return mapper.hasVirtualFile(env.uriToFileName(virtualFileUri));
 		},
 		getVirtualFileByUri(virtualFileUri: string) {
-			return mapper.getVirtualFile(ctx.uriToFileName(virtualFileUri));
+			return mapper.getVirtualFile(env.uriToFileName(virtualFileUri));
 		},
 		getMirrorMapByUri(virtualFileUri: string) {
-			const fileName = ctx.uriToFileName(virtualFileUri);
+			const fileName = env.uriToFileName(virtualFileUri);
 			const [virtualFile] = mapper.getVirtualFile(fileName);
 			if (virtualFile) {
 				const map = mapper.getMirrorMap(virtualFile);
@@ -204,7 +204,7 @@ export function createDocumentsAndSourceMaps(
 			}
 		},
 		getMapsBySourceFileUri(uri: string) {
-			return this.getMapsBySourceFileName(ctx.uriToFileName(uri));
+			return this.getMapsBySourceFileName(env.uriToFileName(uri));
 		},
 		getMapsBySourceFileName(fileName: string) {
 			const source = mapper.getSource(fileName);
@@ -236,7 +236,7 @@ export function createDocumentsAndSourceMaps(
 			}
 		},
 		getMapsByVirtualFileUri(virtualFileUri: string) {
-			return this.getMapsByVirtualFileName(ctx.uriToFileName(virtualFileUri));
+			return this.getMapsByVirtualFileName(env.uriToFileName(virtualFileUri));
 		},
 		*getMapsByVirtualFileName(virtualFileName: string): IterableIterator<[VirtualFile, SourceMapWithDocuments<FileRangeCapabilities>]> {
 			const [virtualFile] = mapper.getVirtualFile(virtualFileName);
@@ -259,7 +259,7 @@ export function createDocumentsAndSourceMaps(
 			}
 		},
 		getDocumentByUri(snapshot: ts.IScriptSnapshot, uri: string) {
-			return this.getDocumentByFileName(snapshot, ctx.uriToFileName(uri));
+			return this.getDocumentByFileName(snapshot, env.uriToFileName(uri));
 		},
 		getDocumentByFileName,
 	};
@@ -270,10 +270,10 @@ export function createDocumentsAndSourceMaps(
 		}
 		const map = _documents.get(snapshot)!;
 		if (!map.has(fileName)) {
-			const uri = ctx.fileNameToUri(fileName);
+			const uri = env.fileNameToUri(fileName);
 			map.set(fileName, TextDocument.create(
 				uri,
-				ctx.host.getScriptLanguageId?.(fileName) ?? resolveCommonLanguageId(uri),
+				env.host.getScriptLanguageId?.(fileName) ?? resolveCommonLanguageId(uri),
 				version++,
 				snapshot.getText(0, snapshot.getLength()),
 			));

--- a/packages/language-service/src/languageFeatures/autoInsert.ts
+++ b/packages/language-service/src/languageFeatures/autoInsert.ts
@@ -1,8 +1,8 @@
 import * as vscode from 'vscode-languageserver-protocol';
-import type { LanguageServicePluginContext, AutoInsertionContext } from '../types';
+import type { ServiceContext, AutoInsertionContext } from '../types';
 import { languageFeatureWorker } from '../utils/featureWorkers';
 
-export function register(context: LanguageServicePluginContext) {
+export function register(context: ServiceContext) {
 
 	return (uri: string, position: vscode.Position, autoInsertContext: AutoInsertionContext, token = vscode.CancellationToken.None) => {
 

--- a/packages/language-service/src/languageFeatures/callHierarchy.ts
+++ b/packages/language-service/src/languageFeatures/callHierarchy.ts
@@ -186,7 +186,7 @@ export function register(context: ServiceContext) {
 			const vueRanges = tsRanges.map(tsRange => map.toSourceRange(tsRange)).filter(notEmpty);
 			const vueItem: vscode.CallHierarchyItem = {
 				...tsItem,
-				name: tsItem.name === path.basename(context.uriToFileName(map.virtualFileDocument.uri)) ? path.basename(context.uriToFileName(map.sourceFileDocument.uri)) : tsItem.name,
+				name: tsItem.name === path.basename(context.env.uriToFileName(map.virtualFileDocument.uri)) ? path.basename(context.env.uriToFileName(map.sourceFileDocument.uri)) : tsItem.name,
 				uri: map.sourceFileDocument.uri,
 				// TS Bug: `range: range` not works
 				range: {

--- a/packages/language-service/src/languageFeatures/callHierarchy.ts
+++ b/packages/language-service/src/languageFeatures/callHierarchy.ts
@@ -1,6 +1,6 @@
 import { posix as path } from 'path';
 import * as vscode from 'vscode-languageserver-protocol';
-import type { LanguageServicePluginContext } from '../types';
+import type { ServiceContext } from '../types';
 import { notEmpty } from '../utils/common';
 import * as dedupe from '../utils/dedupe';
 import { languageFeatureWorker } from '../utils/featureWorkers';
@@ -12,7 +12,7 @@ export interface PluginCallHierarchyData {
 	virtualDocumentUri: string | undefined,
 }
 
-export function register(context: LanguageServicePluginContext) {
+export function register(context: ServiceContext) {
 
 	return {
 

--- a/packages/language-service/src/languageFeatures/codeActionResolve.ts
+++ b/packages/language-service/src/languageFeatures/codeActionResolve.ts
@@ -1,9 +1,9 @@
 import * as vscode from 'vscode-languageserver-protocol';
-import type { LanguageServicePluginContext } from '../types';
+import type { ServiceContext } from '../types';
 import { PluginCodeActionData, RuleCodeActionData } from './codeActions';
 import { embeddedEditToSourceEdit } from './rename';
 
-export function register(context: LanguageServicePluginContext) {
+export function register(context: ServiceContext) {
 
 	return async (item: vscode.CodeAction, token = vscode.CancellationToken.None) => {
 

--- a/packages/language-service/src/languageFeatures/codeActions.ts
+++ b/packages/language-service/src/languageFeatures/codeActions.ts
@@ -1,6 +1,6 @@
 import * as transformer from '../transformer';
 import * as vscode from 'vscode-languageserver-protocol';
-import type { LanguageServicePluginContext } from '../types';
+import type { ServiceContext } from '../types';
 import { getOverlapRange, notEmpty } from '../utils/common';
 import * as dedupe from '../utils/dedupe';
 import { languageFeatureWorker } from '../utils/featureWorkers';
@@ -26,7 +26,7 @@ export interface RuleCodeActionData {
 	index: number,
 }
 
-export function register(context: LanguageServicePluginContext) {
+export function register(context: ServiceContext) {
 
 	return async (uri: string, range: vscode.Range, codeActionContext: vscode.CodeActionContext, token = vscode.CancellationToken.None) => {
 

--- a/packages/language-service/src/languageFeatures/codeLens.ts
+++ b/packages/language-service/src/languageFeatures/codeLens.ts
@@ -1,4 +1,4 @@
-import type { LanguageServicePluginContext } from '../types';
+import type { ServiceContext } from '../types';
 import { languageFeatureWorker } from '../utils/featureWorkers';
 import * as vscode from 'vscode-languageserver-protocol';
 import { notEmpty } from '../utils/common';
@@ -17,7 +17,7 @@ export interface PluginReferencesCodeLensData {
 	pluginId: string,
 }
 
-export function register(context: LanguageServicePluginContext) {
+export function register(context: ServiceContext) {
 
 	return async (uri: string, token = vscode.CancellationToken.None) => {
 

--- a/packages/language-service/src/languageFeatures/codeLensResolve.ts
+++ b/packages/language-service/src/languageFeatures/codeLensResolve.ts
@@ -1,9 +1,9 @@
 import * as vscode from 'vscode-languageserver-protocol';
-import type { LanguageServicePluginContext } from '../types';
+import type { ServiceContext } from '../types';
 import { PluginCodeLensData, PluginReferencesCodeLensData } from './codeLens';
 import * as references from './references';
 
-export function register(context: LanguageServicePluginContext) {
+export function register(context: ServiceContext) {
 
 	const findReferences = references.register(context);
 

--- a/packages/language-service/src/languageFeatures/codeLensResolve.ts
+++ b/packages/language-service/src/languageFeatures/codeLensResolve.ts
@@ -34,7 +34,7 @@ export function register(context: ServiceContext) {
 				references = await plugin.resolveReferencesCodeLensLocations(document, data.range, references, token);
 			}
 
-			item.command = context.commands.createShowReferencesCommand(data.uri, data.range.start, references);
+			item.command = context.commands.showReferences.create(data.uri, data.range.start, references);
 		}
 
 		return item;

--- a/packages/language-service/src/languageFeatures/complete.ts
+++ b/packages/language-service/src/languageFeatures/complete.ts
@@ -2,7 +2,7 @@ import * as transformer from '../transformer';
 import type { FileRangeCapabilities } from '@volar/language-service';
 import * as vscode from 'vscode-languageserver-protocol';
 import type { TextDocument } from 'vscode-languageserver-textdocument';
-import type { Service, LanguageServicePluginContext } from '../types';
+import type { Service, ServiceContext } from '../types';
 import { visitEmbedded } from '../utils/definePlugin';
 
 export interface PluginCompletionData {
@@ -12,7 +12,7 @@ export interface PluginCompletionData {
 	virtualDocumentUri: string | undefined;
 }
 
-export function register(context: LanguageServicePluginContext) {
+export function register(context: ServiceContext) {
 
 	let cache: {
 		uri: string,

--- a/packages/language-service/src/languageFeatures/complete.ts
+++ b/packages/language-service/src/languageFeatures/complete.ts
@@ -2,7 +2,7 @@ import * as transformer from '../transformer';
 import type { FileRangeCapabilities } from '@volar/language-service';
 import * as vscode from 'vscode-languageserver-protocol';
 import type { TextDocument } from 'vscode-languageserver-textdocument';
-import type { LanguageServicePluginInstance, LanguageServicePluginContext } from '../types';
+import type { Service, LanguageServicePluginContext } from '../types';
 import { visitEmbedded } from '../utils/definePlugin';
 
 export interface PluginCompletionData {
@@ -18,7 +18,7 @@ export function register(context: LanguageServicePluginContext) {
 		uri: string,
 		data: {
 			virtualDocumentUri: string | undefined,
-			plugin: LanguageServicePluginInstance,
+			plugin: ReturnType<Service>,
 			list: vscode.CompletionList,
 		}[],
 		mainCompletion: {
@@ -256,7 +256,7 @@ export function register(context: LanguageServicePluginContext) {
 
 		return combineCompletionList(cache.data.map(cacheData => cacheData.list));
 
-		function sortPlugins(a: LanguageServicePluginInstance, b: LanguageServicePluginInstance) {
+		function sortPlugins(a: ReturnType<Service>, b: ReturnType<Service>) {
 			return (b.isAdditionalCompletion ? -1 : 1) - (a.isAdditionalCompletion ? -1 : 1);
 		}
 

--- a/packages/language-service/src/languageFeatures/completeResolve.ts
+++ b/packages/language-service/src/languageFeatures/completeResolve.ts
@@ -1,9 +1,9 @@
 import * as transformer from '../transformer';
 import * as vscode from 'vscode-languageserver-protocol';
-import type { LanguageServicePluginContext } from '../types';
+import type { ServiceContext } from '../types';
 import { PluginCompletionData } from './complete';
 
-export function register(context: LanguageServicePluginContext) {
+export function register(context: ServiceContext) {
 
 	return async (item: vscode.CompletionItem, token = vscode.CancellationToken.None) => {
 

--- a/packages/language-service/src/languageFeatures/definition.ts
+++ b/packages/language-service/src/languageFeatures/definition.ts
@@ -1,5 +1,5 @@
 import * as vscode from 'vscode-languageserver-protocol';
-import type { LanguageServicePluginContext } from '../types';
+import type { ServiceContext } from '../types';
 import { languageFeatureWorker } from '../utils/featureWorkers';
 import * as dedupe from '../utils/dedupe';
 import { TextDocument } from 'vscode-languageserver-textdocument';
@@ -8,7 +8,7 @@ import { SourceMapWithDocuments } from '../documents';
 import { notEmpty } from '../utils/common';
 
 export function register(
-	context: LanguageServicePluginContext,
+	context: ServiceContext,
 	apiName: 'provideDefinition' | 'provideTypeDefinition' | 'provideImplementation',
 	isValidMapping: (data: FileRangeCapabilities) => boolean,
 	isValidMirrorPosition: (mirrorData: MirrorBehaviorCapabilities) => boolean,

--- a/packages/language-service/src/languageFeatures/documentHighlights.ts
+++ b/packages/language-service/src/languageFeatures/documentHighlights.ts
@@ -1,11 +1,11 @@
 import * as vscode from 'vscode-languageserver-protocol';
-import type { LanguageServicePluginContext } from '../types';
+import type { ServiceContext } from '../types';
 import { languageFeatureWorker } from '../utils/featureWorkers';
 import { TextDocument } from 'vscode-languageserver-textdocument';
 import * as dedupe from '../utils/dedupe';
 import { notEmpty } from '../utils/common';
 
-export function register(context: LanguageServicePluginContext) {
+export function register(context: ServiceContext) {
 
 	return (uri: string, position: vscode.Position, token = vscode.CancellationToken.None) => {
 

--- a/packages/language-service/src/languageFeatures/documentLinkResolve.ts
+++ b/packages/language-service/src/languageFeatures/documentLinkResolve.ts
@@ -1,8 +1,8 @@
 import * as vscode from 'vscode-languageserver-protocol';
-import type { LanguageServicePluginContext } from '../types';
+import type { ServiceContext } from '../types';
 import { DocumentLinkData } from './documentLinks';
 
-export function register(context: LanguageServicePluginContext) {
+export function register(context: ServiceContext) {
 
 	return async (item: vscode.CodeLens, token = vscode.CancellationToken.None) => {
 

--- a/packages/language-service/src/languageFeatures/documentLinks.ts
+++ b/packages/language-service/src/languageFeatures/documentLinks.ts
@@ -1,5 +1,5 @@
 import * as vscode from 'vscode-languageserver-protocol';
-import type { LanguageServicePluginContext } from '../types';
+import type { ServiceContext } from '../types';
 import { documentFeatureWorker } from '../utils/featureWorkers';
 import { TextDocument } from 'vscode-languageserver-textdocument';
 import { SourceMapWithDocuments } from '../documents';
@@ -12,7 +12,7 @@ export interface DocumentLinkData {
 	pluginId: string,
 }
 
-export function register(context: LanguageServicePluginContext) {
+export function register(context: ServiceContext) {
 
 	return async (uri: string, token = vscode.CancellationToken.None) => {
 

--- a/packages/language-service/src/languageFeatures/documentSemanticTokens.ts
+++ b/packages/language-service/src/languageFeatures/documentSemanticTokens.ts
@@ -1,11 +1,11 @@
 import * as vscode from 'vscode-languageserver-protocol';
 import { SemanticToken } from '@volar/language-service';
-import type { LanguageServicePluginContext } from '../types';
+import type { ServiceContext } from '../types';
 import { languageFeatureWorker } from '../utils/featureWorkers';
 import { SemanticTokensBuilder } from '../utils/SemanticTokensBuilder';
 import { notEmpty } from '../utils/common';
 
-export function register(context: LanguageServicePluginContext) {
+export function register(context: ServiceContext) {
 
 	return async (
 		uri: string,

--- a/packages/language-service/src/languageFeatures/fileReferences.ts
+++ b/packages/language-service/src/languageFeatures/fileReferences.ts
@@ -1,11 +1,11 @@
-import type { LanguageServicePluginContext } from '../types';
+import type { ServiceContext } from '../types';
 import { languageFeatureWorker } from '../utils/featureWorkers';
 import * as dedupe from '../utils/dedupe';
 import * as vscode from 'vscode-languageserver-protocol';
 import { NullableResult } from '@volar/language-service';
 import { notEmpty } from '../utils/common';
 
-export function register(context: LanguageServicePluginContext) {
+export function register(context: ServiceContext) {
 
 	return (uri: string, token = vscode.CancellationToken.None): NullableResult<vscode.Location[]> => {
 

--- a/packages/language-service/src/languageFeatures/fileRename.ts
+++ b/packages/language-service/src/languageFeatures/fileRename.ts
@@ -1,11 +1,11 @@
-import type { LanguageServicePluginContext } from '../types';
+import type { ServiceContext } from '../types';
 import { embeddedEditToSourceEdit } from './rename';
 import type * as _ from 'vscode-languageserver-protocol';
 import * as dedupe from '../utils/dedupe';
 import { FileKind, forEachEmbeddedFile } from '@volar/language-core';
 import * as vscode from 'vscode-languageserver-protocol';
 
-export function register(context: LanguageServicePluginContext) {
+export function register(context: ServiceContext) {
 
 	return async (oldUri: string, newUri: string, token = vscode.CancellationToken.None) => {
 

--- a/packages/language-service/src/languageFeatures/hover.ts
+++ b/packages/language-service/src/languageFeatures/hover.ts
@@ -1,10 +1,10 @@
 import * as vscode from 'vscode-languageserver-protocol';
-import type { LanguageServicePluginContext } from '../types';
+import type { ServiceContext } from '../types';
 import { languageFeatureWorker } from '../utils/featureWorkers';
 import { isInsideRange } from '../utils/common';
 import { errorMarkups } from './validation';
 
-export function register(context: LanguageServicePluginContext) {
+export function register(context: ServiceContext) {
 
 	return async (uri: string, position: vscode.Position, token = vscode.CancellationToken.None) => {
 

--- a/packages/language-service/src/languageFeatures/inlayHintResolve.ts
+++ b/packages/language-service/src/languageFeatures/inlayHintResolve.ts
@@ -1,8 +1,8 @@
 import * as vscode from 'vscode-languageserver-protocol';
-import type { LanguageServicePluginContext } from '../types';
+import type { ServiceContext } from '../types';
 import { InlayHintData } from './inlayHints';
 
-export function register(context: LanguageServicePluginContext) {
+export function register(context: ServiceContext) {
 
 	return async (item: vscode.InlayHint, token = vscode.CancellationToken.None) => {
 

--- a/packages/language-service/src/languageFeatures/inlayHints.ts
+++ b/packages/language-service/src/languageFeatures/inlayHints.ts
@@ -1,6 +1,6 @@
 import * as transformer from '../transformer';
 import * as vscode from 'vscode-languageserver-protocol';
-import type { LanguageServicePluginContext } from '../types';
+import type { ServiceContext } from '../types';
 import { getOverlapRange, notEmpty } from '../utils/common';
 import { languageFeatureWorker } from '../utils/featureWorkers';
 
@@ -10,7 +10,7 @@ export interface InlayHintData {
 	pluginId: string,
 }
 
-export function register(context: LanguageServicePluginContext) {
+export function register(context: ServiceContext) {
 
 	return async (uri: string, range: vscode.Range, token = vscode.CancellationToken.None) => {
 

--- a/packages/language-service/src/languageFeatures/references.ts
+++ b/packages/language-service/src/languageFeatures/references.ts
@@ -1,10 +1,10 @@
 import * as vscode from 'vscode-languageserver-protocol';
-import type { LanguageServicePluginContext } from '../types';
+import type { ServiceContext } from '../types';
 import { languageFeatureWorker } from '../utils/featureWorkers';
 import * as dedupe from '../utils/dedupe';
 import { TextDocument } from 'vscode-languageserver-textdocument';
 
-export function register(context: LanguageServicePluginContext) {
+export function register(context: ServiceContext) {
 
 	return (uri: string, position: vscode.Position, token = vscode.CancellationToken.None) => {
 

--- a/packages/language-service/src/languageFeatures/rename.ts
+++ b/packages/language-service/src/languageFeatures/rename.ts
@@ -1,12 +1,12 @@
 import * as vscode from 'vscode-languageserver-protocol';
-import type { LanguageServicePluginContext } from '../types';
+import type { ServiceContext } from '../types';
 import { languageFeatureWorker } from '../utils/featureWorkers';
 import * as dedupe from '../utils/dedupe';
 import { TextDocument } from 'vscode-languageserver-textdocument';
 import { DocumentsAndSourceMaps } from '../documents';
 import { FileRangeCapabilities } from '@volar/language-core';
 
-export function register(context: LanguageServicePluginContext) {
+export function register(context: ServiceContext) {
 
 	return (uri: string, position: vscode.Position, newName: string, token = vscode.CancellationToken.None) => {
 

--- a/packages/language-service/src/languageFeatures/renamePrepare.ts
+++ b/packages/language-service/src/languageFeatures/renamePrepare.ts
@@ -1,8 +1,8 @@
 import * as vscode from 'vscode-languageserver-protocol';
-import type { LanguageServicePluginContext } from '../types';
+import type { ServiceContext } from '../types';
 import { languageFeatureWorker } from '../utils/featureWorkers';
 
-export function register(context: LanguageServicePluginContext) {
+export function register(context: ServiceContext) {
 
 	return (uri: string, position: vscode.Position, token = vscode.CancellationToken.None) => {
 

--- a/packages/language-service/src/languageFeatures/signatureHelp.ts
+++ b/packages/language-service/src/languageFeatures/signatureHelp.ts
@@ -1,8 +1,8 @@
 import * as vscode from 'vscode-languageserver-protocol';
-import type { LanguageServicePluginContext } from '../types';
+import type { ServiceContext } from '../types';
 import { languageFeatureWorker } from '../utils/featureWorkers';
 
-export function register(context: LanguageServicePluginContext) {
+export function register(context: ServiceContext) {
 
 	return (
 		uri: string,

--- a/packages/language-service/src/languageFeatures/validation.ts
+++ b/packages/language-service/src/languageFeatures/validation.ts
@@ -204,7 +204,7 @@ export function register(context: ServiceContext) {
 			await doResponse();
 			await lintWorker('onSyntax', cacheMaps.syntax_rules, lastResponse.syntax_rules);
 			await doResponse();
-			await worker('provideSyntacticDiagnostics', cacheMaps.syntactic, lastResponse.syntactic);
+			await worker('provideDiagnostics', cacheMaps.syntactic, lastResponse.syntactic);
 			await doResponse();
 		}
 
@@ -345,7 +345,7 @@ export function register(context: ServiceContext) {
 		}
 
 		async function worker(
-			api: 'provideSyntacticDiagnostics' | 'provideSemanticDiagnostics',
+			api: 'provideDiagnostics' | 'provideSemanticDiagnostics',
 			cacheMap: CacheMap,
 			cache: Cache,
 		) {

--- a/packages/language-service/src/languageFeatures/validation.ts
+++ b/packages/language-service/src/languageFeatures/validation.ts
@@ -167,7 +167,7 @@ export function register(context: ServiceContext) {
 			syntax_rules: { errors: [] },
 			format_rules: { errors: [] },
 		}).get(uri)!;
-		const newSnapshot = context.host.getScriptSnapshot(context.uriToFileName(uri));
+		const newSnapshot = context.env.host.getScriptSnapshot(context.env.uriToFileName(uri));
 
 		let updateCacheRangeFailed = false;
 		let errorsUpdated = false;
@@ -287,7 +287,7 @@ export function register(context: ServiceContext) {
 						error.source ||= 'rules';
 						error.code ||= ruleCtx.ruleId;
 
-						const severity = context.config.lint?.severities?.[ruleCtx.ruleId];
+						const severity = context.env.config.lint?.severities?.[ruleCtx.ruleId];
 						if (severity !== undefined) {
 							error.severity = severity;
 						}

--- a/packages/language-service/src/languageFeatures/validation.ts
+++ b/packages/language-service/src/languageFeatures/validation.ts
@@ -167,7 +167,7 @@ export function register(context: ServiceContext) {
 			syntax_rules: { errors: [] },
 			format_rules: { errors: [] },
 		}).get(uri)!;
-		const newSnapshot = context.env.host.getScriptSnapshot(context.env.uriToFileName(uri));
+		const newSnapshot = context.host.getScriptSnapshot(context.env.uriToFileName(uri));
 
 		let updateCacheRangeFailed = false;
 		let errorsUpdated = false;
@@ -287,7 +287,7 @@ export function register(context: ServiceContext) {
 						error.source ||= 'rules';
 						error.code ||= ruleCtx.ruleId;
 
-						const severity = context.env.config.lint?.severities?.[ruleCtx.ruleId];
+						const severity = context.config.lint?.severities?.[ruleCtx.ruleId];
 						if (severity !== undefined) {
 							error.severity = severity;
 						}

--- a/packages/language-service/src/languageFeatures/validation.ts
+++ b/packages/language-service/src/languageFeatures/validation.ts
@@ -3,7 +3,7 @@ import type * as ts from 'typescript/lib/tsserverlibrary';
 import * as vscode from 'vscode-languageserver-protocol';
 import { TextDocument } from 'vscode-languageserver-textdocument';
 import { SourceMapWithDocuments } from '../documents';
-import type { LanguageServicePluginContext, RuleContext } from '../types';
+import type { ServiceContext, RuleContext } from '../types';
 import { sleep } from '../utils/common';
 import * as dedupe from '../utils/dedupe';
 import { languageFeatureWorker, ruleWorker } from '../utils/featureWorkers';
@@ -128,7 +128,7 @@ export const errorMarkups: Record<string, {
 	markup: vscode.MarkupContent,
 }[]> = {};
 
-export function register(context: LanguageServicePluginContext) {
+export function register(context: ServiceContext) {
 
 	const lastResponses = new Map<
 		string,

--- a/packages/language-service/src/languageFeatures/workspaceSymbols.ts
+++ b/packages/language-service/src/languageFeatures/workspaceSymbols.ts
@@ -1,9 +1,9 @@
 import * as transformer from '../transformer';
 import * as vscode from 'vscode-languageserver-protocol';
-import type { LanguageServicePluginContext } from '../types';
+import type { ServiceContext } from '../types';
 import { notEmpty } from '../utils/common';
 
-export function register(context: LanguageServicePluginContext) {
+export function register(context: ServiceContext) {
 
 	return async (query: string, token = vscode.CancellationToken.None) => {
 

--- a/packages/language-service/src/types.ts
+++ b/packages/language-service/src/types.ts
@@ -53,7 +53,7 @@ export interface LanguageServicePluginContext extends LanguageServiceOptions {
 	/** @private */
 	documents: DocumentsAndSourceMaps;
 	/** @private */
-	plugins: { [id: string]: LanguageServicePluginInstance; };
+	plugins: { [id: string]: ReturnType<Service>; };
 	/** @private */
 	getTextDocument(uri: string): TextDocument | undefined;
 	/** @private */
@@ -76,7 +76,56 @@ export type NullableResult<T> = Result<T | undefined | null>;
 export type SemanticToken = [number, number, number, number, number];
 
 export interface Service {
-	(context?: LanguageServicePluginContext): LanguageServicePluginInstance;
+	(context?: LanguageServicePluginContext): {
+		isAdditionalCompletion?: boolean; // volar specific
+		triggerCharacters?: string[];
+		signatureHelpTriggerCharacters?: string[];
+		signatureHelpRetriggerCharacters?: string[];
+		autoFormatTriggerCharacters?: string[];
+		provideHover?(document: TextDocument, position: vscode.Position, token: vscode.CancellationToken): NullableResult<vscode.Hover>,
+		provideDocumentSymbols?(document: TextDocument, token: vscode.CancellationToken): NullableResult<vscode.DocumentSymbol[]>;
+		provideDocumentHighlights?(document: TextDocument, position: vscode.Position, token: vscode.CancellationToken): NullableResult<vscode.DocumentHighlight[]>;
+		provideLinkedEditingRanges?(document: TextDocument, position: vscode.Position, token: vscode.CancellationToken): NullableResult<vscode.LinkedEditingRanges>;
+		provideDefinition?(document: TextDocument, position: vscode.Position, token: vscode.CancellationToken): NullableResult<vscode.LocationLink[]>;
+		provideTypeDefinition?(document: TextDocument, position: vscode.Position, token: vscode.CancellationToken): NullableResult<vscode.LocationLink[]>;
+		provideImplementation?(document: TextDocument, position: vscode.Position, token: vscode.CancellationToken): NullableResult<vscode.LocationLink[]>;
+		provideCodeLenses?(document: TextDocument, token: vscode.CancellationToken): NullableResult<vscode.CodeLens[]>;
+		provideCodeActions?(document: TextDocument, range: vscode.Range, context: vscode.CodeActionContext, token: vscode.CancellationToken): NullableResult<vscode.CodeAction[]>;
+		provideDocumentFormattingEdits?(document: TextDocument, range: vscode.Range, options: vscode.FormattingOptions, token: vscode.CancellationToken): NullableResult<vscode.TextEdit[]>;
+		provideOnTypeFormattingEdits?(document: TextDocument, position: vscode.Position, key: string, options: vscode.FormattingOptions, token: vscode.CancellationToken): NullableResult<vscode.TextEdit[]>;
+		provideDocumentLinks?(document: TextDocument, token: vscode.CancellationToken): NullableResult<vscode.DocumentLink[]>;
+		provideCompletionItems?(document: TextDocument, position: vscode.Position, context: vscode.CompletionContext, token: vscode.CancellationToken): NullableResult<vscode.CompletionList>,
+		provideDocumentColors?(document: TextDocument, token: vscode.CancellationToken): NullableResult<vscode.ColorInformation[]>;
+		provideColorPresentations?(document: TextDocument, color: vscode.Color, range: vscode.Range, token: vscode.CancellationToken): NullableResult<vscode.ColorPresentation[]>;
+		provideFoldingRanges?(document: TextDocument, token: vscode.CancellationToken): NullableResult<vscode.FoldingRange[]>;
+		provideSignatureHelp?(document: TextDocument, position: vscode.Position, context: vscode.SignatureHelpContext, token: vscode.CancellationToken): NullableResult<vscode.SignatureHelp>;
+		provideRenameRange?(document: TextDocument, position: vscode.Position, token: vscode.CancellationToken): NullableResult<vscode.Range | vscode.ResponseError<void>>;
+		provideRenameEdits?(document: TextDocument, position: vscode.Position, newName: string, token: vscode.CancellationToken): NullableResult<vscode.WorkspaceEdit>;
+		provideReferences?(document: TextDocument, position: vscode.Position, token: vscode.CancellationToken): NullableResult<vscode.Location[]>;
+		provideSelectionRanges?(document: TextDocument, positions: vscode.Position[], token: vscode.CancellationToken): NullableResult<vscode.SelectionRange[]>;
+		provideInlayHints?(document: TextDocument, range: vscode.Range, token: vscode.CancellationToken): NullableResult<vscode.InlayHint[]>,
+		provideCallHierarchyItems?(document: TextDocument, position: vscode.Position, token: vscode.CancellationToken): NullableResult<vscode.CallHierarchyItem[]>;
+		provideCallHierarchyIncomingCalls?(item: vscode.CallHierarchyItem, token: vscode.CancellationToken): Result<vscode.CallHierarchyIncomingCall[]>;
+		provideCallHierarchyOutgoingCalls?(item: vscode.CallHierarchyItem, token: vscode.CancellationToken): Result<vscode.CallHierarchyOutgoingCall[]>;
+		provideDocumentSemanticTokens?(document: TextDocument, range: vscode.Range, legend: vscode.SemanticTokensLegend, token: vscode.CancellationToken): NullableResult<SemanticToken[]>;
+		provideWorkspaceSymbols?(query: string, token: vscode.CancellationToken): NullableResult<vscode.WorkspaceSymbol[]>;
+		provideSyntacticDiagnostics?(document: TextDocument, token: vscode.CancellationToken): NullableResult<vscode.Diagnostic[]>;
+		provideSemanticDiagnostics?(document: TextDocument, token: vscode.CancellationToken): NullableResult<vscode.Diagnostic[]>;
+		provideDiagnosticMarkupContent?(diagnostic: vscode.Diagnostic, token: vscode.CancellationToken): NullableResult<vscode.MarkupContent>;
+		provideFileReferences?(document: TextDocument, token: vscode.CancellationToken): NullableResult<vscode.Location[]>; // volar specific
+		provideReferencesCodeLensRanges?(document: TextDocument, token: vscode.CancellationToken): NullableResult<vscode.Range[]>; // volar specific
+		provideAutoInsertionEdit?(document: TextDocument, position: vscode.Position, context: AutoInsertionContext, token: vscode.CancellationToken): NullableResult<string | vscode.TextEdit>; // volar specific
+		provideFileRenameEdits?(oldUri: string, newUri: string, token: vscode.CancellationToken): NullableResult<vscode.WorkspaceEdit>; // volar specific
+		provideFormattingIndentSensitiveLines?(document: TextDocument, token: vscode.CancellationToken): NullableResult<number[]>; // volar specific
+		resolveCodeLens?(codeLens: vscode.CodeLens, token: vscode.CancellationToken): Result<vscode.CodeLens>;
+		resolveCodeAction?(codeAction: vscode.CodeAction, token: vscode.CancellationToken): Result<vscode.CodeAction>;
+		resolveCompletionItem?(item: vscode.CompletionItem, token: vscode.CancellationToken): Result<vscode.CompletionItem>,
+		resolveDocumentLink?(link: vscode.DocumentLink, token: vscode.CancellationToken): Result<vscode.DocumentLink>;
+		resolveInlayHint?(inlayHint: vscode.InlayHint, token: vscode.CancellationToken): Result<vscode.InlayHint>;
+		resolveReferencesCodeLensLocations?(document: TextDocument, range: vscode.Range, references: vscode.Location[], token: vscode.CancellationToken): Result<vscode.Location[]>; // volar specific
+		resolveRuleContext?(context: RuleContext, ruleType: 'format' | 'syntax' | 'semantic'): Result<RuleContext>; // volar specific
+		resolveEmbeddedRange?(range: vscode.Range): vscode.Range | undefined; // volar specific, only support in resolveCompletionItem for now
+	};
 }
 
 export interface AutoInsertionContext {
@@ -86,57 +135,6 @@ export interface AutoInsertionContext {
 		rangeLength: number;
 		text: string;
 	};
-}
-
-export interface LanguageServicePluginInstance {
-	isAdditionalCompletion?: boolean; // volar specific
-	triggerCharacters?: string[];
-	signatureHelpTriggerCharacters?: string[];
-	signatureHelpRetriggerCharacters?: string[];
-	autoFormatTriggerCharacters?: string[];
-	provideHover?(document: TextDocument, position: vscode.Position, token: vscode.CancellationToken): NullableResult<vscode.Hover>,
-	provideDocumentSymbols?(document: TextDocument, token: vscode.CancellationToken): NullableResult<vscode.DocumentSymbol[]>;
-	provideDocumentHighlights?(document: TextDocument, position: vscode.Position, token: vscode.CancellationToken): NullableResult<vscode.DocumentHighlight[]>;
-	provideLinkedEditingRanges?(document: TextDocument, position: vscode.Position, token: vscode.CancellationToken): NullableResult<vscode.LinkedEditingRanges>;
-	provideDefinition?(document: TextDocument, position: vscode.Position, token: vscode.CancellationToken): NullableResult<vscode.LocationLink[]>;
-	provideTypeDefinition?(document: TextDocument, position: vscode.Position, token: vscode.CancellationToken): NullableResult<vscode.LocationLink[]>;
-	provideImplementation?(document: TextDocument, position: vscode.Position, token: vscode.CancellationToken): NullableResult<vscode.LocationLink[]>;
-	provideCodeLenses?(document: TextDocument, token: vscode.CancellationToken): NullableResult<vscode.CodeLens[]>;
-	provideCodeActions?(document: TextDocument, range: vscode.Range, context: vscode.CodeActionContext, token: vscode.CancellationToken): NullableResult<vscode.CodeAction[]>;
-	provideDocumentFormattingEdits?(document: TextDocument, range: vscode.Range, options: vscode.FormattingOptions, token: vscode.CancellationToken): NullableResult<vscode.TextEdit[]>;
-	provideOnTypeFormattingEdits?(document: TextDocument, position: vscode.Position, key: string, options: vscode.FormattingOptions, token: vscode.CancellationToken): NullableResult<vscode.TextEdit[]>;
-	provideDocumentLinks?(document: TextDocument, token: vscode.CancellationToken): NullableResult<vscode.DocumentLink[]>;
-	provideCompletionItems?(document: TextDocument, position: vscode.Position, context: vscode.CompletionContext, token: vscode.CancellationToken): NullableResult<vscode.CompletionList>,
-	provideDocumentColors?(document: TextDocument, token: vscode.CancellationToken): NullableResult<vscode.ColorInformation[]>;
-	provideColorPresentations?(document: TextDocument, color: vscode.Color, range: vscode.Range, token: vscode.CancellationToken): NullableResult<vscode.ColorPresentation[]>;
-	provideFoldingRanges?(document: TextDocument, token: vscode.CancellationToken): NullableResult<vscode.FoldingRange[]>;
-	provideSignatureHelp?(document: TextDocument, position: vscode.Position, context: vscode.SignatureHelpContext, token: vscode.CancellationToken): NullableResult<vscode.SignatureHelp>;
-	provideRenameRange?(document: TextDocument, position: vscode.Position, token: vscode.CancellationToken): NullableResult<vscode.Range | vscode.ResponseError<void>>;
-	provideRenameEdits?(document: TextDocument, position: vscode.Position, newName: string, token: vscode.CancellationToken): NullableResult<vscode.WorkspaceEdit>;
-	provideReferences?(document: TextDocument, position: vscode.Position, token: vscode.CancellationToken): NullableResult<vscode.Location[]>;
-	provideSelectionRanges?(document: TextDocument, positions: vscode.Position[], token: vscode.CancellationToken): NullableResult<vscode.SelectionRange[]>;
-	provideInlayHints?(document: TextDocument, range: vscode.Range, token: vscode.CancellationToken): NullableResult<vscode.InlayHint[]>,
-	provideCallHierarchyItems?(document: TextDocument, position: vscode.Position, token: vscode.CancellationToken): NullableResult<vscode.CallHierarchyItem[]>;
-	provideCallHierarchyIncomingCalls?(item: vscode.CallHierarchyItem, token: vscode.CancellationToken): Result<vscode.CallHierarchyIncomingCall[]>;
-	provideCallHierarchyOutgoingCalls?(item: vscode.CallHierarchyItem, token: vscode.CancellationToken): Result<vscode.CallHierarchyOutgoingCall[]>;
-	provideDocumentSemanticTokens?(document: TextDocument, range: vscode.Range, legend: vscode.SemanticTokensLegend, token: vscode.CancellationToken): NullableResult<SemanticToken[]>;
-	provideWorkspaceSymbols?(query: string, token: vscode.CancellationToken): NullableResult<vscode.WorkspaceSymbol[]>;
-	provideSyntacticDiagnostics?(document: TextDocument, token: vscode.CancellationToken): NullableResult<vscode.Diagnostic[]>;
-	provideSemanticDiagnostics?(document: TextDocument, token: vscode.CancellationToken): NullableResult<vscode.Diagnostic[]>;
-	provideDiagnosticMarkupContent?(diagnostic: vscode.Diagnostic, token: vscode.CancellationToken): NullableResult<vscode.MarkupContent>;
-	provideFileReferences?(document: TextDocument, token: vscode.CancellationToken): NullableResult<vscode.Location[]>; // volar specific
-	provideReferencesCodeLensRanges?(document: TextDocument, token: vscode.CancellationToken): NullableResult<vscode.Range[]>; // volar specific
-	provideAutoInsertionEdit?(document: TextDocument, position: vscode.Position, context: AutoInsertionContext, token: vscode.CancellationToken): NullableResult<string | vscode.TextEdit>; // volar specific
-	provideFileRenameEdits?(oldUri: string, newUri: string, token: vscode.CancellationToken): NullableResult<vscode.WorkspaceEdit>; // volar specific
-	provideFormattingIndentSensitiveLines?(document: TextDocument, token: vscode.CancellationToken): NullableResult<number[]>; // volar specific
-	resolveCodeLens?(codeLens: vscode.CodeLens, token: vscode.CancellationToken): Result<vscode.CodeLens>;
-	resolveCodeAction?(codeAction: vscode.CodeAction, token: vscode.CancellationToken): Result<vscode.CodeAction>;
-	resolveCompletionItem?(item: vscode.CompletionItem, token: vscode.CancellationToken): Result<vscode.CompletionItem>,
-	resolveDocumentLink?(link: vscode.DocumentLink, token: vscode.CancellationToken): Result<vscode.DocumentLink>;
-	resolveInlayHint?(inlayHint: vscode.InlayHint, token: vscode.CancellationToken): Result<vscode.InlayHint>;
-	resolveReferencesCodeLensLocations?(document: TextDocument, range: vscode.Range, references: vscode.Location[], token: vscode.CancellationToken): Result<vscode.Location[]>; // volar specific
-	resolveRuleContext?(context: RuleContext, ruleType: 'format' | 'syntax' | 'semantic'): Result<RuleContext>; // volar specific
-	resolveEmbeddedRange?(range: vscode.Range): vscode.Range | undefined; // volar specific, only support in resolveCompletionItem for now
 }
 
 export interface Rule {

--- a/packages/language-service/src/types.ts
+++ b/packages/language-service/src/types.ts
@@ -71,15 +71,11 @@ export interface ConfigurationHost {
 	onDidChangeConfiguration: (cb: () => void) => void,
 }
 
-/**
- * LanguageServicePlugin
- */
-
 export type Result<T> = T | Thenable<T>;
 export type NullableResult<T> = Result<T | undefined | null>;
 export type SemanticToken = [number, number, number, number, number];
 
-export interface LanguageServicePlugin {
+export interface Service {
 	(context?: LanguageServicePluginContext): LanguageServicePluginInstance;
 }
 
@@ -206,7 +202,7 @@ export interface RuleFix {
 
 export interface Config {
 	languages?: { [id: string]: Language | undefined; };
-	services?: { [id: string]: LanguageServicePlugin | undefined; };
+	services?: { [id: string]: Service | undefined; };
 	lint?: {
 		rules?: { [id: string]: Rule | undefined; };
 		severities?: { [id: string]: vscode.DiagnosticSeverity; };

--- a/packages/language-service/src/types.ts
+++ b/packages/language-service/src/types.ts
@@ -22,7 +22,8 @@ export interface LanguageServiceOptions {
 	config: Config;
 	uriToFileName(uri: string): string;
 	fileNameToUri(fileName: string): string;
-	configurationHost?: ConfigurationHost;
+	getConfiguration?: (<T> (section: string, scopeUri?: string) => Promise<T | undefined>),
+	onDidChangeConfiguration?: (cb: () => void) => void,
 	documentContext?: DocumentContext;
 	fileSystemProvider?: FileSystemProvider;
 	fileSystemHost?: FileSystemHost;
@@ -64,11 +65,6 @@ export interface ServiceContext extends LanguageServiceOptions {
 			};
 		};
 	};
-}
-
-export interface ConfigurationHost {
-	getConfiguration: (<T> (section: string, scopeUri?: string) => Promise<T | undefined>),
-	onDidChangeConfiguration: (cb: () => void) => void,
 }
 
 export type Result<T> = T | Thenable<T>;

--- a/packages/language-service/src/types.ts
+++ b/packages/language-service/src/types.ts
@@ -34,10 +34,9 @@ interface FileSystemHost {
 	onDidChangeWatchedFiles(cb: (params: vscode.DidChangeWatchedFilesParams) => void): () => void,
 }
 
-export interface Commands {
-	createShowReferencesCommand(uri: string, position: vscode.Position, locations: vscode.Location[]): vscode.Command | undefined;
-	createRenameCommand(uri: string, position: vscode.Position): vscode.Command | undefined;
-	createSetSelectionCommand(position: vscode.Position): vscode.Command | undefined;
+interface Command<T> {
+	create: T;
+	is(value: vscode.Command): boolean;
 }
 
 export interface ServiceContext extends ServiceOptions {
@@ -47,7 +46,12 @@ export interface ServiceContext extends ServiceOptions {
 		languageServiceHost: ts.LanguageServiceHost;
 		languageService: ts.LanguageService;
 	} | undefined;
-	commands: Commands;
+
+	commands: {
+		showReferences: Command<(uri: string, position: vscode.Position, locations: vscode.Location[]) => vscode.Command | undefined>;
+		rename: Command<(uri: string, position: vscode.Position) => vscode.Command | undefined>;
+		setSelection: Command<(position: vscode.Position) => vscode.Command | undefined>;
+	};
 
 	/** @private */
 	core: LanguageContext;

--- a/packages/language-service/src/types.ts
+++ b/packages/language-service/src/types.ts
@@ -11,9 +11,6 @@ export * from 'vscode-languageserver-protocol';
 
 export interface ServiceEnvironment {
 	// InitializeParams
-	modules: {
-		typescript?: typeof import('typescript/lib/tsserverlibrary');
-	};
 	locale?: string;
 	rootUri: URI;
 	clientCapabilities?: vscode.ClientCapabilities;

--- a/packages/language-service/src/types.ts
+++ b/packages/language-service/src/types.ts
@@ -1,4 +1,4 @@
-import { LanguageContext, LanguageModule, LanguageServiceHost } from '@volar/language-core';
+import { LanguageContext, Language as Language, LanguageServiceHost } from '@volar/language-core';
 import type * as ts from 'typescript/lib/tsserverlibrary';
 import type { DocumentContext, FileSystemProvider } from 'vscode-html-languageservice';
 import type { SchemaRequestService } from 'vscode-json-languageservice';
@@ -205,7 +205,7 @@ export interface RuleFix {
 }
 
 export interface Config {
-	languages?: { [id: string]: LanguageModule | undefined; };
+	languages?: { [id: string]: Language | undefined; };
 	services?: { [id: string]: LanguageServicePlugin | undefined; };
 	lint?: {
 		rules?: { [id: string]: Rule | undefined; };

--- a/packages/language-service/src/types.ts
+++ b/packages/language-service/src/types.ts
@@ -1,4 +1,4 @@
-import { LanguageContext, Language as Language, LanguageServiceHost } from '@volar/language-core';
+import { LanguageContext, Language, LanguageServiceHost } from '@volar/language-core';
 import type * as ts from 'typescript/lib/tsserverlibrary';
 import type { DocumentContext, FileSystemProvider } from 'vscode-html-languageservice';
 import type { SchemaRequestService } from 'vscode-json-languageservice';
@@ -14,8 +14,6 @@ export interface ServiceEnvironment {
 	locale?: string;
 	rootUri: URI;
 	clientCapabilities?: vscode.ClientCapabilities;
-	host: LanguageServiceHost;
-	config: Config;
 	uriToFileName(uri: string): string;
 	fileNameToUri(fileName: string): string;
 	getConfiguration?<T>(section: string, scopeUri?: string): Promise<T | undefined>,
@@ -32,6 +30,10 @@ interface Command<T> {
 }
 
 export interface ServiceContext {
+
+	config: Config;
+
+	host: LanguageServiceHost;
 
 	env: ServiceEnvironment;
 

--- a/packages/language-service/src/types.ts
+++ b/packages/language-service/src/types.ts
@@ -31,17 +31,13 @@ interface Command<T> {
 
 export interface ServiceContext {
 
-	config: Config;
-
-	host: LanguageServiceHost;
-
 	env: ServiceEnvironment;
-
+	config: Config;
+	host: LanguageServiceHost;
 	typescript: {
 		languageServiceHost: ts.LanguageServiceHost;
 		languageService: ts.LanguageService;
 	} | undefined;
-
 	commands: {
 		showReferences: Command<(uri: string, position: vscode.Position, locations: vscode.Location[]) => vscode.Command | undefined>;
 		rename: Command<(uri: string, position: vscode.Position) => vscode.Command | undefined>;

--- a/packages/language-service/src/types.ts
+++ b/packages/language-service/src/types.ts
@@ -9,29 +9,24 @@ import { DocumentsAndSourceMaps } from './documents';
 
 export * from 'vscode-languageserver-protocol';
 
-export interface ServiceOptions {
+export interface ServiceEnvironment {
 	// InitializeParams
 	modules: {
 		typescript?: typeof import('typescript/lib/tsserverlibrary');
 	};
 	locale?: string;
 	rootUri: URI;
-	capabilities?: vscode.ClientCapabilities;
-
+	clientCapabilities?: vscode.ClientCapabilities;
 	host: LanguageServiceHost;
 	config: Config;
 	uriToFileName(uri: string): string;
 	fileNameToUri(fileName: string): string;
-	getConfiguration?: (<T> (section: string, scopeUri?: string) => Promise<T | undefined>),
-	onDidChangeConfiguration?: (cb: () => void) => void,
+	getConfiguration?<T>(section: string, scopeUri?: string): Promise<T | undefined>,
+	onDidChangeConfiguration?(cb: () => void): void,
+	onDidChangeWatchedFiles?(cb: (params: vscode.DidChangeWatchedFilesParams) => void): () => void,
 	documentContext?: DocumentContext;
 	fileSystemProvider?: FileSystemProvider;
-	fileSystemHost?: FileSystemHost;
 	schemaRequestService?: SchemaRequestService;
-}
-
-interface FileSystemHost {
-	onDidChangeWatchedFiles(cb: (params: vscode.DidChangeWatchedFilesParams) => void): () => void,
 }
 
 interface Command<T> {
@@ -39,7 +34,9 @@ interface Command<T> {
 	is(value: vscode.Command): boolean;
 }
 
-export interface ServiceContext extends ServiceOptions {
+export interface ServiceContext {
+
+	env: ServiceEnvironment;
 
 	typescript: {
 		module: typeof import('typescript/lib/tsserverlibrary');
@@ -144,34 +141,7 @@ export interface Rule {
 }
 
 export interface RuleContext {
-	/**
-	 * Shared modules.
-	 */
-	modules: {
-		typescript?: typeof import('typescript/lib/tsserverlibrary');
-	},
-	/**
-	 * IDE or user define locale.
-	 * You can use it to localize your rule.
-	 */
-	locale?: string;
-	/**
-	 * Project root path.
-	 */
-	rootUri: URI;
-	uriToFileName(uri: string): string;
-	fileNameToUri(fileName: string): string;
-	/**
-	 * Get configuration from IDE.
-	 * 
-	 * For VSCode, it's .vscode/settings.json
-	 */
-	getConfiguration?: <T> (section: string) => Promise<T | undefined>;
-	onDidChangeConfiguration?: (cb: () => void) => void;
-	/**
-	 * Global settings from config.
-	 */
-	settings: any;
+	env: ServiceEnvironment;
 	ruleId: string;
 	document: TextDocument;
 	report(error: vscode.Diagnostic, ...fixes: RuleFix[]): void;

--- a/packages/language-service/src/types.ts
+++ b/packages/language-service/src/types.ts
@@ -109,7 +109,7 @@ export interface Service {
 		provideCallHierarchyOutgoingCalls?(item: vscode.CallHierarchyItem, token: vscode.CancellationToken): Result<vscode.CallHierarchyOutgoingCall[]>;
 		provideDocumentSemanticTokens?(document: TextDocument, range: vscode.Range, legend: vscode.SemanticTokensLegend, token: vscode.CancellationToken): NullableResult<SemanticToken[]>;
 		provideWorkspaceSymbols?(query: string, token: vscode.CancellationToken): NullableResult<vscode.WorkspaceSymbol[]>;
-		provideSyntacticDiagnostics?(document: TextDocument, token: vscode.CancellationToken): NullableResult<vscode.Diagnostic[]>;
+		provideDiagnostics?(document: TextDocument, token: vscode.CancellationToken): NullableResult<vscode.Diagnostic[]>;
 		provideSemanticDiagnostics?(document: TextDocument, token: vscode.CancellationToken): NullableResult<vscode.Diagnostic[]>;
 		provideDiagnosticMarkupContent?(diagnostic: vscode.Diagnostic, token: vscode.CancellationToken): NullableResult<vscode.MarkupContent>;
 		provideFileReferences?(document: TextDocument, token: vscode.CancellationToken): NullableResult<vscode.Location[]>; // volar specific

--- a/packages/language-service/src/types.ts
+++ b/packages/language-service/src/types.ts
@@ -206,7 +206,7 @@ export interface RuleFix {
 
 export interface Config {
 	languages?: { [id: string]: LanguageModule | undefined; };
-	plugins?: { [id: string]: LanguageServicePlugin | LanguageServicePluginInstance | undefined; };
+	services?: { [id: string]: LanguageServicePlugin | undefined; };
 	lint?: {
 		rules?: { [id: string]: Rule | undefined; };
 		severities?: { [id: string]: vscode.DiagnosticSeverity; };

--- a/packages/language-service/src/types.ts
+++ b/packages/language-service/src/types.ts
@@ -69,7 +69,7 @@ export type NullableResult<T> = Result<T | undefined | null>;
 export type SemanticToken = [number, number, number, number, number];
 
 export interface Service {
-	(context?: ServiceContext): {
+	(context: ServiceContext | undefined, modules: { typescript?: typeof import('typescript/lib/tsserverlibrary'); } | undefined): {
 		isAdditionalCompletion?: boolean; // volar specific
 		triggerCharacters?: string[];
 		signatureHelpTriggerCharacters?: string[];

--- a/packages/language-service/src/types.ts
+++ b/packages/language-service/src/types.ts
@@ -39,7 +39,6 @@ export interface ServiceContext {
 	env: ServiceEnvironment;
 
 	typescript: {
-		module: typeof import('typescript/lib/tsserverlibrary');
 		languageServiceHost: ts.LanguageServiceHost;
 		languageService: ts.LanguageService;
 	} | undefined;

--- a/packages/language-service/src/types.ts
+++ b/packages/language-service/src/types.ts
@@ -9,7 +9,7 @@ import { DocumentsAndSourceMaps } from './documents';
 
 export * from 'vscode-languageserver-protocol';
 
-export interface LanguageServiceOptions {
+export interface ServiceOptions {
 	// InitializeParams
 	modules: {
 		typescript?: typeof import('typescript/lib/tsserverlibrary');
@@ -40,7 +40,7 @@ export interface Commands {
 	createSetSelectionCommand(position: vscode.Position): vscode.Command | undefined;
 }
 
-export interface ServiceContext extends LanguageServiceOptions {
+export interface ServiceContext extends ServiceOptions {
 
 	typescript: {
 		module: typeof import('typescript/lib/tsserverlibrary');

--- a/packages/language-service/src/types.ts
+++ b/packages/language-service/src/types.ts
@@ -39,7 +39,7 @@ export interface Commands {
 	createSetSelectionCommand(position: vscode.Position): vscode.Command | undefined;
 }
 
-export interface LanguageServicePluginContext extends LanguageServiceOptions {
+export interface ServiceContext extends LanguageServiceOptions {
 
 	typescript: {
 		module: typeof import('typescript/lib/tsserverlibrary');
@@ -76,7 +76,7 @@ export type NullableResult<T> = Result<T | undefined | null>;
 export type SemanticToken = [number, number, number, number, number];
 
 export interface Service {
-	(context?: LanguageServicePluginContext): {
+	(context?: ServiceContext): {
 		isAdditionalCompletion?: boolean; // volar specific
 		triggerCharacters?: string[];
 		signatureHelpTriggerCharacters?: string[];

--- a/packages/language-service/src/utils/featureWorkers.ts
+++ b/packages/language-service/src/utils/featureWorkers.ts
@@ -1,6 +1,6 @@
 import type { TextDocument } from 'vscode-languageserver-textdocument';
 import { visitEmbedded } from './definePlugin';
-import type { LanguageServicePluginInstance, LanguageServicePluginContext, Rule, RuleContext } from '../types';
+import type { Service, LanguageServicePluginContext, Rule, RuleContext } from '../types';
 import { FileRangeCapabilities, VirtualFile } from '@volar/language-service';
 import { SourceMapWithDocuments } from '../documents';
 
@@ -8,7 +8,7 @@ export async function documentFeatureWorker<T>(
 	context: LanguageServicePluginContext,
 	uri: string,
 	isValidSourceMap: (file: VirtualFile, sourceMap: SourceMapWithDocuments<FileRangeCapabilities>) => boolean,
-	worker: (plugin: LanguageServicePluginInstance, document: TextDocument) => T,
+	worker: (service: ReturnType<Service>, document: TextDocument) => T,
 	transform: (result: NonNullable<Awaited<T>>, sourceMap: SourceMapWithDocuments<FileRangeCapabilities> | undefined) => Awaited<T> | undefined,
 	combineResult?: (results: NonNullable<Awaited<T>>[]) => NonNullable<Awaited<T>>,
 ) {
@@ -33,7 +33,7 @@ export async function languageFeatureWorker<T, K>(
 	uri: string,
 	arg: K,
 	transformArg: (arg: K, sourceMap: SourceMapWithDocuments<FileRangeCapabilities>, file: VirtualFile) => Generator<K> | K[],
-	worker: (plugin: LanguageServicePluginInstance, document: TextDocument, arg: K, sourceMap: SourceMapWithDocuments<FileRangeCapabilities> | undefined, file: VirtualFile | undefined) => T,
+	worker: (service: ReturnType<Service>, document: TextDocument, arg: K, sourceMap: SourceMapWithDocuments<FileRangeCapabilities> | undefined, file: VirtualFile | undefined) => T,
 	transform: (result: NonNullable<Awaited<T>>, sourceMap: SourceMapWithDocuments<FileRangeCapabilities> | undefined) => Awaited<T> | undefined,
 	combineResult?: (results: NonNullable<Awaited<T>>[]) => NonNullable<Awaited<T>>,
 	reportProgress?: (result: NonNullable<Awaited<T>>) => void,

--- a/packages/language-service/src/utils/featureWorkers.ts
+++ b/packages/language-service/src/utils/featureWorkers.ts
@@ -1,11 +1,11 @@
 import type { TextDocument } from 'vscode-languageserver-textdocument';
 import { visitEmbedded } from './definePlugin';
-import type { Service, LanguageServicePluginContext, Rule, RuleContext } from '../types';
+import type { Service, ServiceContext, Rule, RuleContext } from '../types';
 import { FileRangeCapabilities, VirtualFile } from '@volar/language-service';
 import { SourceMapWithDocuments } from '../documents';
 
 export async function documentFeatureWorker<T>(
-	context: LanguageServicePluginContext,
+	context: ServiceContext,
 	uri: string,
 	isValidSourceMap: (file: VirtualFile, sourceMap: SourceMapWithDocuments<FileRangeCapabilities>) => boolean,
 	worker: (service: ReturnType<Service>, document: TextDocument) => T,
@@ -29,7 +29,7 @@ export async function documentFeatureWorker<T>(
 }
 
 export async function languageFeatureWorker<T, K>(
-	context: LanguageServicePluginContext,
+	context: ServiceContext,
 	uri: string,
 	arg: K,
 	transformArg: (arg: K, sourceMap: SourceMapWithDocuments<FileRangeCapabilities>, file: VirtualFile) => Generator<K> | K[],
@@ -117,7 +117,7 @@ export async function languageFeatureWorker<T, K>(
 }
 
 export async function ruleWorker<T>(
-	context: LanguageServicePluginContext,
+	context: ServiceContext,
 	api: 'onSyntax' | 'onSemantic' | 'onFormat',
 	uri: string,
 	isValidSourceMap: (file: VirtualFile) => boolean,

--- a/packages/language-service/src/utils/featureWorkers.ts
+++ b/packages/language-service/src/utils/featureWorkers.ts
@@ -141,15 +141,7 @@ export async function ruleWorker<T>(
 			}
 
 			let ruleCtx: RuleContext = {
-				// project context
-				modules: { typescript: context.typescript?.module },
-				uriToFileName: context.uriToFileName,
-				fileNameToUri: context.fileNameToUri,
-				rootUri: context.rootUri,
-				locale: context.locale,
-				getConfiguration: context.getConfiguration,
-				onDidChangeConfiguration: context.onDidChangeConfiguration,
-				settings: context.config.lint?.settings ?? {},
+				env: context.env,
 				// document context
 				ruleId: '',
 				document: map.virtualFileDocument,
@@ -170,9 +162,9 @@ export async function ruleWorker<T>(
 				}
 			}
 
-			for (const ruleName in context.config.lint?.rules) {
+			for (const ruleName in context.env.config.lint?.rules) {
 
-				const rule = context.config.lint?.rules[ruleName];
+				const rule = context.env.config.lint?.rules[ruleName];
 				if (!rule) {
 					continue;
 				}
@@ -207,15 +199,7 @@ export async function ruleWorker<T>(
 	else if (document) {
 
 		let ruleCtx: RuleContext = {
-			// project context
-			modules: { typescript: context.typescript?.module },
-			uriToFileName: context.uriToFileName,
-			fileNameToUri: context.fileNameToUri,
-			rootUri: context.rootUri,
-			locale: context.locale,
-			getConfiguration: context.getConfiguration,
-			onDidChangeConfiguration: context.onDidChangeConfiguration,
-			settings: context.config.lint?.settings ?? {},
+			env: context.env,
 			// document context
 			ruleId: '',
 			document,
@@ -236,9 +220,9 @@ export async function ruleWorker<T>(
 			}
 		}
 
-		for (const ruleName in context.config.lint?.rules) {
+		for (const ruleName in context.env.config.lint?.rules) {
 
-			const rule = context.config.lint?.rules[ruleName];
+			const rule = context.env.config.lint?.rules[ruleName];
 			if (!rule) {
 				continue;
 			}

--- a/packages/language-service/src/utils/featureWorkers.ts
+++ b/packages/language-service/src/utils/featureWorkers.ts
@@ -162,9 +162,9 @@ export async function ruleWorker<T>(
 				}
 			}
 
-			for (const ruleName in context.env.config.lint?.rules) {
+			for (const ruleName in context.config.lint?.rules) {
 
-				const rule = context.env.config.lint?.rules[ruleName];
+				const rule = context.config.lint?.rules[ruleName];
 				if (!rule) {
 					continue;
 				}
@@ -220,9 +220,9 @@ export async function ruleWorker<T>(
 			}
 		}
 
-		for (const ruleName in context.env.config.lint?.rules) {
+		for (const ruleName in context.config.lint?.rules) {
 
-			const rule = context.env.config.lint?.rules[ruleName];
+			const rule = context.config.lint?.rules[ruleName];
 			if (!rule) {
 				continue;
 			}

--- a/packages/language-service/src/utils/featureWorkers.ts
+++ b/packages/language-service/src/utils/featureWorkers.ts
@@ -147,8 +147,8 @@ export async function ruleWorker<T>(
 				fileNameToUri: context.fileNameToUri,
 				rootUri: context.rootUri,
 				locale: context.locale,
-				getConfiguration: context.configurationHost?.getConfiguration,
-				onDidChangeConfiguration: context.configurationHost?.onDidChangeConfiguration,
+				getConfiguration: context.getConfiguration,
+				onDidChangeConfiguration: context.onDidChangeConfiguration,
 				settings: context.config.lint?.settings ?? {},
 				// document context
 				ruleId: '',
@@ -213,8 +213,8 @@ export async function ruleWorker<T>(
 			fileNameToUri: context.fileNameToUri,
 			rootUri: context.rootUri,
 			locale: context.locale,
-			getConfiguration: context.configurationHost?.getConfiguration,
-			onDidChangeConfiguration: context.configurationHost?.onDidChangeConfiguration,
+			getConfiguration: context.getConfiguration,
+			onDidChangeConfiguration: context.onDidChangeConfiguration,
 			settings: context.config.lint?.settings ?? {},
 			// document context
 			ruleId: '',

--- a/packages/monaco/src/worker.ts
+++ b/packages/monaco/src/worker.ts
@@ -22,8 +22,7 @@ export function createLanguageService(options: {
 	const config = options.config ?? {};
 	const compilerOptions = options.typescript?.compilerOptions ?? {};
 	let host = createLanguageServiceHost();
-	let languageService = _createLanguageService({
-		modules: { typescript: ts },
+	let languageService = _createLanguageService({ typescript: ts }, {
 		host,
 		config,
 		uriToFileName: (uri: string) => URI.parse(uri).fsPath.replace(/\\/g, '/'),
@@ -57,8 +56,7 @@ export function createLanguageService(options: {
 				if (newVersion !== dtsVersion) {
 					dtsVersion = newVersion;
 					languageService.dispose();
-					languageService = _createLanguageService({
-						modules: { typescript: ts },
+					languageService = _createLanguageService({ typescript: ts }, {
 						host,
 						config,
 						rootUri: URI.file('/'),

--- a/packages/monaco/src/worker.ts
+++ b/packages/monaco/src/worker.ts
@@ -22,13 +22,16 @@ export function createLanguageService(options: {
 	const config = options.config ?? {};
 	const compilerOptions = options.typescript?.compilerOptions ?? {};
 	let host = createLanguageServiceHost();
-	let languageService = _createLanguageService({ typescript: ts }, {
-		host,
+	let languageService = _createLanguageService(
+		{ typescript: ts },
+		{
+			uriToFileName: (uri: string) => URI.parse(uri).fsPath.replace(/\\/g, '/'),
+			fileNameToUri: (fileName: string) => URI.file(fileName).toString(),
+			rootUri: URI.file('/'),
+		},
 		config,
-		uriToFileName: (uri: string) => URI.parse(uri).fsPath.replace(/\\/g, '/'),
-		fileNameToUri: (fileName: string) => URI.file(fileName).toString(),
-		rootUri: URI.file('/'),
-	});
+		host,
+	);
 	let dtsVersion = 0;
 
 	class InnocentRabbit { };
@@ -56,13 +59,16 @@ export function createLanguageService(options: {
 				if (newVersion !== dtsVersion) {
 					dtsVersion = newVersion;
 					languageService.dispose();
-					languageService = _createLanguageService({ typescript: ts }, {
-						host,
+					languageService = _createLanguageService(
+						{ typescript: ts },
+						{
+							rootUri: URI.file('/'),
+							uriToFileName: (uri: string) => URI.parse(uri).fsPath.replace(/\\/g, '/'),
+							fileNameToUri: (fileName: string) => URI.file(fileName).toString(),
+						},
 						config,
-						rootUri: URI.file('/'),
-						uriToFileName: (uri: string) => URI.parse(uri).fsPath.replace(/\\/g, '/'),
-						fileNameToUri: (fileName: string) => URI.file(fileName).toString(),
-					});
+						host,
+					);
 				}
 				result = await (languageService as any)[api](...args);
 				newVersion = await options.dtsHost.getVersion();

--- a/packages/typescript/src/index.ts
+++ b/packages/typescript/src/index.ts
@@ -2,7 +2,7 @@ import * as ts from 'typescript'; // this is a peer dependency
 import { getProgram } from './getProgram';
 import * as embedded from '@volar/language-core';
 
-export function createLanguageService(host: embedded.LanguageServiceHost, mods: embedded.LanguageModule[]) {
+export function createLanguageService(host: embedded.LanguageServiceHost, mods: embedded.Language[]) {
 
 	type _LanguageService = {
 		__internal__: {

--- a/packages/typescript/src/index.ts
+++ b/packages/typescript/src/index.ts
@@ -11,7 +11,7 @@ export function createLanguageService(host: embedded.LanguageServiceHost, mods: 
 		};
 	} & ts.LanguageService;
 
-	const core = embedded.createLanguageContext(host, { typescript: ts as any }, mods);
+	const core = embedded.createLanguageContext({ typescript: ts as any }, host, mods);
 
 	if (!ts) {
 		throw new Error('TypeScript module not provided.');

--- a/packages/vscode/src/features/tsVersion.ts
+++ b/packages/vscode/src/features/tsVersion.ts
@@ -2,7 +2,7 @@ import * as path from 'typesafe-path';
 import * as vscode from 'vscode';
 import { BaseLanguageClient } from 'vscode-languageclient';
 import { quickPick } from '../common';
-import { LanguageServerInitializationOptions } from '@volar/language-server';
+import { InitializationOptions } from '@volar/language-server';
 
 const defaultTsdkPath = 'node_modules/typescript/lib' as path.PosixPath;
 
@@ -101,7 +101,7 @@ export async function activate(
 
 	async function reloadServers() {
 		const tsPaths = await getTsdk(context);
-		const newInitOptions: LanguageServerInitializationOptions = {
+		const newInitOptions: InitializationOptions = {
 			...client.clientOptions.initializationOptions,
 			typescript: tsPaths,
 		};


### PR DESCRIPTION
Major changes:

- `Config.plugins` -> `Config.services`
- `LanguageModule` -> `Language`
	- `createFile` -> `createVirtualFile`
	- `updateFile` -> `updateVirtualFile`
	- `deleteFile` -> `deleteVirtualFile`
	- `proxyLanguageServicehost` -> `resolveHost`
- `LangaugeServicePlugin.provideSyntacticDiagnostics` -> `Service.provideDiagnostics`
- `LanguageServiceContext.uriToFileName` -> `ServiceContext.env.uriToFileName`...
- move `modules` from `LanguageServiceContext` to `Service` factory function second parameter

Please focus on the api actual type instead of the above list.