### PR TITLE
refactor(monaco): remove namespace usage

### DIFF
--- a/packages/monaco/lib/editor.ts
+++ b/packages/monaco/lib/editor.ts
@@ -1,223 +1,220 @@
 import type { LanguageService } from '@volar/language-service';
-import type { editor as _editor, IDisposable, Uri } from 'monaco-editor-core';
+import type { editor, IDisposable, Uri } from 'monaco-editor-core';
 import { markers } from './utils/markers.js';
 import * as protocol2monaco from './utils/protocol2monaco.js';
 import * as monaco2protocol from './utils/monaco2protocol.js';
 
-interface IInternalEditorModel extends _editor.IModel {
+interface IInternalEditorModel extends editor.IModel {
 	onDidChangeAttached(listener: () => void): IDisposable;
 	isAttachedToEditor(): boolean;
 }
 
-export namespace editor {
+export function activateMarkers(
+	worker: editor.MonacoWebWorker<LanguageService>,
+	languages: string[],
+	markersOwn: string,
+	getSyncUris: () => Uri[],
+	editor: typeof import('monaco-editor-core').editor,
+): IDisposable {
 
-	export function activateMarkers(
-		worker: _editor.MonacoWebWorker<LanguageService>,
-		languages: string[],
-		markersOwn: string,
-		getSyncUris: () => Uri[],
-		editor: typeof import('monaco-editor-core').editor,
-	): IDisposable {
+	const disposables: IDisposable[] = [];
+	const listener = new Map<string, IDisposable>();
 
-		const disposables: IDisposable[] = [];
-		const listener = new Map<string, IDisposable>();
+	disposables.push(
+		editor.onDidCreateModel((model) => hostingMarkers(model)),
+		editor.onWillDisposeModel(stopHostingMarkers),
+		editor.onDidChangeModelLanguage((event) => {
+			stopHostingMarkers(event.model);
+			hostingMarkers(event.model);
+		}),
+		{
+			dispose: () => {
+				for (const model of editor.getModels()) {
+					stopHostingMarkers(model);
+				}
+			}
+		},
+	);
 
-		disposables.push(
-			editor.onDidCreateModel((model) => hostingMarkers(model)),
-			editor.onWillDisposeModel(stopHostingMarkers),
-			editor.onDidChangeModelLanguage((event) => {
-				stopHostingMarkers(event.model);
-				hostingMarkers(event.model);
-			}),
+	for (const model of editor.getModels()) {
+		hostingMarkers(model);
+	}
+
+	return { dispose: () => disposables.forEach((d) => d.dispose()) };
+
+	function stopHostingMarkers(model: editor.IModel): void {
+		editor.setModelMarkers(model, markersOwn, []);
+		const key = model.uri.toString();
+		if (listener.has(key)) {
+			listener.get(key)?.dispose();
+			listener.delete(key);
+		}
+	}
+
+	function hostingMarkers(model: IInternalEditorModel): void {
+		if (!languages.includes(model.getLanguageId?.() ?? (model as any).getModeId?.())) {
+			return;
+		}
+
+		let timer: number | undefined;
+		const changeSubscription = model.onDidChangeContent(() => {
+			clearTimeout(timer);
+			timer = setTimeout(() => doValidation(model), 250);
+		});
+		const visibleSubscription = model.onDidChangeAttached(() => {
+			if (model.isAttachedToEditor()) {
+				doValidation(model);
+			} else {
+				editor.setModelMarkers(model, markersOwn, []);
+			}
+		});
+
+		listener.set(
+			model.uri.toString(),
 			{
 				dispose: () => {
-					for (const model of editor.getModels()) {
-						stopHostingMarkers(model);
-					}
+					changeSubscription.dispose();
+					visibleSubscription.dispose();
+					clearTimeout(timer);
 				}
 			},
 		);
 
-		for (const model of editor.getModels()) {
-			hostingMarkers(model);
+		doValidation(model);
+	}
+
+	async function doValidation(model: editor.ITextModel) {
+		if (model.isDisposed()) {
+			return;
+		}
+		if (!model.isAttachedToEditor()) {
+			return;
 		}
 
-		return { dispose: () => disposables.forEach((d) => d.dispose()) };
-
-		function stopHostingMarkers(model: _editor.IModel): void {
-			editor.setModelMarkers(model, markersOwn, []);
-			const key = model.uri.toString();
-			if (listener.has(key)) {
-				listener.get(key)?.dispose();
-				listener.delete(key);
-			}
+		const version = model.getVersionId();
+		const languageService = await worker.withSyncedResources(getSyncUris());
+		const diagnostics = await languageService.doValidation(
+			model.uri.toString(),
+			'all',
+		);
+		if (model.getVersionId() !== version) {
+			return;
 		}
+		const result = diagnostics.map(error => {
+			const marker = protocol2monaco.asMarkerData(error);
+			markers.set(marker, error);
+			return marker;
+		});
 
-		function hostingMarkers(model: IInternalEditorModel): void {
-			if (!languages.includes(model.getLanguageId?.() ?? (model as any).getModeId?.())) {
-				return;
-			}
+		editor.setModelMarkers(model, markersOwn, result);
+	}
+}
 
-			let timer: number | undefined;
-			const changeSubscription = model.onDidChangeContent(() => {
-				clearTimeout(timer);
-				timer = setTimeout(() => doValidation(model), 250);
-			});
-			const visibleSubscription = model.onDidChangeAttached(() => {
-				if (model.isAttachedToEditor()) {
-					doValidation(model);
-				} else {
-					editor.setModelMarkers(model, markersOwn, []);
+export function activateAutoInsertion(
+	worker: editor.MonacoWebWorker<LanguageService>,
+	languages: string[],
+	getSyncUris: () => Uri[],
+	editor: typeof import('monaco-editor-core').editor,
+): IDisposable {
+
+	const disposables: IDisposable[] = [];
+	const listener = new Map<editor.IModel, IDisposable>();
+
+	let timeout: number | undefined;
+
+	disposables.push(
+		editor.onDidCreateModel((model) => hostingAutoInsertion(model)),
+		editor.onWillDisposeModel(stopHostingAutoInsertion),
+		editor.onDidChangeModelLanguage((event) => {
+			stopHostingAutoInsertion(event.model);
+			hostingAutoInsertion(event.model);
+		}),
+		{
+			dispose: () => {
+				for (const disposable of listener.values()) {
+					disposable.dispose();
 				}
-			});
+				listener.clear();
+			}
+		},
+	);
 
-			listener.set(
-				model.uri.toString(),
-				{
-					dispose: () => {
-						changeSubscription.dispose();
-						visibleSubscription.dispose();
-						clearTimeout(timer);
-					}
-				},
-			);
+	for (const model of editor.getModels()) {
+		hostingAutoInsertion(model);
+	}
 
-			doValidation(model);
+	return { dispose: () => disposables.forEach((d) => d.dispose()) };
+
+	function stopHostingAutoInsertion(model: editor.IModel): void {
+		if (listener.has(model)) {
+			listener.get(model)?.dispose();
+			listener.delete(model);
 		}
+	}
 
-		async function doValidation(model: _editor.ITextModel) {
+	function hostingAutoInsertion(model: IInternalEditorModel) {
+		if (!languages.includes(model.getLanguageId?.() ?? (model as any).getModeId?.())) {
+			return;
+		}
+		listener.set(model, model.onDidChangeContent((e) => {
 			if (model.isDisposed()) {
 				return;
 			}
 			if (!model.isAttachedToEditor()) {
 				return;
 			}
-
-			const version = model.getVersionId();
-			const languageService = await worker.withSyncedResources(getSyncUris());
-			const diagnostics = await languageService.doValidation(
-				model.uri.toString(),
-				'all',
-			);
-			if (model.getVersionId() !== version) {
+			if (e.changes.length === 0 || e.isUndoing || e.isRedoing) {
 				return;
 			}
-			const result = diagnostics.map(error => {
-				const marker = protocol2monaco.asMarkerData(error);
-				markers.set(marker, error);
-				return marker;
-			});
-
-			editor.setModelMarkers(model, markersOwn, result);
-		}
+			const lastChange = e.changes[e.changes.length - 1];
+			doAutoInsert(model, lastChange);
+		}));
 	}
 
-	export function activateAutoInsertion(
-		worker: _editor.MonacoWebWorker<LanguageService>,
-		languages: string[],
-		getSyncUris: () => Uri[],
-		editor: typeof import('monaco-editor-core').editor,
-	): IDisposable {
-
-		const disposables: IDisposable[] = [];
-		const listener = new Map<_editor.IModel, IDisposable>();
-
-		let timeout: number | undefined;
-
-		disposables.push(
-			editor.onDidCreateModel((model) => hostingAutoInsertion(model)),
-			editor.onWillDisposeModel(stopHostingAutoInsertion),
-			editor.onDidChangeModelLanguage((event) => {
-				stopHostingAutoInsertion(event.model);
-				hostingAutoInsertion(event.model);
-			}),
-			{
-				dispose: () => {
-					for (const disposable of listener.values()) {
-						disposable.dispose();
-					}
-					listener.clear();
-				}
-			},
-		);
-
-		for (const model of editor.getModels()) {
-			hostingAutoInsertion(model);
+	async function doAutoInsert(
+		model: editor.ITextModel,
+		lastChange: editor.IModelContentChange,
+	) {
+		if (timeout) {
+			clearTimeout(timeout);
+			timeout = undefined;
 		}
-
-		return { dispose: () => disposables.forEach((d) => d.dispose()) };
-
-		function stopHostingAutoInsertion(model: _editor.IModel): void {
-			if (listener.has(model)) {
-				listener.get(model)?.dispose();
-				listener.delete(model);
-			}
-		}
-
-		function hostingAutoInsertion(model: IInternalEditorModel) {
-			if (!languages.includes(model.getLanguageId?.() ?? (model as any).getModeId?.())) {
-				return;
-			}
-			listener.set(model, model.onDidChangeContent((e) => {
-				if (model.isDisposed()) {
+		const version = model.getVersionId();
+		timeout = setTimeout(() => {
+			(async () => {
+				if (model.getVersionId() !== version) {
 					return;
 				}
-				if (!model.isAttachedToEditor()) {
-					return;
-				}
-				if (e.changes.length === 0 || e.isUndoing || e.isRedoing) {
-					return;
-				}
-				const lastChange = e.changes[e.changes.length - 1];
-				doAutoInsert(model, lastChange);
-			}));
-		}
-
-		async function doAutoInsert(
-			model: _editor.ITextModel,
-			lastChange: _editor.IModelContentChange,
-		) {
-			if (timeout) {
-				clearTimeout(timeout);
-				timeout = undefined;
-			}
-			const version = model.getVersionId();
-			timeout = setTimeout(() => {
-				(async () => {
-					if (model.getVersionId() !== version) {
-						return;
-					}
-					const languageService = await worker.withSyncedResources(getSyncUris());
-					const edit = await languageService.doAutoInsert(
-						model.uri.toString(),
-						monaco2protocol.asPosition({
-							lineNumber: lastChange.range.startLineNumber,
-							column: lastChange.range.startColumn + lastChange.text.length,
-						}),
-						{
-							lastChange: {
-								range: monaco2protocol.asRange(lastChange.range),
-								rangeLength: lastChange.rangeLength,
-								text: lastChange.text,
-								rangeOffset: lastChange.rangeOffset,
-							},
+				const languageService = await worker.withSyncedResources(getSyncUris());
+				const edit = await languageService.doAutoInsert(
+					model.uri.toString(),
+					monaco2protocol.asPosition({
+						lineNumber: lastChange.range.startLineNumber,
+						column: lastChange.range.startColumn + lastChange.text.length,
+					}),
+					{
+						lastChange: {
+							range: monaco2protocol.asRange(lastChange.range),
+							rangeLength: lastChange.rangeLength,
+							text: lastChange.text,
+							rangeOffset: lastChange.rangeOffset,
 						},
-					);
-					if (model.getVersionId() !== version) {
-						return;
+					},
+				);
+				if (model.getVersionId() !== version) {
+					return;
+				}
+				const codeEditor = editor.getEditors().find((e) => e.getModel() === model);
+				if (codeEditor && edit && model.getVersionId() === version) {
+					if (typeof edit === 'string') {
+						(codeEditor?.getContribution('snippetController2') as any)?.insert(edit);
 					}
-					const codeEditor = editor.getEditors().find((e) => e.getModel() === model);
-					if (codeEditor && edit && model.getVersionId() === version) {
-						if (typeof edit === 'string') {
-							(codeEditor?.getContribution('snippetController2') as any)?.insert(edit);
-						}
-						else {
-							model.pushEditOperations([], [protocol2monaco.asTextEdit(edit)], () => []);
-						}
+					else {
+						model.pushEditOperations([], [protocol2monaco.asTextEdit(edit)], () => []);
 					}
-				})();
-				timeout = undefined;
-			}, 100);
-		}
+				}
+			})();
+			timeout = undefined;
+		}, 100);
 	}
 }

--- a/packages/monaco/lib/languages.ts
+++ b/packages/monaco/lib/languages.ts
@@ -1,49 +1,46 @@
 import type {
 	editor,
-	languages as _languages,
+	languages,
 	IDisposable,
 	Uri,
 } from 'monaco-editor-core';
 import type { LanguageService } from '@volar/language-service';
 import { createLanguageFeaturesProvider } from './utils/provider.js';
 
-export namespace languages {
+export async function registerProviders(
+	worker: editor.MonacoWebWorker<LanguageService>,
+	language: languages.LanguageSelector,
+	getSyncUris: () => Uri[],
+	languages: typeof import('monaco-editor-core').languages,
+): Promise<IDisposable> {
 
-	export async function registerProviders(
-		worker: editor.MonacoWebWorker<LanguageService>,
-		language: _languages.LanguageSelector,
-		getSyncUris: () => Uri[],
-		languages: typeof import('monaco-editor-core').languages,
-	): Promise<IDisposable> {
+	const provider = await createLanguageFeaturesProvider(worker, getSyncUris);
+	const disposables: IDisposable[] = [
+		languages.registerHoverProvider(language, provider),
+		languages.registerReferenceProvider(language, provider),
+		languages.registerRenameProvider(language, provider),
+		languages.registerSignatureHelpProvider(language, provider),
+		languages.registerDocumentSymbolProvider(language, provider),
+		languages.registerDocumentHighlightProvider(language, provider),
+		languages.registerLinkedEditingRangeProvider(language, provider),
+		languages.registerDefinitionProvider(language, provider),
+		languages.registerImplementationProvider(language, provider),
+		languages.registerTypeDefinitionProvider(language, provider),
+		languages.registerCodeLensProvider(language, provider),
+		languages.registerCodeActionProvider(language, provider),
+		languages.registerDocumentFormattingEditProvider(language, provider),
+		languages.registerDocumentRangeFormattingEditProvider(language, provider),
+		languages.registerOnTypeFormattingEditProvider(language, provider),
+		languages.registerLinkProvider(language, provider),
+		languages.registerCompletionItemProvider(language, provider),
+		languages.registerColorProvider(language, provider),
+		languages.registerFoldingRangeProvider(language, provider),
+		languages.registerDeclarationProvider(language, provider),
+		languages.registerSelectionRangeProvider(language, provider),
+		languages.registerInlayHintsProvider(language, provider),
+		languages.registerDocumentSemanticTokensProvider(language, provider),
+		languages.registerDocumentRangeSemanticTokensProvider(language, provider),
+	];
 
-		const provider = await createLanguageFeaturesProvider(worker, getSyncUris);
-		const disposables: IDisposable[] = [
-			languages.registerHoverProvider(language, provider),
-			languages.registerReferenceProvider(language, provider),
-			languages.registerRenameProvider(language, provider),
-			languages.registerSignatureHelpProvider(language, provider),
-			languages.registerDocumentSymbolProvider(language, provider),
-			languages.registerDocumentHighlightProvider(language, provider),
-			languages.registerLinkedEditingRangeProvider(language, provider),
-			languages.registerDefinitionProvider(language, provider),
-			languages.registerImplementationProvider(language, provider),
-			languages.registerTypeDefinitionProvider(language, provider),
-			languages.registerCodeLensProvider(language, provider),
-			languages.registerCodeActionProvider(language, provider),
-			languages.registerDocumentFormattingEditProvider(language, provider),
-			languages.registerDocumentRangeFormattingEditProvider(language, provider),
-			languages.registerOnTypeFormattingEditProvider(language, provider),
-			languages.registerLinkProvider(language, provider),
-			languages.registerCompletionItemProvider(language, provider),
-			languages.registerColorProvider(language, provider),
-			languages.registerFoldingRangeProvider(language, provider),
-			languages.registerDeclarationProvider(language, provider),
-			languages.registerSelectionRangeProvider(language, provider),
-			languages.registerInlayHintsProvider(language, provider),
-			languages.registerDocumentSemanticTokensProvider(language, provider),
-			languages.registerDocumentRangeSemanticTokensProvider(language, provider),
-		];
-
-		return { dispose: () => disposables.forEach((d) => d.dispose()) };
-	}
+	return { dispose: () => disposables.forEach((d) => d.dispose()) };
 }


### PR DESCRIPTION
TypeScript namespaces are typically considered a bad practice, as they are TypeScript specific. Also they compile to something that can’t be tree-shaken, and the names used conflict with those of Monaco editor.

This is a breaking change.