### PR TITLE
fix: Avoid downstream need node polyfill for browser

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
 		"test": "vitest run"
 	},
 	"devDependencies": {
-		"@types/node": "latest",
 		"typescript": "latest",
 		"vite": "latest",
 		"vitest": "latest"

--- a/packages/kit/package.json
+++ b/packages/kit/package.json
@@ -18,6 +18,9 @@
 		"vscode-languageserver-textdocument": "^1.0.11",
 		"vscode-uri": "^3.0.8"
 	},
+	"devDependencies": {
+		"@types/node": "latest"
+	},
 	"peerDependencies": {
 		"typescript": "*"
 	}

--- a/packages/labs/package.json
+++ b/packages/labs/package.json
@@ -81,6 +81,7 @@
 		"size": "npm run prepack -- --metafile && esbuild-visualizer --metadata ./meta.json && open ./stats.html"
 	},
 	"devDependencies": {
+		"@types/node": "latest",
 		"@types/vscode": "^1.82.0",
 		"@volar/language-server": "1.10.6",
 		"@volar/source-map": "1.10.6",

--- a/packages/language-service/src/languageFeatures/callHierarchy.ts
+++ b/packages/language-service/src/languageFeatures/callHierarchy.ts
@@ -1,4 +1,3 @@
-import { posix as path } from 'path';
 import type * as vscode from 'vscode-languageserver-protocol';
 import type { ServiceContext } from '../types';
 import { notEmpty } from '../utils/common';
@@ -187,7 +186,9 @@ export function register(context: ServiceContext) {
 			const vueRanges = tsRanges.map(tsRange => map.toSourceRange(tsRange)).filter(notEmpty);
 			const vueItem: vscode.CallHierarchyItem = {
 				...tsItem,
-				name: tsItem.name === path.basename(context.env.uriToFileName(map.virtualFileDocument.uri)) ? path.basename(context.env.uriToFileName(map.sourceFileDocument.uri)) : tsItem.name,
+				name: tsItem.name === map.virtualFileDocument.uri.substring(map.virtualFileDocument.uri.lastIndexOf('/') + 1)
+					? map.sourceFileDocument.uri.substring(map.sourceFileDocument.uri.lastIndexOf('/') + 1)
+					: tsItem.name,
 				uri: map.sourceFileDocument.uri,
 				// TS Bug: `range: range` not works
 				range: {

--- a/packages/monaco/src/editor.ts
+++ b/packages/monaco/src/editor.ts
@@ -58,7 +58,7 @@ export namespace editor {
 				return;
 			}
 
-			let timer: NodeJS.Timeout | undefined;
+			let timer: number | undefined;
 			const changeSubscription = model.onDidChangeContent(() => {
 				clearTimeout(timer);
 				timer = setTimeout(() => doValidation(model), 250);
@@ -122,7 +122,7 @@ export namespace editor {
 		const disposables: IDisposable[] = [];
 		const listener = new Map<_editor.IModel, IDisposable>();
 
-		let timeout: NodeJS.Timeout | undefined;
+		let timeout: number | undefined;
 
 		disposables.push(
 			editor.onDidCreateModel((model) => hostingAutoInsertion(model)),

--- a/packages/typescript/package.json
+++ b/packages/typescript/package.json
@@ -13,9 +13,11 @@
 		"directory": "packages/typescript"
 	},
 	"dependencies": {
-		"@volar/language-core": "1.10.6"
+		"@volar/language-core": "1.10.6",
+		"path-browserify": "^1.0.1"
 	},
 	"devDependencies": {
+		"@types/path-browserify": "^1.0.1",
 		"@volar/language-service": "1.10.6"
 	}
 }

--- a/packages/typescript/src/languageServiceHost.ts
+++ b/packages/typescript/src/languageServiceHost.ts
@@ -1,6 +1,6 @@
 import type { FileKind, VirtualFile, LanguageContext } from '@volar/language-core';
 import type * as ts from 'typescript/lib/tsserverlibrary';
-import { posix as path } from 'path';
+import * as path from 'path-browserify';
 import { matchFiles } from './typescript/utilities';
 
 const fileVersions = new Map<string, { lastVersion: number; snapshotVersions: WeakMap<ts.IScriptSnapshot, number>; }>();

--- a/packages/typescript/src/sys.ts
+++ b/packages/typescript/src/sys.ts
@@ -1,6 +1,6 @@
 import type { FileChangeType, FileType, ServiceEnvironment, Disposable, FileStat } from '@volar/language-service';
 import type * as ts from 'typescript/lib/tsserverlibrary';
-import { posix as path } from 'path';
+import * as path from 'path-browserify';
 import { matchFiles } from './typescript/utilities';
 
 interface File {
@@ -109,6 +109,7 @@ export function createSys(
 				if (sys.directoryExists(rootPath)) {
 					// https://github.com/vuejs/language-tools/issues/2480
 					try {
+						// @ts-expect-error
 						process.chdir(rootPath);
 					} catch { }
 				}

--- a/packages/typescript/src/typescript/corePublic.ts
+++ b/packages/typescript/src/typescript/corePublic.ts
@@ -116,6 +116,7 @@ namespace NativeCollections {
 	declare const self: any;
 
 	const globals = typeof globalThis !== "undefined" ? globalThis :
+		// @ts-expect-error node global
 		typeof global !== "undefined" ? global :
 			typeof self !== "undefined" ? self :
 				undefined;

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -18,6 +18,7 @@
 		"vscode-nls": "^5.2.0"
 	},
 	"devDependencies": {
+		"@types/node": "latest",
 		"@types/vscode": "^1.82.0",
 		"vscode-languageclient": "^9.0.1"
 	},

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,9 +15,6 @@ importers:
         specifier: latest
         version: 2.6.0(typescript@5.2.2)
     devDependencies:
-      '@types/node':
-        specifier: latest
-        version: 20.8.9
       typescript:
         specifier: latest
         version: 5.2.2
@@ -48,6 +45,10 @@ importers:
       vscode-uri:
         specifier: ^3.0.8
         version: 3.0.8
+    devDependencies:
+      '@types/node':
+        specifier: latest
+        version: 20.8.9
 
   packages/labs:
     devDependencies:
@@ -167,7 +168,13 @@ importers:
       '@volar/language-core':
         specifier: 1.10.6
         version: link:../language-core
+      path-browserify:
+        specifier: ^1.0.1
+        version: 1.0.1
     devDependencies:
+      '@types/path-browserify':
+        specifier: ^1.0.1
+        version: 1.0.1
       '@volar/language-service':
         specifier: 1.10.6
         version: link:../language-service
@@ -1141,6 +1148,10 @@ packages:
     requiresBuild: true
     dev: false
     optional: true
+
+  /@types/path-browserify@1.0.1:
+    resolution: {integrity: sha512-rUSqIy7fAfK6sRasdFCukWO4S77pXcTxViURlLdo1VKuekTDS8ASMdX1LA0TFlbzT3fZgFlgQTCrqmJBuTHpxA==}
+    dev: true
 
   /@types/vscode@1.83.0:
     resolution: {integrity: sha512-3mUtHqLAVz9hegut9au4xehuBrzRE3UJiQMpoEHkNl6XHliihO7eATx2BMHs0odsmmrwjJrlixx/Pte6M3ygDQ==}
@@ -4510,6 +4521,10 @@ packages:
     dependencies:
       entities: 4.5.0
     dev: true
+
+  /path-browserify@1.0.1:
+    resolution: {integrity: sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==}
+    dev: false
 
   /path-exists@3.0.0:
     resolution: {integrity: sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -52,6 +52,9 @@ importers:
 
   packages/labs:
     devDependencies:
+      '@types/node':
+        specifier: latest
+        version: 20.8.9
       '@types/vscode':
         specifier: ^1.82.0
         version: 1.83.0
@@ -191,6 +194,9 @@ importers:
         specifier: ^5.2.0
         version: 5.2.0
     devDependencies:
+      '@types/node':
+        specifier: latest
+        version: 20.8.9
       '@types/vscode':
         specifier: ^1.82.0
         version: 1.83.0


### PR DESCRIPTION
For packages that are environment agnostic, import node modules should be avoided. If needed, polyfill packages are used directly, so no additional compatibility is required downstream.

### Node environment packages:

- @volar/kit
- @volar/labs
- @volar/vscode

### Environment agnostic packages:

- @volar/cdn
- @volar/language-core
- @volar/language-server
- @volar/language-service
- @volar/monaco
- @volar/source-map
- @volar/typescript

There is an issue that needs further resolution, @volar/language-server/browser is importing typescript/lib/typescript.js directly, the code of typescript.js contains require("path"), so bundler still tries to resolve path module and requires downstream polyfill . But in fact, the path module is not used by typescript in the browser, because typescript checks whether the current environment is node. If not, the code that imports the path module will not be executed.

https://github.com/microsoft/TypeScript/blob/85c2577285154657f99f32db6231cb3f9815fe51/src/compiler/sys.ts#L2003-L2005

I'm considering having typescript imported by a CDN rather than importing it directly, so bundler doesn't try to resolve the import of typescript.js. Otherwise, downstream configuration of the bundler is currently required to avoid resolving node modules from typescript.js.