### PR TITLE
feat(language-server): Dynamically download TypeScript from CDN on Web

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,0 @@
-modules-cache-max-age=0
-prefer-frozen-lockfile=true
-auto-install-peers=false

--- a/packages/language-server/src/browser/index.ts
+++ b/packages/language-server/src/browser/index.ts
@@ -28,8 +28,15 @@ export function startLanguageServer(connection: vscode.Connection, ...plugins: L
 				return { dispose: () => clearTimeout(handle) };
 			},
 		},
-		loadTypescript() {
-			return importTsFromCdn();
+		async loadTypescript() {
+			const _module = globalThis.module;
+			globalThis.module = { exports: {} } as typeof _module;
+			const tsVersion = 'latest';
+			const tsUrl = `https://cdn.jsdelivr.net/npm/typescript@${tsVersion}/lib/typescript.js`;
+			await import(tsUrl);
+			const ts = globalThis.module.exports;
+			globalThis.module = _module;
+			return ts as typeof import('typescript/lib/tsserverlibrary');
 		},
 		async loadTypescriptLocalized(tsdk, locale) {
 			try {
@@ -43,16 +50,6 @@ export function startLanguageServer(connection: vscode.Connection, ...plugins: L
 		},
 		fs: createFs(connection),
 	}));
-}
-
-async function importTsFromCdn(tsVersion = 'latest') {
-	const _module = globalThis.module
-		; (globalThis as any).module = { exports: {} };
-	const tsUrl = `https://cdn.jsdelivr.net/npm/typescript@${tsVersion}/lib/typescript.js`;
-	await import(/* @vite-ignore */ tsUrl);
-	const ts = globalThis.module.exports;
-	globalThis.module = _module;
-	return ts as typeof import('typescript/lib/tsserverlibrary');
 }
 
 /**

--- a/packages/language-server/src/browser/index.ts
+++ b/packages/language-server/src/browser/index.ts
@@ -29,7 +29,7 @@ export function startLanguageServer(connection: vscode.Connection, ...plugins: L
 			},
 		},
 		loadTypescript() {
-			return require('typescript'); // force bundle because not support load by user config in web
+			return importTsFromCdn();
 		},
 		async loadTypescriptLocalized(tsdk, locale) {
 			try {
@@ -43,6 +43,16 @@ export function startLanguageServer(connection: vscode.Connection, ...plugins: L
 		},
 		fs: createFs(connection),
 	}));
+}
+
+async function importTsFromCdn(tsVersion = 'latest') {
+	const _module = globalThis.module
+		; (globalThis as any).module = { exports: {} };
+	const tsUrl = `https://cdn.jsdelivr.net/npm/typescript@${tsVersion}/lib/typescript.js`;
+	await import(/* @vite-ignore */ tsUrl);
+	const ts = globalThis.module.exports;
+	globalThis.module = _module;
+	return ts as typeof import('typescript/lib/tsserverlibrary');
 }
 
 /**

--- a/packages/language-server/src/browser/index.ts
+++ b/packages/language-server/src/browser/index.ts
@@ -28,19 +28,25 @@ export function startLanguageServer(connection: vscode.Connection, ...plugins: L
 				return { dispose: () => clearTimeout(handle) };
 			},
 		},
-		async loadTypescript() {
+		async loadTypeScript(options) {
+			const tsdkUri = options.typescript?.tsdkUri;
+			if (!tsdkUri) {
+				return;
+			}
 			const _module = globalThis.module;
 			globalThis.module = { exports: {} } as typeof _module;
-			const tsVersion = 'latest';
-			const tsUrl = `https://cdn.jsdelivr.net/npm/typescript@${tsVersion}/lib/typescript.js`;
-			await import(tsUrl);
+			await import(`${tsdkUri}/lib/typescript.js`);
 			const ts = globalThis.module.exports;
 			globalThis.module = _module;
 			return ts as typeof import('typescript/lib/tsserverlibrary');
 		},
-		async loadTypescriptLocalized(tsdk, locale) {
+		async loadTypeScriptLocalized(options, locale) {
+			const tsdkUri = options.typescript?.tsdkUri;
+			if (!tsdkUri) {
+				return;
+			}
 			try {
-				const uri = fileNameToUri(`${tsdk}/${locale}/diagnosticMessages.generated.json`);
+				const uri = fileNameToUri(`${tsdkUri}/${locale}/diagnosticMessages.generated.json`);
 				const json = await httpSchemaRequestHandler(uri);
 				if (json) {
 					return JSON.parse(json);

--- a/packages/language-server/src/browser/index.ts
+++ b/packages/language-server/src/browser/index.ts
@@ -29,7 +29,7 @@ export function startLanguageServer(connection: vscode.Connection, ...plugins: L
 			},
 		},
 		async loadTypeScript(options) {
-			const tsdkUri = options.typescript?.tsdkUri;
+			const tsdkUri = options.typescript?.tsdkUrl;
 			if (!tsdkUri) {
 				return;
 			}
@@ -41,7 +41,7 @@ export function startLanguageServer(connection: vscode.Connection, ...plugins: L
 			return ts as typeof import('typescript/lib/tsserverlibrary');
 		},
 		async loadTypeScriptLocalized(options, locale) {
-			const tsdkUri = options.typescript?.tsdkUri;
+			const tsdkUri = options.typescript?.tsdkUrl;
 			if (!tsdkUri) {
 				return;
 			}

--- a/packages/language-server/src/common/server.ts
+++ b/packages/language-server/src/common/server.ts
@@ -62,11 +62,9 @@ export function startCommonLanguageServer(connection: vscode.Connection, _plugin
 				},
 			},
 		};
-		ts = options.typescript
-			? await context.server.runtimeEnv.loadTypescript(options.typescript.tsdk)
-			: undefined;
-		tsLocalized = options.typescript && initParams.locale
-			? await context.server.runtimeEnv.loadTypescriptLocalized(options.typescript.tsdk, initParams.locale)
+		ts = await context.server.runtimeEnv.loadTypeScript(options);
+		tsLocalized = initParams.locale
+			? await context.server.runtimeEnv.loadTypeScriptLocalized(options, initParams.locale)
 			: undefined;
 		cancelTokenHost = createCancellationTokenHost(options.cancellationPipeName);
 		plugins = context.server.plugins.map(plugin => plugin(options, { typescript: ts }));

--- a/packages/language-server/src/node/index.ts
+++ b/packages/language-server/src/node/index.ts
@@ -92,7 +92,11 @@ export function startLanguageServer(connection: vscode.Connection, ...plugins: L
 				return { dispose: () => clearImmediate(handle) };
 			},
 		},
-		loadTypescript(tsdk) {
+		loadTypeScript(options) {
+			const tsdk = options.typescript?.tsdk;
+			if (!tsdk) {
+				return;
+			}
 			for (const name of ['./typescript.js', './tsserverlibrary.js']) {
 				try {
 					return require(require.resolve(name, { paths: [tsdk] }));
@@ -108,7 +112,11 @@ export function startLanguageServer(connection: vscode.Connection, ...plugins: L
 
 			throw new Error(`Can't find typescript.js or tsserverlibrary.js in ${tsdk}`);
 		},
-		async loadTypescriptLocalized(tsdk, locale) {
+		async loadTypeScriptLocalized(options, locale) {
+			const tsdk = options.typescript?.tsdk;
+			if (!tsdk) {
+				return;
+			}
 			try {
 				const path = require.resolve(`./${locale}/diagnosticMessages.generated.json`, { paths: [tsdk] });
 				return require(path);

--- a/packages/language-server/src/types.ts
+++ b/packages/language-server/src/types.ts
@@ -59,7 +59,7 @@ export interface InitializationOptions {
 		/**
 		 * URI to node_modules/typescript/lib, available for web
 		 */
-		tsdkUri: string;
+		tsdkUrl: string;
 	};
 	l10n?: {
 		location: string; // uri

--- a/packages/language-server/src/types.ts
+++ b/packages/language-server/src/types.ts
@@ -58,6 +58,9 @@ export interface InitializationOptions {
 		tsdk: string;
 		/**
 		 * URI to node_modules/typescript/lib, available for web
+		 * @example "https://cdn.jsdelivr.net/npm/typescript"
+		 * @example "https://cdn.jsdelivr.net/npm/typescript@latest"
+		 * @example "https://cdn.jsdelivr.net/npm/typescript@5.0.0"
 		 */
 		tsdkUrl: string;
 	};

--- a/packages/language-server/src/types.ts
+++ b/packages/language-server/src/types.ts
@@ -14,7 +14,7 @@ export interface Timer {
 export interface RuntimeEnvironment {
 	uriToFileName(uri: string): string;
 	fileNameToUri(fileName: string): string;
-	loadTypescript(tsdk: string): typeof import('typescript/lib/tsserverlibrary');
+	loadTypescript(tsdk: string): Promise<typeof import('typescript/lib/tsserverlibrary')>;
 	loadTypescriptLocalized(tsdk: string, locale: string): Promise<{} | undefined>;
 	fs: FileSystem;
 	// https://github.com/microsoft/vscode/blob/7927075f89db213bc6e2182fa684d514d69e2359/extensions/html-language-features/server/src/htmlServer.ts#L53-L56

--- a/packages/language-server/src/types.ts
+++ b/packages/language-server/src/types.ts
@@ -14,8 +14,8 @@ export interface Timer {
 export interface RuntimeEnvironment {
 	uriToFileName(uri: string): string;
 	fileNameToUri(fileName: string): string;
-	loadTypescript(tsdk: string): Promise<typeof import('typescript/lib/tsserverlibrary')>;
-	loadTypescriptLocalized(tsdk: string, locale: string): Promise<{} | undefined>;
+	loadTypeScript(options: InitializationOptions): Promise<typeof import('typescript/lib/tsserverlibrary') | undefined>;
+	loadTypeScriptLocalized(options: InitializationOptions, locale: string): Promise<{} | undefined>;
 	fs: FileSystem;
 	// https://github.com/microsoft/vscode/blob/7927075f89db213bc6e2182fa684d514d69e2359/extensions/html-language-features/server/src/htmlServer.ts#L53-L56
 	timer: Timer;
@@ -53,9 +53,13 @@ export enum DiagnosticModel {
 export interface InitializationOptions {
 	typescript?: {
 		/**
-		 * Absolute path to node_modules/typescript/lib
+		 * Absolute path to node_modules/typescript/lib, available for node
 		 */
 		tsdk: string;
+		/**
+		 * URI to node_modules/typescript/lib, available for web
+		 */
+		tsdkUri: string;
 	};
 	l10n?: {
 		location: string; // uri

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,7 +1,7 @@
 lockfileVersion: '6.0'
 
 settings:
-  autoInstallPeers: false
+  autoInstallPeers: true
   excludeLinksFromLockfile: false
 
 importers:
@@ -39,6 +39,9 @@ importers:
       typesafe-path:
         specifier: ^0.2.2
         version: 0.2.2
+      typescript:
+        specifier: '*'
+        version: 5.2.2
       vscode-languageserver-textdocument:
         specifier: ^1.0.11
         version: 1.0.11


### PR DESCRIPTION
Fixed downstream must polyfill node modules for typescript. See #70

The language client should pass the typescript url via InitializationOptions.