### PR TITLE
perf(language-core): only synchronize the source file currently needed

### DIFF
--- a/packages/kit/lib/createChecker.ts
+++ b/packages/kit/lib/createChecker.ts
@@ -72,7 +72,10 @@ function createTypeScriptCheckerWorker(
 	};
 
 	const projectHost = getTypeScriptProjectHost(env);
-	const project = createTypeScriptProject(languages, projectHost, env.fileNameToUri, resolveCommonLanguageId);
+	const project = createTypeScriptProject(languages, projectHost, {
+		idToFileName: env.uriToFileName,
+		getLanguageId: resolveCommonLanguageId,
+	});
 	const service = createLanguageService(
 		{ typescript: ts as any },
 		services,

--- a/packages/language-server/lib/documentManager.ts
+++ b/packages/language-server/lib/documentManager.ts
@@ -17,7 +17,7 @@ interface IncrementalScriptSnapshotChange {
 	snapshot: WeakRef<ts.IScriptSnapshot> | undefined,
 }
 
-export class IncrementalScriptSnapshot {
+class IncrementalScriptSnapshot {
 
 	private document: TextDocument;
 	uri: string;

--- a/packages/language-server/lib/project/typescriptProject.ts
+++ b/packages/language-server/lib/project/typescriptProject.ts
@@ -109,8 +109,10 @@ export async function createTypeScriptServerProject(
 				createTypeScriptProject(
 					Object.values(config.languages ?? {}),
 					typescriptProjectHost,
-					serviceEnv.fileNameToUri,
-					fileName => context.workspaces.documents.data.pathGet(fileName)?.languageId ?? resolveCommonLanguageId(fileName),
+					{
+						idToFileName: serviceEnv.uriToFileName,
+						getLanguageId: id => context.workspaces.documents.data.pathGet(id)?.languageId ?? resolveCommonLanguageId(id),
+					}
 				),
 			);
 		}

--- a/packages/language-server/lib/register/registerEditorFeatures.ts
+++ b/packages/language-server/lib/register/registerEditorFeatures.ts
@@ -76,21 +76,23 @@ export function registerEditorFeatures(
 
 			const rootUri = languageService.context.env.workspaceFolder.uri.toString();
 
-			for (const sourceFile of languageService.context.project.fileProvider.getAllSourceFiles()) {
-				if (sourceFile.root) {
-					for (const virtualFile of forEachEmbeddedFile(sourceFile.root)) {
-						if (virtualFile.kind === FileKind.TypeScriptHostFile && virtualFile.id.startsWith(rootUri)) {
-							const { snapshot } = virtualFile;
-							fs.writeFile(languageService.context.env.uriToFileName(virtualFile.id), snapshot.getText(0, snapshot.getLength()), () => { });
-						}
-					}
-				}
-			}
-			for (const fileName of languageService.context.project.typescript?.projectHost.getScriptFileNames()) {
+			for (const fileName of languageService.context.project.typescript.projectHost.getScriptFileNames()) {
 				if (!fs.existsSync(fileName)) {
-					const snapshot = languageService.context.project.typescript?.projectHost.getScriptSnapshot(fileName);
+					const snapshot = languageService.context.project.typescript.projectHost.getScriptSnapshot(fileName);
 					if (snapshot) {
 						fs.writeFile(fileName, snapshot.getText(0, snapshot.getLength()), () => { });
+					}
+				}
+				else {
+					const uri = languageService.context.env.fileNameToUri(fileName);
+					const sourceFile = languageService.context.project.fileProvider.getSourceFile(uri);
+					if (sourceFile?.root) {
+						for (const virtualFile of forEachEmbeddedFile(sourceFile.root)) {
+							if (virtualFile.kind === FileKind.TypeScriptHostFile && virtualFile.id.startsWith(rootUri)) {
+								const { snapshot } = virtualFile;
+								fs.writeFile(languageService.context.env.uriToFileName(virtualFile.id), snapshot.getText(0, snapshot.getLength()), () => { });
+							}
+						}
 					}
 				}
 			}

--- a/packages/typescript/lib/node/decorateLanguageServiceHost.ts
+++ b/packages/typescript/lib/node/decorateLanguageServiceHost.ts
@@ -176,10 +176,10 @@ export function decorateLanguageServiceHost(
 
 			if (text !== undefined) {
 				extraProjectVersion++;
-				const virtualFile = virtualFiles.updateSourceFile(fileName, ts.ScriptSnapshot.fromString(text), resolveCommonLanguageId(fileName));
-				if (virtualFile) {
+				const sourceFile = virtualFiles.updateSourceFile(fileName, ts.ScriptSnapshot.fromString(text), resolveCommonLanguageId(fileName));
+				if (sourceFile.root) {
 					let patchedText = text.split('\n').map(line => ' '.repeat(line.length)).join('\n');
-					for (const file of forEachEmbeddedFile(virtualFile)) {
+					for (const file of forEachEmbeddedFile(sourceFile.root)) {
 						const ext = file.id.substring(fileName.length);
 						if (file.kind === FileKind.TypeScriptHostFile && (ext === '.d.ts' || ext.match(/^\.(js|ts)x?$/))) {
 							extension = ext;


### PR DESCRIPTION
`FileProvider` can no longer access all virtual files, as this requires implementing a synchronized function that updates all project source files. Instead, the upper layer should loop through its list of source files and request virtual files from the `FileProvider` one by one.

The advantage of this is that the synchronization function drops from O(n) to O(1).