### PR TITLE
refactor: type-only Provide / Inject APIs

### DIFF
--- a/packages/language-server/src/node/fileSystem.ts
+++ b/packages/language-server/src/node/fileSystem.ts
@@ -83,7 +83,7 @@ export function createNodeFileSystemHost(
 		});
 		const fileExistsCache = new Map<string, boolean>();
 		const directoryExistsCache = new Map<string, boolean>();
-		// don't cache fs result if client did not supports file watcher
+		// don't cache fs result if the client did not support file watcher
 		const sys = capabilities.workspace?.didChangeWatchedFiles
 			? new Proxy<Partial<ts.System>>({
 				fileExists(path: string) {

--- a/packages/language-server/src/node/index.ts
+++ b/packages/language-server/src/node/index.ts
@@ -61,7 +61,7 @@ export function startLanguageServer(connection: vscode.Connection, ...plugins: L
 					https: httpSchemaRequestHandler,
 				},
 				onDidChangeConfiguration(settings) {
-					configureHttpRequests(settings.http && settings.http.proxy, settings.http && settings.http.proxyStrictSSL);
+					configureHttpRequests(settings.http?.proxy, settings.http?.proxyStrictSSL);
 				},
 				createFileSystemHost: createNodeFileSystemHost,
 				fileSystemProvide: {

--- a/packages/language-service/src/baseLanguageService.ts
+++ b/packages/language-service/src/baseLanguageService.ts
@@ -108,15 +108,6 @@ function createLanguageServicePluginContext(
 	const documentVersions = new Map<string, number>();
 	const context: ServiceContext = {
 		env,
-		inject: (key, ...args) => {
-			for (const service of Object.values(context.services)) {
-				const provide = service.provide?.[key as any];
-				if (provide) {
-					return provide(...args as any);
-				}
-			}
-			throw `no service for injection key ${JSON.stringify(key)}.`;
-		},
 		config,
 		host,
 		core: languageContext,

--- a/packages/language-service/src/languageFeatures/validation.ts
+++ b/packages/language-service/src/languageFeatures/validation.ts
@@ -247,7 +247,7 @@ export function register(context: ServiceContext) {
 				ruleType,
 				uri,
 				file => ruleType === RuleType.Format ? !!file.capabilities.documentFormatting : !!file.capabilities.diagnostic,
-				async (ruleName, rule, lintDocument, ruleCtx) => {
+				async (ruleId, rule, lintDocument, ruleCtx) => {
 
 					if (token) {
 						if (Date.now() - lastCheckCancelAt >= 5) {
@@ -259,7 +259,7 @@ export function register(context: ServiceContext) {
 						}
 					}
 
-					const pluginCache = cacheMap.get(ruleName) ?? cacheMap.set(ruleName, new Map()).get(ruleName)!;
+					const pluginCache = cacheMap.get(ruleId) ?? cacheMap.set(ruleId, new Map()).get(ruleId)!;
 					const cache = pluginCache.get(lintDocument.uri);
 					const tsProjectVersion = (ruleType === RuleType.Semantic) ? context.core.typescript.languageServiceHost.getProjectVersion?.() : undefined;
 
@@ -284,7 +284,7 @@ export function register(context: ServiceContext) {
 						}
 
 						error.message ||= 'No message.';
-						error.source ||= ruleCtx.ruleId;
+						error.source ||= ruleId;
 
 						reportResults.push([error, ...fixes]);
 					};
@@ -293,22 +293,22 @@ export function register(context: ServiceContext) {
 						await rule.run(lintDocument, ruleCtx);
 					}
 					catch (err) {
-						console.warn(`[volar/rules-api] ${ruleName} ${ruleType} error.`);
+						console.warn(`[volar/rules-api] ${ruleId} ${ruleType} error.`);
 						console.warn(err);
 					}
 
 					context.ruleFixes ??= {};
 					context.ruleFixes[lintDocument.uri] ??= {};
-					context.ruleFixes[lintDocument.uri][ruleCtx.ruleId] ??= {};
+					context.ruleFixes[lintDocument.uri][ruleId] ??= {};
 
 					reportResults?.forEach(([error, ...fixes], index) => {
-						context.ruleFixes![lintDocument.uri][ruleCtx.ruleId][index] = [error, fixes];
+						context.ruleFixes![lintDocument.uri][ruleId][index] = [error, fixes];
 						error.data = {
 							uri,
 							version: newDocument!.version,
 							type: 'rule',
 							isFormat: ruleType === RuleType.Format,
-							serviceOrRuleId: ruleCtx.ruleId,
+							serviceOrRuleId: ruleId,
 							original: {
 								data: error.data,
 							},


### PR DESCRIPTION
This is another solution to replace #37, the new design only needs to import type, so no runtime dependencies.

In addition, in order to avoid over-design, `inject()` now can only be used in Rules and not in Services.

## Usage

- volar-service-foo

```ts
import type { Service } from '@volar/language-service';

export interface MyProvide {
	'foo-ast': (doc: TextDocument) => FooAST;
}

export default (): Service => (context): ReturnType<Service> => {
	return {
		provide: {
			'foo-ast': parseFooAst
		} satisfies MyProvide,
	};
	function parseFooAst(document: TextDocument) {
		// ...
	}
};
```

- volar-rule-no-baz

```ts
import type { Rule } from '@volar/language-service';
import type { MyProvide } from 'volar-service-foo';

export default (): Rule<MyProvide> = {
	return {
		run(document, ctx) {
			const fooAst = ctx.inject('foo-ast', document);
			//        ^? FooAST
		},
	};
};
```