### PR TITLE
Convert @volar/monaco to ESM

### DIFF
--- a/packages/monaco/index.ts
+++ b/packages/monaco/index.ts
@@ -1,2 +1,2 @@
-export * from './lib/editor';
-export * from './lib/languages';
+export * from './lib/editor.js';
+export * from './lib/languages.js';

--- a/packages/monaco/lib/editor.ts
+++ b/packages/monaco/lib/editor.ts
@@ -1,8 +1,8 @@
 import type { LanguageService } from '@volar/language-service';
 import type { editor as _editor, IDisposable, Uri } from 'monaco-editor-core';
-import { markers } from './utils/markers';
-import * as protocol2monaco from './utils/protocol2monaco';
-import * as monaco2protocol from './utils/monaco2protocol';
+import { markers } from './utils/markers.js';
+import * as protocol2monaco from './utils/protocol2monaco.js';
+import * as monaco2protocol from './utils/monaco2protocol.js';
 
 interface IInternalEditorModel extends _editor.IModel {
 	onDidChangeAttached(listener: () => void): IDisposable;

--- a/packages/monaco/lib/languages.ts
+++ b/packages/monaco/lib/languages.ts
@@ -5,7 +5,7 @@ import type {
 	Uri,
 } from 'monaco-editor-core';
 import type { LanguageService } from '@volar/language-service';
-import { createLanguageFeaturesProvider } from './utils/provider';
+import { createLanguageFeaturesProvider } from './utils/provider.js';
 
 export namespace languages {
 

--- a/packages/monaco/lib/utils/provider.ts
+++ b/packages/monaco/lib/utils/provider.ts
@@ -1,9 +1,9 @@
 import { LanguageService, standardSemanticTokensLegend } from '@volar/language-service';
 import type { editor, languages, Uri } from 'monaco-editor-core';
 import type * as vscode from 'vscode-languageserver-protocol';
-import { markers } from './markers';
-import * as monaco2protocol from './monaco2protocol';
-import * as protocol2monaco from './protocol2monaco';
+import { markers } from './markers.js';
+import * as monaco2protocol from './monaco2protocol.js';
+import * as protocol2monaco from './protocol2monaco.js';
 
 export async function createLanguageFeaturesProvider(
 	worker: editor.MonacoWebWorker<LanguageService>,

--- a/packages/monaco/package.json
+++ b/packages/monaco/package.json
@@ -2,6 +2,7 @@
 	"name": "@volar/monaco",
 	"version": "1.11.1",
 	"license": "MIT",
+	"type": "module",
 	"files": [
 		"**/*.js",
 		"**/*.d.ts"

--- a/packages/monaco/tsconfig.json
+++ b/packages/monaco/tsconfig.json
@@ -4,7 +4,4 @@
 	"references": [
 		{ "path": "../language-service/tsconfig.json" },
 	],
-	"compilerOptions": {
-		"esModuleInterop": true
-	},
 }

--- a/packages/monaco/tsconfig.json
+++ b/packages/monaco/tsconfig.json
@@ -4,4 +4,7 @@
 	"references": [
 		{ "path": "../language-service/tsconfig.json" },
 	],
+	"compilerOptions": {
+		"esModuleInterop": true
+	},
 }

--- a/packages/monaco/worker.ts
+++ b/packages/monaco/worker.ts
@@ -7,7 +7,7 @@ import {
 	type LanguageService,
 } from '@volar/language-service';
 import type * as monaco from 'monaco-editor-core';
-import type * as ts from 'typescript/lib/tsserverlibrary';
+import type * as ts from 'typescript/lib/tsserverlibrary.js';
 import { URI } from 'vscode-uri';
 
 export function createServiceEnvironment(): ServiceEnvironment {


### PR DESCRIPTION
Since this code only works when bundled, there’s no need to compile it to CJS.