### PR TITLE
fix(language-server, vscode): Properly handle FS requests on browser

### DIFF
--- a/packages/language-server/src/browser/index.ts
+++ b/packages/language-server/src/browser/index.ts
@@ -3,8 +3,16 @@ import { startCommonLanguageServer } from '../common/server';
 import { LanguageServerPlugin } from '../types';
 import httpSchemaRequestHandler from '../common/schemaRequestHandlers/http';
 import { URI } from 'vscode-uri';
-import { FsReadFileRequest, FsReadDirectoryRequest, FsStatRequest } from '../protocol';
-import { FileType } from '@volar/language-service';
+import {
+	FsReadFileRequest,
+	FsReadDirectoryRequest,
+	FsStatRequest,
+	FsCacheRequest,
+	UseReadFileCacheNotification,
+	UseReadDirectoryCacheNotification,
+	UseStatCacheNotification
+} from '../protocol';
+import { FileType, FileStat } from '@volar/language-service';
 
 export * from '../index';
 
@@ -21,6 +29,7 @@ export function startLanguageServer(connection: vscode.Connection, ...plugins: L
 
 	const jobs = new Map<Promise<any>, string>();
 
+	let cache: ReturnType<typeof requestCache> | undefined;
 	let fsProgress: Promise<vscode.WorkDoneProgressServerReporter> | undefined;
 	let totalJobs = 0;
 
@@ -80,6 +89,16 @@ export function startLanguageServer(connection: vscode.Connection, ...plugins: L
 					}
 					return undefined;
 				}
+				if (!cache) {
+					cache = requestCache();
+				}
+				const _cache = await cache;
+				if (_cache.stat.has(uri)) {
+					const res = _cache.stat.get(uri)!;
+					_cache.stat.delete(uri);
+					connection.sendNotification(UseStatCacheNotification.type, uri);
+					return res;
+				}
 				return await connection.sendRequest(FsStatRequest.type, uri);
 			},
 			async readFile(uri) {
@@ -90,6 +109,16 @@ export function startLanguageServer(connection: vscode.Connection, ...plugins: L
 					return await httpSchemaRequestHandler(uri);
 				}
 				return withProgress(async () => {
+					if (!cache) {
+						cache = requestCache();
+					}
+					const _cache = await cache;
+					if (_cache.readFile.has(uri)) {
+						const res = _cache.readFile.get(uri)!;
+						_cache.readFile.delete(uri);
+						connection.sendNotification(UseReadFileCacheNotification.type, uri);
+						return res;
+					}
 					return await connection.sendRequest(FsReadFileRequest.type, uri) ?? undefined;
 				}, uri);
 			},
@@ -101,6 +130,16 @@ export function startLanguageServer(connection: vscode.Connection, ...plugins: L
 					return [];
 				}
 				return withProgress(async () => {
+					if (!cache) {
+						cache = requestCache();
+					}
+					const _cache = await cache;
+					if (_cache.readDirectory.has(uri)) {
+						const res = _cache.readDirectory.get(uri)!;
+						_cache.readDirectory.delete(uri);
+						connection.sendNotification(UseReadDirectoryCacheNotification.type, uri);
+						return res;
+					}
 					return await connection.sendRequest(FsReadDirectoryRequest.type, uri);
 				}, uri);
 			},
@@ -109,6 +148,30 @@ export function startLanguageServer(connection: vscode.Connection, ...plugins: L
 			return original ?? vscode.CancellationToken.None;
 		},
 	}));
+
+	async function requestCache() {
+
+		const stat = new Map<string, FileStat>();
+		const readDirectory = new Map<string, [string, FileType][]>();
+		const readFile = new Map<string, string>();
+		const cache = await connection.sendRequest(FsCacheRequest.type);
+
+		for (const [uri, fileStat] of cache?.stat ?? []) {
+			stat.set(uri, fileStat);
+		}
+		for (const [uri, entries] of cache?.readDirectory ?? []) {
+			readDirectory.set(uri, entries);
+		}
+		for (const [uri, text] of cache?.readFile ?? []) {
+			readFile.set(uri, text);
+		}
+
+		return {
+			stat,
+			readDirectory,
+			readFile,
+		};
+	}
 
 	async function withProgress<T>(fn: () => Promise<T>, asset: string): Promise<T> {
 		const path = URI.parse(asset).path;

--- a/packages/language-server/src/browser/index.ts
+++ b/packages/language-server/src/browser/index.ts
@@ -114,7 +114,7 @@ export function startLanguageServer(connection: vscode.Connection, ...plugins: L
 		const path = URI.parse(asset).path;
 		if (!fsProgress) {
 			fsProgress = connection.window.createWorkDoneProgress();
-			fsProgress.then(progress => progress.begin('Load', 0, path));
+			fsProgress.then(progress => progress.begin(''));
 		}
 		const _fsProgress = await fsProgress;
 		totalJobs++;
@@ -122,6 +122,10 @@ export function startLanguageServer(connection: vscode.Connection, ...plugins: L
 		try {
 			job = fn();
 			jobs.set(job, path);
+			for (const [_, path] of jobs) {
+				_fsProgress.report((totalJobs - jobs.size) / totalJobs * 100, `Loading ${totalJobs - jobs.size} of ${totalJobs} files: ${path}`);
+				break;
+			}
 			return await job;
 		} finally {
 			jobs.delete(job);
@@ -131,7 +135,7 @@ export function startLanguageServer(connection: vscode.Connection, ...plugins: L
 			}
 			else {
 				for (const [_, path] of jobs) {
-					_fsProgress.report((totalJobs - jobs.size) / totalJobs * 100, path);
+					_fsProgress.report((totalJobs - jobs.size) / totalJobs * 100, `Loading ${totalJobs - jobs.size} of ${totalJobs} files: ${path}`);
 					break;
 				}
 			}

--- a/packages/language-server/src/browser/index.ts
+++ b/packages/language-server/src/browser/index.ts
@@ -114,7 +114,7 @@ export function startLanguageServer(connection: vscode.Connection, ...plugins: L
 		const path = URI.parse(asset).path;
 		if (!fsProgress) {
 			fsProgress = connection.window.createWorkDoneProgress();
-			fsProgress.then(progress => progress.begin(''));
+			fsProgress.then(progress => progress.begin('', 0));
 		}
 		const _fsProgress = await fsProgress;
 		totalJobs++;
@@ -123,7 +123,7 @@ export function startLanguageServer(connection: vscode.Connection, ...plugins: L
 			job = fn();
 			jobs.set(job, path);
 			for (const [_, path] of jobs) {
-				_fsProgress.report((totalJobs - jobs.size) / totalJobs * 100, `Loading ${totalJobs - jobs.size} of ${totalJobs} files: ${path}`);
+				_fsProgress.report(0, `Loading ${totalJobs - jobs.size} of ${totalJobs} files: ${path}`);
 				break;
 			}
 			return await job;

--- a/packages/language-server/src/common/project.ts
+++ b/packages/language-server/src/common/project.ts
@@ -189,17 +189,17 @@ export async function createProject(context: ProjectContext) {
 			}
 		}
 
-		for (const change of changes) {
+		await Promise.all(changes.map(async change => {
 			if (askedFiles.uriGet(change.uri) && globalSnapshots.get(fs)!.uriGet(change.uri)) {
 				if (change.type === vscode.FileChangeType.Changed) {
-					updateRootScriptSnapshot(change.uri);
+					await updateRootScriptSnapshot(change.uri);
 				}
 				else if (change.type === vscode.FileChangeType.Deleted) {
 					globalSnapshots.get(fs)!.uriSet(change.uri, undefined);
 				}
 				projectVersion++;
 			}
-		}
+		}));
 
 		if (oldProjectVersion !== projectVersion) {
 			token = context.server.runtimeEnv.getCancellationToken();

--- a/packages/language-server/src/common/project.ts
+++ b/packages/language-server/src/common/project.ts
@@ -189,17 +189,17 @@ export async function createProject(context: ProjectContext) {
 			}
 		}
 
-		await Promise.all(changes.map(async change => {
+		for (const change of changes) {
 			if (askedFiles.uriGet(change.uri) && globalSnapshots.get(fs)!.uriGet(change.uri)) {
 				if (change.type === vscode.FileChangeType.Changed) {
-					await updateRootScriptSnapshot(change.uri);
+					updateRootScriptSnapshot(change.uri);
 				}
 				else if (change.type === vscode.FileChangeType.Deleted) {
 					globalSnapshots.get(fs)!.uriSet(change.uri, undefined);
 				}
 				projectVersion++;
 			}
-		}));
+		}
 
 		if (oldProjectVersion !== projectVersion) {
 			token = context.server.runtimeEnv.getCancellationToken();

--- a/packages/language-server/src/protocol.ts
+++ b/packages/language-server/src/protocol.ts
@@ -19,6 +19,27 @@ export namespace FsStatRequest {
 	export const type = new vscode.RequestType<vscode.DocumentUri, FileStat, unknown>('volar/server/fs/stat');
 }
 
+export namespace FsCacheRequest {
+	export type ResponseType = {
+		stat: [string, FileStat][];
+		readDirectory: [string, [string, FileType][]][];
+		readFile: [string, string][];
+	} | null | undefined;
+	export const type = new vscode.RequestType0<ResponseType, unknown>('volar/server/fs/cache');
+}
+
+export namespace UseReadFileCacheNotification {
+	export const type = new vscode.NotificationType<vscode.DocumentUri>('volar/server/fs/readFile/cache');
+}
+
+export namespace UseReadDirectoryCacheNotification {
+	export const type = new vscode.NotificationType<vscode.DocumentUri>('volar/server/fs/readDirectory/cache');
+}
+
+export namespace UseStatCacheNotification {
+	export const type = new vscode.NotificationType<vscode.DocumentUri>('volar/server/fs/stat/cache');
+}
+
 /**
  * Client request server
  */

--- a/packages/language-server/src/protocol.ts
+++ b/packages/language-server/src/protocol.ts
@@ -19,27 +19,6 @@ export namespace FsStatRequest {
 	export const type = new vscode.RequestType<vscode.DocumentUri, FileStat, unknown>('volar/server/fs/stat');
 }
 
-export namespace FsCacheRequest {
-	export type ResponseType = {
-		stat: [string, FileStat][];
-		readDirectory: [string, [string, FileType][]][];
-		readFile: [string, string][];
-	} | null | undefined;
-	export const type = new vscode.RequestType0<ResponseType, unknown>('volar/server/fs/cache');
-}
-
-export namespace UseReadFileCacheNotification {
-	export const type = new vscode.NotificationType<vscode.DocumentUri>('volar/server/fs/readFile/cache');
-}
-
-export namespace UseReadDirectoryCacheNotification {
-	export const type = new vscode.NotificationType<vscode.DocumentUri>('volar/server/fs/readDirectory/cache');
-}
-
-export namespace UseStatCacheNotification {
-	export const type = new vscode.NotificationType<vscode.DocumentUri>('volar/server/fs/stat/cache');
-}
-
 /**
  * Client request server
  */

--- a/packages/vscode/browser.d.ts
+++ b/packages/vscode/browser.d.ts
@@ -1,0 +1,1 @@
+export * from 'vscode-languageclient/browser';

--- a/packages/vscode/browser.js
+++ b/packages/vscode/browser.js
@@ -1,0 +1,1 @@
+module.exports = require('vscode-languageclient/node');

--- a/packages/vscode/node.d.ts
+++ b/packages/vscode/node.d.ts
@@ -1,0 +1,1 @@
+export * from 'vscode-languageclient/browser';

--- a/packages/vscode/node.js
+++ b/packages/vscode/node.js
@@ -1,0 +1,1 @@
+module.exports = require('vscode-languageclient/node');

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -15,20 +15,12 @@
 	"dependencies": {
 		"@volar/language-server": "1.10.10",
 		"path-browserify": "^1.0.1",
+		"vscode-languageclient": "^9.0.1",
 		"vscode-nls": "^5.2.0"
 	},
 	"devDependencies": {
 		"@types/node": "latest",
 		"@types/path-browserify": "latest",
-		"@types/vscode": "^1.82.0",
-		"vscode-languageclient": "^9.0.1"
-	},
-	"peerDependencies": {
-		"vscode-languageclient": "^9.0.1"
-	},
-	"peerDependenciesMeta": {
-		"vscode-languageclient": {
-			"optional": true
-		}
+		"@types/vscode": "^1.82.0"
 	}
 }

--- a/packages/vscode/src/features/serverSys.ts
+++ b/packages/vscode/src/features/serverSys.ts
@@ -2,55 +2,90 @@ import * as vscode from 'vscode';
 import type { BaseLanguageClient, State } from 'vscode-languageclient';
 import { FsReadDirectoryRequest, FsReadFileRequest, FsStatRequest } from '@volar/language-server/protocol';
 
-export async function activate(client: BaseLanguageClient) {
+export async function activate(context: vscode.ExtensionContext, client: BaseLanguageClient) {
 
 	const subscriptions: vscode.Disposable[] = [];
 	const textDecoder = new TextDecoder();
 
-	addHandle();
+	addRequestHandlers();
 
 	subscriptions.push(client.onDidChangeState(() => {
 		if (client.state === 2 satisfies State.Running) {
-			addHandle();
+			addRequestHandlers();
 		}
 	}));
 
 	return vscode.Disposable.from(...subscriptions);
 
-	function addHandle() {
+	// To avoid hitting the API hourly limit, we keep requests as low as possible.
+	function addRequestHandlers() {
 
-		subscriptions.push(client.onRequest(FsStatRequest.type, async uri => {
-			const uri2 = client.protocol2CodeConverter.asUri(uri);
-			try {
-				return await vscode.workspace.fs.stat(uri2);
-			}
-			catch (err) {
-				// ignore
-			}
-		}));
+		subscriptions.push(client.onRequest(FsStatRequest.type, stat));
+		subscriptions.push(client.onRequest(FsReadFileRequest.type, readFile));
+		subscriptions.push(client.onRequest(FsReadDirectoryRequest.type, readDirectory));
 
-		subscriptions.push(client.onRequest(FsReadFileRequest.type, async uri => {
-			const uri2 = client.protocol2CodeConverter.asUri(uri);
-			try {
-				const data = await vscode.workspace.fs.readFile(uri2);
-				const text = textDecoder.decode(data);
-				return text;
-			}
-			catch (err) {
-				// ignore
-			}
-		}));
+		async function stat(uri: string) {
 
-		subscriptions.push(client.onRequest(FsReadDirectoryRequest.type, async uri => {
+			// return early
+			const dirUri = uri.substring(0, uri.lastIndexOf('/'));
+			const baseName = uri.substring(uri.lastIndexOf('/') + 1);
+			const entries = await readDirectory(dirUri);
+			if (!entries.some(entry => entry[0] === baseName)) {
+				return;
+			}
+
 			try {
 				const uri2 = client.protocol2CodeConverter.asUri(uri);
-				let data = await vscode.workspace.fs.readDirectory(uri2);
-				data = data.filter(([name]) => !name.startsWith('.'));
-				return data;
+				return await vscode.workspace.fs.stat(uri2);
 			}
 			catch {
+				// ignore
+			}
+		}
+
+		async function readFile(uri: string) {
+
+			// return early
+			const dirUri = uri.substring(0, uri.lastIndexOf('/'));
+			const baseName = uri.substring(uri.lastIndexOf('/') + 1);
+			const entries = await readDirectory(dirUri);
+			if (!entries.some(entry => entry[0] === baseName && entry[1] === vscode.FileType.File)) {
+				return;
+			}
+
+			try {
+				const uri2 = client.protocol2CodeConverter.asUri(uri);
+				const stat = await vscode.workspace.fs.stat(uri2);
+				if (context.workspaceState.get<number>(uri + '?mtime') !== stat.mtime) {
+					const data = textDecoder.decode(await vscode.workspace.fs.readFile(uri2));
+					context.workspaceState.update(uri + '?mtime', stat.mtime);
+					context.workspaceState.update(uri, data);
+				}
+				return context.workspaceState.get<string>(uri)!;
+			}
+			catch {
+				// ignore
+			}
+		}
+
+		async function readDirectory(uri: string): Promise<[string, vscode.FileType][]> {
+			try {
+				const uri2 = client.protocol2CodeConverter.asUri(uri);
+				const stat = await vscode.workspace.fs.stat(uri2);
+				if (context.workspaceState.get<number>(uri + '?mtime') !== stat.mtime) {
+					const data = stat.type === vscode.FileType.Directory
+						? (await vscode.workspace.fs.readDirectory(uri2))
+							.filter(([name]) => !name.startsWith('.'))
+						: [];
+					context.workspaceState.update(uri + '?mtime', stat.mtime);
+					context.workspaceState.update(uri + '?readdir', data);
+				}
+				return context.workspaceState.get<[string, vscode.FileType][]>(uri + '?readdir')!;
+			}
+			catch {
+				// ignore
 				return [];
 			}
-		}));
+		}
 	}
 }

--- a/packages/vscode/src/features/serverSys.ts
+++ b/packages/vscode/src/features/serverSys.ts
@@ -1,6 +1,14 @@
 import * as vscode from 'vscode';
-import type { BaseLanguageClient, State } from 'vscode-languageclient';
-import { FsReadDirectoryRequest, FsReadFileRequest, FsStatRequest } from '@volar/language-server/protocol';
+import { BaseLanguageClient, State, DidChangeWatchedFilesNotification, FileChangeType } from 'vscode-languageclient';
+import {
+	FsReadDirectoryRequest,
+	FsReadFileRequest,
+	FsStatRequest,
+	FsCacheRequest,
+	UseReadFileCacheNotification,
+	UseReadDirectoryCacheNotification,
+	UseStatCacheNotification
+} from '@volar/language-server/protocol';
 
 export async function activate(context: vscode.ExtensionContext, client: BaseLanguageClient) {
 
@@ -24,32 +32,126 @@ export async function activate(context: vscode.ExtensionContext, client: BaseLan
 		subscriptions.push(client.onRequest(FsReadFileRequest.type, readFile));
 		subscriptions.push(client.onRequest(FsReadDirectoryRequest.type, readDirectory));
 
-		async function stat(uri: string) {
+		subscriptions.push(client.onRequest(FsCacheRequest.type, getCache));
+		subscriptions.push(client.onNotification(UseStatCacheNotification.type, async uri => {
 
-			// return early
-			const dirUri = uri.substring(0, uri.lastIndexOf('/'));
-			const baseName = uri.substring(uri.lastIndexOf('/') + 1);
-			const entries = await readDirectory(dirUri);
-			if (!entries.some(entry => entry[0] === baseName)) {
-				return;
+			const cache = context.workspaceState.get<vscode.FileStat>(uri + '?stat');
+			const _stat = await stat(uri);
+
+			if (_stat?.mtime !== cache?.mtime) {
+				if (cache?.type !== vscode.FileType.File && _stat?.type === vscode.FileType.File) {
+					await client.sendNotification(DidChangeWatchedFilesNotification.type, {
+						changes: [{ uri, type: FileChangeType.Created }]
+					});
+				}
+				else if (cache?.type === vscode.FileType.File && _stat?.type !== vscode.FileType.File) {
+					await client.sendNotification(DidChangeWatchedFilesNotification.type, {
+						changes: [{ uri, type: FileChangeType.Deleted }]
+					});
+				}
+				else {
+					await client.sendNotification(DidChangeWatchedFilesNotification.type, {
+						changes: [{ uri, type: FileChangeType.Changed }]
+					});
+				}
+			}
+		}));
+		subscriptions.push(client.onNotification(UseReadFileCacheNotification.type, async uri => {
+
+			const mtime = context.workspaceState.get<number>(uri + '?mtime');
+			const _stat = await stat(uri);
+
+			if (_stat?.mtime !== mtime) {
+				if (mtime === undefined && _stat?.type === vscode.FileType.File) {
+					await client.sendNotification(DidChangeWatchedFilesNotification.type, {
+						changes: [{ uri, type: FileChangeType.Created }]
+					});
+				}
+				else if (mtime !== undefined && _stat?.type !== vscode.FileType.File) {
+					await client.sendNotification(DidChangeWatchedFilesNotification.type, {
+						changes: [{ uri, type: FileChangeType.Deleted }]
+					});
+				}
+				else {
+					await client.sendNotification(DidChangeWatchedFilesNotification.type, {
+						changes: [{ uri, type: FileChangeType.Changed }]
+					});
+				}
+			}
+		}));
+		subscriptions.push(client.onNotification(UseReadDirectoryCacheNotification.type, async uri => {
+
+			const mtime = context.workspaceState.get<number>(uri + '?mtime');
+			const _stat = await stat(uri);
+
+			if (_stat?.mtime !== mtime) {
+
+				const oldEntries = (context.workspaceState.get<[string, vscode.FileType][]>(uri + '?readdir') ?? [])
+					.reduce((map, item) => {
+						map.set(item[0], item[1]);
+						return map;
+					}, new Map<string, vscode.FileType>());
+				const newEntries = (await readDirectory(uri))
+					.reduce((map, item) => {
+						map.set(item[0], item[1]);
+						return map;
+					}, new Map<string, vscode.FileType>());
+				const changes: { uri: string, type: FileChangeType; }[] = [];
+
+				for (const [name, fileType] of oldEntries) {
+					if (fileType === vscode.FileType.File && newEntries.get(name) !== vscode.FileType.File) {
+						changes.push({ uri: uri + '/' + name, type: FileChangeType.Deleted });
+					}
+				}
+				for (const [name, fileType] of newEntries) {
+					if (fileType === vscode.FileType.File && oldEntries.get(name) !== vscode.FileType.File) {
+						changes.push({ uri: uri + '/' + name, type: FileChangeType.Changed });
+					}
+				}
+
+				await client.sendNotification(DidChangeWatchedFilesNotification.type, { changes });
+			}
+		}));
+
+		function getCache() {
+
+			const res: FsCacheRequest.ResponseType = {
+				stat: [],
+				readDirectory: [],
+				readFile: [],
+			};
+
+			for (const key of context.workspaceState.keys()) {
+				const value = context.workspaceState.get(key)!;
+				if (key.endsWith('?stat')) {
+					res.stat.push([key.slice(0, -'?stat'.length), value as vscode.FileStat]);
+				}
+				else if (key.endsWith('?readdir')) {
+					res.readDirectory.push([key.slice(0, -'?readdir'.length), value as [string, vscode.FileType][]]);
+				}
+				else if (!key.includes('?')) {
+					res.readFile.push([key, value as string]);
+				}
 			}
 
+			return res;
+		}
+
+		async function stat(uri: string) {
+
 			const uri2 = client.protocol2CodeConverter.asUri(uri);
-			return await _stat(uri2);
+			const stat = await _stat(uri2);
+
+			context.workspaceState.update(uri + '?stat', stat);
+
+			return stat;
 		}
 
 		async function readFile(uri: string) {
 
-			// return early
-			const dirUri = uri.substring(0, uri.lastIndexOf('/'));
-			const baseName = uri.substring(uri.lastIndexOf('/') + 1);
-			const entries = await readDirectory(dirUri);
-			if (!entries.some(entry => entry[0] === baseName && entry[1] === vscode.FileType.File)) {
-				return;
-			}
-
 			const uri2 = client.protocol2CodeConverter.asUri(uri);
 			const stat = await _stat(uri2);
+
 			if (context.workspaceState.get<number>(uri + '?mtime') !== stat?.mtime) {
 				if (stat) {
 					const data = await _readFile(uri2);
@@ -61,12 +163,15 @@ export async function activate(context: vscode.ExtensionContext, client: BaseLan
 					context.workspaceState.update(uri, undefined);
 				}
 			}
-			return context.workspaceState.get<string>(uri)!;
+
+			return context.workspaceState.get<string>(uri);
 		}
 
 		async function readDirectory(uri: string): Promise<[string, vscode.FileType][]> {
+
 			const uri2 = client.protocol2CodeConverter.asUri(uri);
 			const stat = await _stat(uri2);
+
 			if (context.workspaceState.get<number>(uri + '?mtime') !== stat?.mtime) {
 				if (stat) {
 					const data = stat.type === vscode.FileType.Directory
@@ -81,7 +186,8 @@ export async function activate(context: vscode.ExtensionContext, client: BaseLan
 					context.workspaceState.update(uri + '?readdir', undefined);
 				}
 			}
-			return context.workspaceState.get<[string, vscode.FileType][]>(uri + '?readdir')!;
+
+			return context.workspaceState.get<[string, vscode.FileType][]>(uri + '?readdir') ?? [];
 		}
 
 		async function _readFile(uri: vscode.Uri) {

--- a/packages/vscode/src/features/serverSys.ts
+++ b/packages/vscode/src/features/serverSys.ts
@@ -6,6 +6,10 @@ export async function activate(context: vscode.ExtensionContext, client: BaseLan
 
 	const subscriptions: vscode.Disposable[] = [];
 	const textDecoder = new TextDecoder();
+	const jobs = new Map<Promise<any>, string>();
+
+	let startProgress = false;
+	let totalJobs = 0;
 
 	addRequestHandlers();
 
@@ -21,8 +25,43 @@ export async function activate(context: vscode.ExtensionContext, client: BaseLan
 	function addRequestHandlers() {
 
 		subscriptions.push(client.onRequest(FsStatRequest.type, stat));
-		subscriptions.push(client.onRequest(FsReadFileRequest.type, readFile));
-		subscriptions.push(client.onRequest(FsReadDirectoryRequest.type, readDirectory));
+		subscriptions.push(client.onRequest(FsReadFileRequest.type, uri => {
+			return withProgress(() => readFile(uri), uri);
+		}));
+		subscriptions.push(client.onRequest(FsReadDirectoryRequest.type, uri => {
+			return withProgress(() => readDirectory(uri), uri);
+		}));
+
+		async function withProgress<T>(fn: () => Promise<T>, asset: string): Promise<T> {
+			asset = vscode.Uri.parse(asset).path;
+			totalJobs++;
+			let job!: Promise<T>;
+			try {
+				job = fn();
+				jobs.set(job, asset);
+				if (!startProgress && jobs.size >= 10) {
+					startProgress = true;
+					vscode.window.withProgress({ location: vscode.ProgressLocation.Notification }, async progress => {
+						progress.report({
+							message: `Loading ${totalJobs} resources: ${asset}`
+						});
+						while (jobs.size) {
+							for (const [_, asset] of jobs) {
+								progress.report({
+									message: `Loading ${totalJobs} resources: ${asset}`,
+								});
+								await sleep(100);
+								break;
+							}
+						}
+						startProgress = false;
+					});
+				}
+				return await job;
+			} finally {
+				jobs.delete(job);
+			}
+		}
 
 		async function stat(uri: string) {
 
@@ -113,4 +152,8 @@ export async function activate(context: vscode.ExtensionContext, client: BaseLan
 			} catch { }
 		}
 	}
+}
+
+function sleep(ms: number) {
+	return new Promise(resolve => setTimeout(resolve, ms));
 }

--- a/packages/vscode/src/features/serverSys.ts
+++ b/packages/vscode/src/features/serverSys.ts
@@ -1,14 +1,6 @@
 import * as vscode from 'vscode';
-import { BaseLanguageClient, State, DidChangeWatchedFilesNotification, FileChangeType } from 'vscode-languageclient';
-import {
-	FsReadDirectoryRequest,
-	FsReadFileRequest,
-	FsStatRequest,
-	FsCacheRequest,
-	UseReadFileCacheNotification,
-	UseReadDirectoryCacheNotification,
-	UseStatCacheNotification
-} from '@volar/language-server/protocol';
+import type { BaseLanguageClient, State } from 'vscode-languageclient';
+import { FsReadDirectoryRequest, FsReadFileRequest, FsStatRequest } from '@volar/language-server/protocol';
 
 export async function activate(context: vscode.ExtensionContext, client: BaseLanguageClient) {
 
@@ -32,125 +24,36 @@ export async function activate(context: vscode.ExtensionContext, client: BaseLan
 		subscriptions.push(client.onRequest(FsReadFileRequest.type, readFile));
 		subscriptions.push(client.onRequest(FsReadDirectoryRequest.type, readDirectory));
 
-		subscriptions.push(client.onRequest(FsCacheRequest.type, getCache));
-		subscriptions.push(client.onNotification(UseStatCacheNotification.type, async uri => {
-
-			const cache = context.workspaceState.get<vscode.FileStat>(uri + '?stat');
-			const _stat = await stat(uri);
-
-			if (_stat?.mtime !== cache?.mtime) {
-				if (cache?.type !== vscode.FileType.File && _stat?.type === vscode.FileType.File) {
-					await client.sendNotification(DidChangeWatchedFilesNotification.type, {
-						changes: [{ uri, type: FileChangeType.Created }]
-					});
-				}
-				else if (cache?.type === vscode.FileType.File && _stat?.type !== vscode.FileType.File) {
-					await client.sendNotification(DidChangeWatchedFilesNotification.type, {
-						changes: [{ uri, type: FileChangeType.Deleted }]
-					});
-				}
-				else {
-					await client.sendNotification(DidChangeWatchedFilesNotification.type, {
-						changes: [{ uri, type: FileChangeType.Changed }]
-					});
-				}
-			}
-		}));
-		subscriptions.push(client.onNotification(UseReadFileCacheNotification.type, async uri => {
-
-			const mtime = context.workspaceState.get<number>(uri + '?mtime');
-			const _stat = await stat(uri);
-
-			if (_stat?.mtime !== mtime) {
-				if (mtime === undefined && _stat?.type === vscode.FileType.File) {
-					await client.sendNotification(DidChangeWatchedFilesNotification.type, {
-						changes: [{ uri, type: FileChangeType.Created }]
-					});
-				}
-				else if (mtime !== undefined && _stat?.type !== vscode.FileType.File) {
-					await client.sendNotification(DidChangeWatchedFilesNotification.type, {
-						changes: [{ uri, type: FileChangeType.Deleted }]
-					});
-				}
-				else {
-					await client.sendNotification(DidChangeWatchedFilesNotification.type, {
-						changes: [{ uri, type: FileChangeType.Changed }]
-					});
-				}
-			}
-		}));
-		subscriptions.push(client.onNotification(UseReadDirectoryCacheNotification.type, async uri => {
-
-			const mtime = context.workspaceState.get<number>(uri + '?mtime');
-			const _stat = await stat(uri);
-
-			if (_stat?.mtime !== mtime) {
-
-				const oldEntries = (context.workspaceState.get<[string, vscode.FileType][]>(uri + '?readdir') ?? [])
-					.reduce((map, item) => {
-						map.set(item[0], item[1]);
-						return map;
-					}, new Map<string, vscode.FileType>());
-				const newEntries = (await readDirectory(uri))
-					.reduce((map, item) => {
-						map.set(item[0], item[1]);
-						return map;
-					}, new Map<string, vscode.FileType>());
-				const changes: { uri: string, type: FileChangeType; }[] = [];
-
-				for (const [name, fileType] of oldEntries) {
-					if (fileType === vscode.FileType.File && newEntries.get(name) !== vscode.FileType.File) {
-						changes.push({ uri: uri + '/' + name, type: FileChangeType.Deleted });
-					}
-				}
-				for (const [name, fileType] of newEntries) {
-					if (fileType === vscode.FileType.File && oldEntries.get(name) !== vscode.FileType.File) {
-						changes.push({ uri: uri + '/' + name, type: FileChangeType.Changed });
-					}
-				}
-
-				await client.sendNotification(DidChangeWatchedFilesNotification.type, { changes });
-			}
-		}));
-
-		function getCache() {
-
-			const res: FsCacheRequest.ResponseType = {
-				stat: [],
-				readDirectory: [],
-				readFile: [],
-			};
-
-			for (const key of context.workspaceState.keys()) {
-				const value = context.workspaceState.get(key)!;
-				if (key.endsWith('?stat')) {
-					res.stat.push([key.slice(0, -'?stat'.length), value as vscode.FileStat]);
-				}
-				else if (key.endsWith('?readdir')) {
-					res.readDirectory.push([key.slice(0, -'?readdir'.length), value as [string, vscode.FileType][]]);
-				}
-				else if (!key.includes('?')) {
-					res.readFile.push([key, value as string]);
-				}
-			}
-
-			return res;
-		}
-
 		async function stat(uri: string) {
 
+			// return early
+			const dirUri = uri.substring(0, uri.lastIndexOf('/'));
+			const baseName = uri.substring(uri.lastIndexOf('/') + 1);
+			const entries = await readDirectory(dirUri);
+			if (!entries.some(entry => entry[0] === baseName)) {
+				return;
+			}
+
 			const uri2 = client.protocol2CodeConverter.asUri(uri);
-			const stat = await _stat(uri2);
-
-			context.workspaceState.update(uri + '?stat', stat);
-
-			return stat;
+			return await _stat(uri2);
 		}
 
 		async function readFile(uri: string) {
 
+			// return early
+			const dirUri = uri.substring(0, uri.lastIndexOf('/'));
+			const baseName = uri.substring(uri.lastIndexOf('/') + 1);
+			const entries = await readDirectory(dirUri);
 			const uri2 = client.protocol2CodeConverter.asUri(uri);
-			const stat = await _stat(uri2);
+
+			let stat: vscode.FileStat | undefined;
+
+			if (!entries.some(entry => entry[0] === baseName && entry[1] === vscode.FileType.File)) {
+				stat = undefined;
+			}
+			else {
+				stat = await _stat(uri2);
+			}
 
 			if (context.workspaceState.get<number>(uri + '?mtime') !== stat?.mtime) {
 				if (stat) {
@@ -187,7 +90,7 @@ export async function activate(context: vscode.ExtensionContext, client: BaseLan
 				}
 			}
 
-			return context.workspaceState.get<[string, vscode.FileType][]>(uri + '?readdir') ?? [];
+			return await context.workspaceState.get<[string, vscode.FileType][]>(uri + '?readdir') ?? [];
 		}
 
 		async function _readFile(uri: vscode.Uri) {

--- a/packages/vscode/src/index.ts
+++ b/packages/vscode/src/index.ts
@@ -8,6 +8,8 @@ export { activate as activateTsConfigStatusItem } from './features/tsconfig';
 export { activate as activateServerSys } from './features/serverSys';
 export { activate as activateTsVersionStatusItem, getTsdk } from './features/tsVersion';
 
+export * from 'vscode-languageclient';
+
 export function takeOverModeActive(context: vscode.ExtensionContext) {
 	if (vscode.workspace.getConfiguration('volar').get<string>('takeOverMode.extension') === context.extension.id) {
 		return !vscode.extensions.getExtension('vscode.typescript-language-features');

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -196,9 +196,6 @@ importers:
       path-browserify:
         specifier: ^1.0.1
         version: 1.0.1
-      vscode-languageclient:
-        specifier: ^9.0.1
-        version: 9.0.1
       vscode-nls:
         specifier: ^5.2.0
         version: 5.2.0
@@ -212,6 +209,9 @@ importers:
       '@types/vscode':
         specifier: ^1.82.0
         version: 1.83.0
+      vscode-languageclient:
+        specifier: ^9.0.1
+        version: 9.0.1
 
 packages:
 
@@ -3811,6 +3811,7 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       brace-expansion: 2.0.1
+    dev: true
 
   /minimatch@9.0.3:
     resolution: {integrity: sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==}
@@ -5916,6 +5917,7 @@ packages:
       minimatch: 5.1.6
       semver: 7.5.4
       vscode-languageserver-protocol: 3.17.5
+    dev: true
 
   /vscode-languageserver-protocol@3.17.5:
     resolution: {integrity: sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -196,6 +196,9 @@ importers:
       path-browserify:
         specifier: ^1.0.1
         version: 1.0.1
+      vscode-languageclient:
+        specifier: ^9.0.1
+        version: 9.0.1
       vscode-nls:
         specifier: ^5.2.0
         version: 5.2.0
@@ -209,9 +212,6 @@ importers:
       '@types/vscode':
         specifier: ^1.82.0
         version: 1.83.0
-      vscode-languageclient:
-        specifier: ^9.0.1
-        version: 9.0.1
 
 packages:
 
@@ -3811,7 +3811,6 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       brace-expansion: 2.0.1
-    dev: true
 
   /minimatch@9.0.3:
     resolution: {integrity: sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==}
@@ -5917,7 +5916,6 @@ packages:
       minimatch: 5.1.6
       semver: 7.5.4
       vscode-languageserver-protocol: 3.17.5
-    dev: true
 
   /vscode-languageserver-protocol@3.17.5:
     resolution: {integrity: sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg==}


### PR DESCRIPTION
This PR only affects the browser language server.

- ~~Determine whether to send `fs.readDirectory`, `fs.readFile` requests based on `mtime` response by `fs.stat`, otherwise use the `workspaceState` cache~~ This reduces performance in real-world situations
- Loading files should show a progress bar
- language server no longer caches readDirectory