### PR TITLE
feat: Project / Inject APIs

### DIFF
--- a/packages/kit/src/createLinter.ts
+++ b/packages/kit/src/createLinter.ts
@@ -88,7 +88,7 @@ export function createLinter(config: Config, host: LanguageServiceHost) {
 		if (!diagnostics.length) return;
 		let text = formatErrors(fileName, diagnostics);
 		for (const diagnostic of diagnostics) {
-			text = text.replace(`TS${diagnostic.code}`, `${(diagnostic.source ?? '')}(${diagnostic.code})`);
+			text = text.replace(`TS${diagnostic.code}`, (diagnostic.source ?? '') + (diagnostic.code ? `(${diagnostic.code})` : ''));
 		}
 		console.log(text);
 	}

--- a/packages/language-service/src/baseLanguageService.ts
+++ b/packages/language-service/src/baseLanguageService.ts
@@ -115,6 +115,7 @@ function createLanguageServicePluginContext(
 					return provide(...args as any);
 				}
 			}
+			throw `no service for injection key ${JSON.stringify(key)}.`;
 		},
 		config,
 		host,

--- a/packages/language-service/src/baseLanguageService.ts
+++ b/packages/language-service/src/baseLanguageService.ts
@@ -38,7 +38,6 @@ import * as linkedEditingRanges from './documentFeatures/linkedEditingRanges';
 import * as selectionRanges from './documentFeatures/selectionRanges';
 import * as vscode from 'vscode-languageserver-protocol';
 
-// fix build
 import { notEmpty, resolveCommonLanguageId } from './utils/common';
 
 export type LanguageService = ReturnType<typeof createLanguageServiceBase>;
@@ -109,6 +108,14 @@ function createLanguageServicePluginContext(
 	const documentVersions = new Map<string, number>();
 	const context: ServiceContext = {
 		env,
+		inject: (key, ...args) => {
+			for (const service of Object.values(context.services)) {
+				const provide = service.provide?.[key as any];
+				if (provide) {
+					return provide(...args as any);
+				}
+			}
+		},
 		config,
 		host,
 		core: languageContext,

--- a/packages/language-service/src/languageFeatures/validation.ts
+++ b/packages/language-service/src/languageFeatures/validation.ts
@@ -286,12 +286,6 @@ export function register(context: ServiceContext) {
 						error.message ||= 'No message.';
 						error.source ||= ruleCtx.ruleId;
 
-						for (const service of Object.values(context.services)) {
-							if (service.rules?.resolveDiagnostic) {
-								error = service.rules.resolveDiagnostic(error);
-							}
-						}
-
 						reportResults.push([error, ...fixes]);
 					};
 


### PR DESCRIPTION
Implement Provide / Inject API ([similar to Vue](https://vuejs.org/guide/components/provide-inject.html)) for sharing AST / LanguageService or other instances across Services.

This is also the basis for making the Rules API AST agnostic.

## Usage

- volar-service-foo

```ts
import { Service } from '@volar/language-service';

export default (): Service => (context): ReturnType<Service> => {
	return {
		provide: {
			'foo-ast': (document: TextDocument) => parseFooAst(document),
		},
	};
};
```

- volar-service-bar

```ts
import { Service } from '@volar/language-service';

export default (): Service => (context): ReturnType<Service> => {
	return {
		provideDocumentColors(document) {
			const fooAst = context.inject('foo-ast', document);
			// ...
		},
	};
};
```

## Typed Support

- volar-service-foo

```ts
import { Service, InjectionKey, defineProvide } from '@volar/language-service';

export const fooKey: InjectionKey<[TextDocument], FooAST> = 'foo-ast';

export default (): Service => (context): ReturnType<Service> => {
	return {
		provide: defineProvide(key, parseFooAst),
	};
};
```

- volar-service-bar

```ts
import { Service } from '@volar/language-service';
import { fooKey } from 'volar-service-foo';

export default (): Service => (context): ReturnType<Service> => {
	return {
		provideDocumentColors(document) {
			const fooAst = context.inject(fooKey, document);
			//        ^? FooAST
		},
	};
};
```

## Use in Rules API

- volar-rule-no-baz

```ts
import { Rule } from '@volar/language-service';
import { fooKey } from 'volar-service-foo';

export default (): Rule = {
	return {
		run(ctx) {
			const fooAst = ctx.inject(fooKey, ctx.document);
			//        ^? FooAST
		},
	};
};
`