### PR TITLE
fix: performance issue with o(n^2) complexity of directoryExists()

### DIFF
--- a/packages/typescript/src/languageServiceHost.ts
+++ b/packages/typescript/src/languageServiceHost.ts
@@ -18,6 +18,7 @@ export function createLanguageServiceHost(
 	let lastProjectVersion: number | string | undefined;
 	let tsProjectVersion = 0;
 	let tsFileNames: string[] = [];
+	let tsDirectories: Record<string, true> = {};
 
 	const _tsHost: ts.LanguageServiceHost = {
 		...sys,
@@ -204,6 +205,12 @@ export function createLanguageServiceHost(
 			}
 		}
 		tsFileNames = [...tsFileNamesSet];
+
+		// Update tsDirectories for `directoryExists()`
+		tsDirectories = {};
+		for (const fileName of tsFileNames) {
+			tsDirectories[path.dirname(fileName)] = true;
+		}
 	}
 
 	function readDirectory(
@@ -323,8 +330,7 @@ export function createLanguageServiceHost(
 	}
 
 	function directoryExists(dirName: string): boolean {
-		return sys.directoryExists(dirName)
-			|| tsFileNames.some(fileName => fileName.toLowerCase().startsWith(dirName.toLowerCase()));
+		return tsDirectories[dirName] || sys.directoryExists(dirName);
 	}
 
 	function fileExists(fileName: string) {


### PR DESCRIPTION
Related to https://github.com/vuejs/language-tools/discussions/2740

Profiling `.vue` file saves on a very big project:

Before (notice the 15s-long file save):
![screenshot](https://cdn.discordapp.com/attachments/874728348306255924/1159058030177042495/image.png?ex=651e8068&is=651d2ee8&hm=f55d0a59ca4275af55710a39fdd6b694a1b1edc7747d998fd7aaca80b5761225&)

Profile:
[CPU-20231004T112107.zip](https://github.com/volarjs/volar.js/files/12802051/CPU-20231004T112107.zip)

After:
![screenshot](https://cdn.discordapp.com/attachments/874728348306255924/1159066559113875477/image.png?ex=651e885a&is=651d36da&hm=4f85c41787a633a84d5713e59993a020ff0e0440472dfda9d3e532e40c9137c5&)

Profile:
[CPU-20231004T115709.zip](https://github.com/volarjs/volar.js/files/12802055/CPU-20231004T115709.zip)

