### PR TITLE
Clearly distinguish between `rootPath` and `workspacePath`

### DIFF
--- a/packages/kit/src/createFormatter.ts
+++ b/packages/kit/src/createFormatter.ts
@@ -19,6 +19,7 @@ export function createFormatter(
 	const service = createLanguageService(
 		{ typescript: ts },
 		{
+			workspaceUri: URI.file('/'),
 			rootUri: URI.file('/'),
 			uriToFileName: uri => {
 				if (uri.startsWith(dummyScriptUri))
@@ -77,7 +78,8 @@ export function createFormatter(
 	function createHost() {
 		let projectVersion = 0;
 		const host: TypeScriptLanguageHost = {
-			getCurrentDirectory: () => '/',
+			workspacePath: '/',
+			rootPath: '/',
 			getCompilationSettings: () => compilerOptions,
 			getProjectVersion: () => (projectVersion++).toString(),
 			getScriptFileNames: () => fakeScriptSnapshot ? [fakeScriptFileName] : [],

--- a/packages/kit/src/createLinter.ts
+++ b/packages/kit/src/createLinter.ts
@@ -14,7 +14,8 @@ export function createLinter(config: Config, host: TypeScriptLanguageHost) {
 		{
 			uriToFileName,
 			fileNameToUri,
-			rootUri: URI.parse(fileNameToUri(host.getCurrentDirectory())),
+			workspaceUri: URI.parse(fileNameToUri(host.workspacePath)),
+			rootUri: URI.parse(fileNameToUri(host.rootPath)),
 			getConfiguration: section => getConfiguration(settings, section),
 			fs,
 			console,

--- a/packages/kit/src/createProject.ts
+++ b/packages/kit/src/createProject.ts
@@ -46,9 +46,8 @@ function createProjectBase(rootPath: string, createParsedCommandLine: () => Pick
 
 	const ts = require('typescript') as typeof import('typescript/lib/tsserverlibrary');
 	const languageHost: TypeScriptLanguageHost = {
-		getCurrentDirectory: () => {
-			return rootPath;
-		},
+		workspacePath: rootPath,
+		rootPath: rootPath,
 		getCompilationSettings: () => {
 			return parsedCommandLine.options;
 		},

--- a/packages/language-core/src/types.ts
+++ b/packages/language-core/src/types.ts
@@ -93,6 +93,8 @@ export interface Language<T extends VirtualFile = VirtualFile> {
 }
 
 interface LanguageHost {
+	workspacePath: string;
+	rootPath: string;
 	getProjectVersion(): string;
 	getScriptFileNames(): string[];
 	getScriptSnapshot(fileName: string): ts.IScriptSnapshot | undefined;
@@ -100,8 +102,7 @@ interface LanguageHost {
 }
 
 export interface TypeScriptLanguageHost extends LanguageHost, Pick<ts.LanguageServiceHost,
-	'getCurrentDirectory'
-	| 'getCancellationToken'
+	'getCancellationToken'
 	| 'getLocalizedDiagnosticMessages'
 	| 'getCompilationSettings'
 	| 'getProjectReferences'

--- a/packages/language-server/src/common/project.ts
+++ b/packages/language-server/src/common/project.ts
@@ -39,6 +39,7 @@ export async function createProject(context: ProjectContext) {
 		fs,
 		console: context.server.runtimeEnv.console,
 		locale: context.workspaces.initParams.locale,
+		workspaceUri: context.workspace.rootUri,
 		rootUri: context.project.rootUri,
 		clientCapabilities: context.workspaces.initParams.capabilities,
 		getConfiguration: context.server.configurationHost?.getConfiguration,
@@ -52,6 +53,8 @@ export async function createProject(context: ProjectContext) {
 
 	const askedFiles = createUriMap<boolean>(fileNameToUri);
 	const languageHost: TypeScriptLanguageHost = {
+		workspacePath: uriToFileName(context.workspace.rootUri.toString()),
+		rootPath: uriToFileName(context.project.rootUri.toString()),
 		getProjectVersion: () => projectVersion.toString(),
 		getScriptFileNames: () => parsedCommandLine.fileNames,
 		getScriptSnapshot: (fileName) => {
@@ -69,7 +72,6 @@ export async function createProject(context: ProjectContext) {
 		getCancellationToken: () => tsToken,
 		getCompilationSettings: () => parsedCommandLine.options,
 		getLocalizedDiagnosticMessages: context.workspaces.tsLocalized ? () => context.workspaces.tsLocalized : undefined,
-		getCurrentDirectory: () => uriToFileName(context.project.rootUri.toString()),
 		getProjectReferences: () => parsedCommandLine.projectReferences,
 	};
 	const docChangeWatcher = context.workspaces.documents.onDidChangeContent(() => {

--- a/packages/language-server/tests/triple-directory/main.spec.ts
+++ b/packages/language-server/tests/triple-directory/main.spec.ts
@@ -8,6 +8,7 @@ describe('triple-directory', () => {
 	// https://github.com/vuejs/language-tools/issues/3282
 	it('Should not throw "Maximum call stack size exceeded"', () => {
 		const sys = createSys(require('typescript'), {
+			workspaceUri: URI.parse(fileNameToUri(__dirname)),
 			rootUri: URI.parse(fileNameToUri(__dirname)),
 			fileNameToUri,
 			uriToFileName,

--- a/packages/language-service/src/baseLanguageService.ts
+++ b/packages/language-service/src/baseLanguageService.ts
@@ -48,7 +48,7 @@ export function createLanguageService(
 	languageHost: TypeScriptLanguageHost,
 ) {
 
-	if (languageHost.getCurrentDirectory().indexOf('\\') >= 0) {
+	if (languageHost.workspacePath.indexOf('\\') >= 0 || languageHost.rootPath.indexOf('\\') >= 0) {
 		throw new Error('Volar: Current directory must be posix style.');
 	}
 	if (languageHost.getScriptFileNames().some(fileName => fileName.indexOf('\\') >= 0)) {

--- a/packages/language-service/src/types.ts
+++ b/packages/language-service/src/types.ts
@@ -13,6 +13,7 @@ export interface SharedModules {
 export interface ServiceEnvironment {
 
 	locale?: string;
+	workspaceUri: URI;
 	rootUri: URI;
 	clientCapabilities?: vscode.ClientCapabilities;
 	getConfiguration?<T>(section: string, scopeUri?: string): Promise<T | undefined>;

--- a/packages/monaco/src/worker.ts
+++ b/packages/monaco/src/worker.ts
@@ -14,6 +14,7 @@ export function createServiceEnvironment(): ServiceEnvironment {
 	return {
 		uriToFileName: uri => URI.parse(uri).fsPath.replace(/\\/g, '/'),
 		fileNameToUri: fileName => URI.file(fileName).toString(),
+		workspaceUri: URI.file('/'),
 		rootUri: URI.file('/'),
 		console,
 	};
@@ -31,6 +32,8 @@ export function createLanguageHost(
 	const modelSnapshot = new WeakMap<monaco.worker.IMirrorModel, readonly [number, ts.IScriptSnapshot]>();
 	const modelVersions = new Map<monaco.worker.IMirrorModel, number>();
 	const host: TypeScriptLanguageHost = {
+		workspacePath: rootPath,
+		rootPath: rootPath,
 		getProjectVersion() {
 			const models = getMirrorModels();
 			if (modelVersions.size === getMirrorModels().length) {
@@ -68,9 +71,6 @@ export function createLanguageHost(
 		},
 		getCompilationSettings() {
 			return compilerOptions;
-		},
-		getCurrentDirectory() {
-			return rootPath;
 		},
 	};
 

--- a/packages/typescript/src/languageServiceHost.ts
+++ b/packages/typescript/src/languageServiceHost.ts
@@ -17,7 +17,7 @@ export function createLanguageServiceHost(
 
 	const _tsHost: ts.LanguageServiceHost = {
 		...sys,
-		getCurrentDirectory: () => ctx.host.getCurrentDirectory(),
+		getCurrentDirectory: () => ctx.host.workspacePath,
 		getCompilationSettings: () => ctx.host.getCompilationSettings(),
 		getCancellationToken: ctx.host.getCancellationToken ? () => ctx.host.getCancellationToken!() : undefined,
 		getLocalizedDiagnosticMessages: ctx.host.getLocalizedDiagnosticMessages ? () => ctx.host.getLocalizedDiagnosticMessages!() : undefined,
@@ -152,7 +152,7 @@ export function createLanguageServiceHost(
 			excludes,
 			includes,
 			sys?.useCaseSensitiveFileNames ?? false,
-			ctx.host.getCurrentDirectory(),
+			ctx.host.workspacePath,
 			depth,
 			(dirPath) => {
 


### PR DESCRIPTION
In the past, we have been using TS getCurrentDirectory to return the root path of the current project, which is usually the upper level directory of tsconfig, which makes TS DocumentRegistry always unable to share SourceFile instances between multiple projects in monorepo, because the DocumentRegistry requires the currentDirectory to be the same.

Now `LanguageHost.getCurrentDirectory` has been removed, and `rootPath` and `workspacePath` have been added instead.

- `rootPath`: replaced the old `LanguageHost.getCurrentDirectory`
- `workspacePath`: use for `DocumentRegistry` and TS's `LanguageServiceHost.getCurrentDirectory`.