### PR TITLE
refactor: `LanguageHost` -> `ProjectHost`

### DIFF
--- a/packages/kit/lib/createFormatter.ts
+++ b/packages/kit/lib/createFormatter.ts
@@ -1,4 +1,4 @@
-import { Config, FormattingOptions, TypeScriptLanguageHost, createLanguageService } from '@volar/language-service';
+import { Config, FormattingOptions, TypeScriptProjectHost, createLanguageService } from '@volar/language-service';
 import { TextDocument } from 'vscode-languageserver-textdocument';
 import { URI } from 'vscode-uri';
 import { asPosix, defaultCompilerOptions, fileNameToUri, fs, getConfiguration, uriToFileName } from './utils';
@@ -36,7 +36,7 @@ export function createFormatter(
 			console,
 		},
 		config,
-		createHost(),
+		createProjectHost(),
 	);
 
 	return {
@@ -75,9 +75,9 @@ export function createFormatter(
 		return content;
 	}
 
-	function createHost() {
+	function createProjectHost() {
 		let projectVersion = 0;
-		const host: TypeScriptLanguageHost = {
+		const host: TypeScriptProjectHost = {
 			workspacePath: '/',
 			rootPath: '/',
 			getCompilationSettings: () => compilerOptions,

--- a/packages/kit/lib/createLinter.ts
+++ b/packages/kit/lib/createLinter.ts
@@ -1,10 +1,10 @@
-import { CodeActionTriggerKind, Config, Diagnostic, DiagnosticSeverity, TypeScriptLanguageHost, createLanguageService, mergeWorkspaceEdits } from '@volar/language-service';
+import { CodeActionTriggerKind, Config, Diagnostic, DiagnosticSeverity, ProjectHost, createLanguageService, mergeWorkspaceEdits } from '@volar/language-service';
 import type * as ts from 'typescript/lib/tsserverlibrary';
 import { TextDocument } from 'vscode-languageserver-textdocument';
 import { asPosix, fileNameToUri, fs, getConfiguration, uriToFileName } from './utils';
 import { URI } from 'vscode-uri';
 
-export function createLinter(config: Config, host: TypeScriptLanguageHost) {
+export function createLinter(config: Config, projectHost: ProjectHost) {
 
 	let settings = {} as any;
 
@@ -14,14 +14,14 @@ export function createLinter(config: Config, host: TypeScriptLanguageHost) {
 		{
 			uriToFileName,
 			fileNameToUri,
-			workspaceUri: URI.parse(fileNameToUri(host.workspacePath)),
-			rootUri: URI.parse(fileNameToUri(host.rootPath)),
+			workspaceUri: URI.parse(fileNameToUri(projectHost.workspacePath)),
+			rootUri: URI.parse(fileNameToUri(projectHost.rootPath)),
 			getConfiguration: section => getConfiguration(settings, section),
 			fs,
 			console,
 		},
 		config,
-		host,
+		projectHost,
 	);
 
 	return {

--- a/packages/kit/lib/createProject.ts
+++ b/packages/kit/lib/createProject.ts
@@ -1,4 +1,4 @@
-import type { TypeScriptLanguageHost } from '@volar/language-service';
+import type { TypeScriptProjectHost } from '@volar/language-service';
 import * as path from 'typesafe-path/posix';
 import type * as ts from 'typescript/lib/tsserverlibrary';
 import { asPosix, defaultCompilerOptions } from './utils';
@@ -45,7 +45,7 @@ export function createProject(
 function createProjectBase(rootPath: string, createParsedCommandLine: () => Pick<ts.ParsedCommandLine, 'options' | 'fileNames'>) {
 
 	const ts = require('typescript') as typeof import('typescript/lib/tsserverlibrary');
-	const languageHost: TypeScriptLanguageHost = {
+	const languageHost: TypeScriptProjectHost = {
 		workspacePath: rootPath,
 		rootPath: rootPath,
 		getCompilationSettings: () => {

--- a/packages/language-core/lib/languageContext.ts
+++ b/packages/language-core/lib/languageContext.ts
@@ -1,16 +1,14 @@
 import { createVirtualFiles } from './virtualFiles';
-import { Language, TypeScriptLanguageHost } from './types';
+import { Language, ProjectHost } from './types';
 import type * as ts from 'typescript/lib/tsserverlibrary';
 
-export interface LanguageContext {
-	rawHost: TypeScriptLanguageHost;
-	host: TypeScriptLanguageHost;
+export function createProxyHostAndVirtualFiles<P extends ProjectHost = ProjectHost>(projectHost: P, languages: Language<any, P>[]): {
+	rawHost: P;
+	host: P;
 	virtualFiles: ReturnType<typeof createVirtualFiles>;
-}
+} {
 
-export function createLanguageContext(rawHost: TypeScriptLanguageHost, languages: Language<any>[]): LanguageContext {
-
-	let host = rawHost;
+	let host = projectHost;
 	let lastRootFiles = new Map<string, ts.IScriptSnapshot | undefined>();
 	let lastProjectVersion: number | string | undefined;
 
@@ -36,7 +34,7 @@ export function createLanguageContext(rawHost: TypeScriptLanguageHost, languages
 	}
 
 	return {
-		rawHost,
+		rawHost: projectHost,
 		host,
 		virtualFiles: new Proxy(virtualFiles, {
 			get: (target, property) => {

--- a/packages/language-core/lib/types.ts
+++ b/packages/language-core/lib/types.ts
@@ -85,26 +85,26 @@ export interface VirtualFile {
 	embeddedFiles: VirtualFile[],
 }
 
-export interface Language<T extends VirtualFile = VirtualFile> {
-	resolveHost?(host: TypeScriptLanguageHost): TypeScriptLanguageHost;
+export interface Language<T extends VirtualFile = VirtualFile, P extends ProjectHost = ProjectHost> {
+	resolveHost?(host: P): P;
 	createVirtualFile(fileName: string, snapshot: ts.IScriptSnapshot, languageId: string | undefined): T | undefined;
 	updateVirtualFile(virtualFile: T, snapshot: ts.IScriptSnapshot): void;
 	deleteVirtualFile?(virtualFile: T): void;
 }
 
-interface LanguageHost {
+export interface ProjectHost {
 	workspacePath: string;
 	rootPath: string;
 	getProjectVersion(): string;
 	getScriptFileNames(): string[];
 	getScriptSnapshot(fileName: string): ts.IScriptSnapshot | undefined;
 	getLanguageId?(fileName: string): string | undefined;
+	getCancellationToken?(): ts.HostCancellationToken;
 }
 
-export interface TypeScriptLanguageHost extends LanguageHost, Pick<
+export interface TypeScriptProjectHost extends ProjectHost, Pick<
 	ts.LanguageServiceHost,
-	'getCancellationToken'
-	| 'getLocalizedDiagnosticMessages'
+	'getLocalizedDiagnosticMessages'
 	| 'getCompilationSettings'
 	| 'getProjectReferences'
 > {

--- a/packages/language-server/lib/common/features/languageFeatures.ts
+++ b/packages/language-server/lib/common/features/languageFeatures.ts
@@ -359,7 +359,7 @@ export function register(
 		});
 	}
 	async function getProject(uri: string) {
-		return (await workspaces.getProject(uri))?.project;
+		return await workspaces.getProject(uri);
 	}
 	function fixTextEdit(item: vscode.CompletionItem) {
 		const insertReplaceSupport = initParams.capabilities.textDocument?.completion?.completionItem?.insertReplaceSupport ?? false;

--- a/packages/language-server/lib/types.ts
+++ b/packages/language-server/lib/types.ts
@@ -1,5 +1,5 @@
 import { FileSystem, Console, LanguageService, ServiceEnvironment, SharedModules } from '@volar/language-service';
-import type { TypeScriptLanguageHost } from '@volar/language-core';
+import type { ProjectHost } from '@volar/language-core';
 import type * as ts from 'typescript/lib/tsserverlibrary';
 import * as vscode from 'vscode-languageserver';
 import { Config } from '@volar/language-service';
@@ -31,7 +31,7 @@ export interface LanguageServerPlugin {
 			config: Config,
 			ctx: {
 				env: ServiceEnvironment;
-				host: TypeScriptLanguageHost;
+				host: ProjectHost;
 			} & ProjectContext | undefined,
 		): Config | Promise<Config>;
 		resolveExistingOptions?(options: ts.CompilerOptions | undefined): ts.CompilerOptions | undefined;

--- a/packages/language-service/lib/documentFeatures/format.ts
+++ b/packages/language-service/lib/documentFeatures/format.ts
@@ -282,8 +282,8 @@ export function register(context: ServiceContext) {
 			const [_, map] = maps.get(_sourceFileName)!;
 			const version = fakeVersion++;
 			return new SourceMapWithDocuments(
-				TextDocument.create(context.env.fileNameToUri(_sourceFileName), context.host.getLanguageId?.(_sourceFileName) ?? resolveCommonLanguageId(context.env.fileNameToUri(_sourceFileName)), version, _sourceSnapshot.getText(0, _sourceSnapshot.getLength())),
-				TextDocument.create(context.env.fileNameToUri(file.fileName), context.host.getLanguageId?.(file.fileName) ?? resolveCommonLanguageId(context.env.fileNameToUri(file.fileName)), version, file.snapshot.getText(0, file.snapshot.getLength())),
+				TextDocument.create(context.env.fileNameToUri(_sourceFileName), context.project.host.getLanguageId?.(_sourceFileName) ?? resolveCommonLanguageId(context.env.fileNameToUri(_sourceFileName)), version, _sourceSnapshot.getText(0, _sourceSnapshot.getLength())),
+				TextDocument.create(context.env.fileNameToUri(file.fileName), context.project.host.getLanguageId?.(file.fileName) ?? resolveCommonLanguageId(context.env.fileNameToUri(file.fileName)), version, file.snapshot.getText(0, file.snapshot.getLength())),
 				map,
 			);
 		}

--- a/packages/language-service/lib/documents.ts
+++ b/packages/language-service/lib/documents.ts
@@ -1,4 +1,4 @@
-import { VirtualFiles, VirtualFile, FileRangeCapabilities, MirrorBehaviorCapabilities, MirrorMap, forEachEmbeddedFile, TypeScriptLanguageHost } from '@volar/language-core';
+import { VirtualFiles, VirtualFile, FileRangeCapabilities, MirrorBehaviorCapabilities, MirrorMap, forEachEmbeddedFile, ProjectHost } from '@volar/language-core';
 import { Mapping, SourceMap } from '@volar/source-map';
 import type * as vscode from 'vscode-languageserver-protocol';
 import { TextDocument } from 'vscode-languageserver-textdocument';
@@ -168,7 +168,7 @@ export class MirrorMapWithDocument extends SourceMapWithDocuments<[MirrorBehavio
 
 export function createDocumentsAndSourceMaps(
 	env: ServiceEnvironment,
-	host: TypeScriptLanguageHost,
+	host: ProjectHost,
 	mapper: VirtualFiles,
 ) {
 

--- a/packages/language-service/lib/languageFeatures/validation.ts
+++ b/packages/language-service/lib/languageFeatures/validation.ts
@@ -168,7 +168,7 @@ export function register(context: ServiceContext) {
 			syntax_rules: { errors: [] },
 			format_rules: { errors: [] },
 		}).get(uri)!;
-		const newSnapshot = context.host.getScriptSnapshot(context.env.uriToFileName(uri));
+		const newSnapshot = context.project.host.getScriptSnapshot(context.env.uriToFileName(uri));
 
 		let updateCacheRangeFailed = false;
 		let errorsUpdated = false;
@@ -262,7 +262,7 @@ export function register(context: ServiceContext) {
 
 					const pluginCache = cacheMap.get(ruleId) ?? cacheMap.set(ruleId, new Map()).get(ruleId)!;
 					const cache = pluginCache.get(lintDocument.uri);
-					const projectVersion = (ruleType === RuleType.Semantic) ? context.host.getProjectVersion?.() : undefined;
+					const projectVersion = (ruleType === RuleType.Semantic) ? context.project.host.getProjectVersion?.() : undefined;
 
 					if (ruleType === RuleType.Semantic) {
 						if (cache && cache.documentVersion === lintDocument.version && cache.projectVersion === projectVersion) {
@@ -364,7 +364,7 @@ export function register(context: ServiceContext) {
 					const serviceId = Object.keys(context.services).find(key => context.services[key] === service)!;
 					const serviceCache = cacheMap.get(serviceId) ?? cacheMap.set(serviceId, new Map()).get(serviceId)!;
 					const cache = serviceCache.get(document.uri);
-					const projectVersion = api === 'provideSemanticDiagnostics' ? context.host.getProjectVersion?.() : undefined;
+					const projectVersion = api === 'provideSemanticDiagnostics' ? context.project.host.getProjectVersion?.() : undefined;
 
 					if (api === 'provideSemanticDiagnostics') {
 						if (cache && cache.documentVersion === document.version && cache.projectVersion === projectVersion) {

--- a/packages/language-service/lib/types.ts
+++ b/packages/language-service/lib/types.ts
@@ -1,4 +1,4 @@
-import { Language, LanguageContext } from '@volar/language-core';
+import { Language, ProjectHost, VirtualFiles } from '@volar/language-core';
 import type * as vscode from 'vscode-languageserver-protocol';
 import type { TextDocument } from 'vscode-languageserver-textdocument';
 import { URI } from 'vscode-uri';
@@ -59,7 +59,11 @@ interface Command<T> {
 	is(value: vscode.Command): boolean;
 }
 
-export interface ServiceContext<Provide = any> extends LanguageContext {
+export interface ServiceContext<Provide = any> {
+	project: {
+		host: ProjectHost;
+		virtualFiles: VirtualFiles;
+	};
 	env: ServiceEnvironment;
 	inject<K extends keyof Provide>(key: K, ...args: Provide[K] extends (...args: any) => any ? Parameters<Provide[K]> : never): ReturnType<Provide[K] extends (...args: any) => any ? Provide[K] : never>;
 	getTextDocument(uri: string): TextDocument | undefined;

--- a/packages/monaco/worker.ts
+++ b/packages/monaco/worker.ts
@@ -1,6 +1,6 @@
 import {
 	createLanguageService as _createLanguageService,
-	type TypeScriptLanguageHost,
+	type TypeScriptProjectHost,
 	type Config,
 	type ServiceEnvironment,
 	type SharedModules,
@@ -20,18 +20,18 @@ export function createServiceEnvironment(): ServiceEnvironment {
 	};
 }
 
-export function createLanguageHost(
+export function createProjectHost(
 	getMirrorModels: monaco.worker.IWorkerContext<any>['getMirrorModels'],
 	env: ServiceEnvironment,
 	rootPath: string,
 	compilerOptions: ts.CompilerOptions = {}
-): TypeScriptLanguageHost {
+): TypeScriptProjectHost {
 
 	let projectVersion = 0;
 
 	const modelSnapshot = new WeakMap<monaco.worker.IMirrorModel, readonly [number, ts.IScriptSnapshot]>();
 	const modelVersions = new Map<monaco.worker.IMirrorModel, number>();
-	const host: TypeScriptLanguageHost = {
+	const host: TypeScriptProjectHost = {
 		workspacePath: rootPath,
 		rootPath: rootPath,
 		getProjectVersion() {
@@ -81,7 +81,7 @@ export function createLanguageService<T = {}>(
 	modules: SharedModules,
 	env: ServiceEnvironment,
 	config: Config,
-	host: TypeScriptLanguageHost,
+	host: TypeScriptProjectHost,
 	extraApis: T = {} as any,
 ): LanguageService & T {
 

--- a/packages/typescript/lib/getProgram.ts
+++ b/packages/typescript/lib/getProgram.ts
@@ -1,9 +1,11 @@
 import type * as ts from 'typescript/lib/tsserverlibrary';
 import type * as embedded from '@volar/language-core';
+import type { TypeScriptProjectHost } from './projectHost';
 
 export function getProgram(
 	ts: typeof import('typescript/lib/tsserverlibrary'),
-	core: embedded.LanguageContext,
+	projectHost: TypeScriptProjectHost,
+	virtualFiles: embedded.VirtualFiles,
 	ls: ts.LanguageService,
 	sys: ts.System,
 ): ts.Program {
@@ -67,7 +69,7 @@ export function getProgram(
 
 		if (sourceFile) {
 
-			const [virtualFile, source] = core.virtualFiles.getVirtualFile(sourceFile.fileName);
+			const [virtualFile, source] = virtualFiles.getVirtualFile(sourceFile.fileName);
 
 			if (virtualFile && source) {
 
@@ -106,14 +108,14 @@ export function getProgram(
 				&& diagnostic.length !== undefined
 			) {
 
-				const [virtualFile, source] = core.virtualFiles.getVirtualFile(diagnostic.file.fileName);
+				const [virtualFile, source] = virtualFiles.getVirtualFile(diagnostic.file.fileName);
 
 				if (virtualFile && source) {
 
 					if (sys.fileExists?.(source.fileName) === false)
 						continue;
 
-					for (const [_, [sourceSnapshot, map]] of core.virtualFiles.getMaps(virtualFile)) {
+					for (const [_, [sourceSnapshot, map]] of virtualFiles.getMaps(virtualFile)) {
 
 						if (sourceSnapshot !== source.snapshot)
 							continue;
@@ -160,7 +162,7 @@ export function getProgram(
 			if (!file) {
 
 				if (docText === undefined) {
-					const snapshot = core.host.getScriptSnapshot(fileName);
+					const snapshot = projectHost.getScriptSnapshot(fileName);
 					if (snapshot) {
 						docText = snapshot.getText(0, snapshot.getLength());
 					}

--- a/packages/typescript/lib/getProgram.ts
+++ b/packages/typescript/lib/getProgram.ts
@@ -1,11 +1,10 @@
 import type * as ts from 'typescript/lib/tsserverlibrary';
-import type * as embedded from '@volar/language-core';
-import type { TypeScriptProjectHost } from './projectHost';
+import type { TypeScriptProjectHost, VirtualFiles } from '@volar/language-core';
 
 export function getProgram(
 	ts: typeof import('typescript/lib/tsserverlibrary'),
 	projectHost: TypeScriptProjectHost,
-	virtualFiles: embedded.VirtualFiles,
+	virtualFiles: VirtualFiles,
 	ls: ts.LanguageService,
 	sys: ts.System,
 ): ts.Program {

--- a/packages/typescript/lib/languageServiceHost.ts
+++ b/packages/typescript/lib/languageServiceHost.ts
@@ -1,8 +1,7 @@
-import type { FileKind, VirtualFile, VirtualFiles } from '@volar/language-core';
+import type { FileKind, TypeScriptProjectHost, VirtualFile, VirtualFiles } from '@volar/language-core';
 import type * as ts from 'typescript/lib/tsserverlibrary';
 import * as path from 'path-browserify';
 import { matchFiles } from './typescript/utilities';
-import { TypeScriptProjectHost } from './projectHost';
 
 const fileVersions = new Map<string, { lastVersion: number; snapshotVersions: WeakMap<ts.IScriptSnapshot, number>; }>();
 


### PR DESCRIPTION
The `LanguageHost`, `TypeScriptLanguageHost` interface was renamed to `ProjectHost`, `TypeScriptProjectHost` for more accurate meaning.

This is a pre-PR. The `TypeScriptProjectHost` interface and implementation will be abstract from the core to `@volar/typescript`. Downstream tools should be able to build project-aware language tooling (such as Deno) that has nothing to do with typescript, or non-project-aware language tooling (such as CSS). , JSON...).