### PR TITLE
feat(language-core): abstract virtual file name to source file name resolution

### DIFF
--- a/packages/language-core/index.ts
+++ b/packages/language-core/index.ts
@@ -1,6 +1,7 @@
 export * from './lib/fileProvider';
 export * from './lib/linkedCodeMap';
 export * from './lib/types';
+export * from './lib/utils';
 export * from '@volar/source-map';
 
 export function resolveCommonLanguageId(fileNameOrUri: string) {

--- a/packages/language-core/lib/fileProvider.ts
+++ b/packages/language-core/lib/fileProvider.ts
@@ -2,23 +2,21 @@ import { MappingKey, SourceMap } from '@volar/source-map';
 import type * as ts from 'typescript/lib/tsserverlibrary';
 import { LinkedCodeMap } from './linkedCodeMap';
 import type { CodeInformation, Language, SourceFile, VirtualFile } from './types';
+import { FileMap } from './utils';
 
 export type FileProvider = ReturnType<typeof createFileProvider>;
 
 export function createFileProvider(languages: Language[], caseSensitive: boolean, sync: (sourceFileId: string) => void) {
 
-	const sourceFileRegistry = new Map<string, SourceFile>();
-	const virtualFileRegistry = new Map<string, [VirtualFile, SourceFile]>();
+	const sourceFileRegistry = new FileMap<SourceFile>(caseSensitive);
+	const virtualFileRegistry = new FileMap<[VirtualFile, SourceFile]>(caseSensitive);
 	const virtualFileToMaps = new WeakMap<ts.IScriptSnapshot, Map<string, [ts.IScriptSnapshot, SourceMap<CodeInformation>]>>();
 	const virtualFileToLinkedCodeMap = new WeakMap<ts.IScriptSnapshot, LinkedCodeMap | undefined>();
-	const normalizeId = caseSensitive
-		? (id: string) => id
-		: (id: string) => id.toLowerCase();
 
 	return {
 		updateSourceFile(id: string, snapshot: ts.IScriptSnapshot, languageId: string): SourceFile {
 
-			const value = sourceFileRegistry.get(normalizeId(id));
+			const value = sourceFileRegistry.get(id);
 			if (value) {
 				if (value.languageId !== languageId) {
 					// languageId changed
@@ -51,23 +49,23 @@ export function createFileProvider(languages: Language[], caseSensitive: boolean
 						snapshot,
 						virtualFile: [virtualFile, language],
 					};
-					sourceFileRegistry.set(normalizeId(id), source);
+					sourceFileRegistry.set(id, source);
 					updateVirtualFiles(source);
 					return source;
 				}
 			}
 
 			const source: SourceFile = { id: id, languageId, snapshot };
-			sourceFileRegistry.set(normalizeId(id), source);
+			sourceFileRegistry.set(id, source);
 			return source;
 		},
 		deleteSourceFile(id: string) {
-			const value = sourceFileRegistry.get(normalizeId(id));
+			const value = sourceFileRegistry.get(id);
 			if (value) {
 				if (value.virtualFile) {
 					value.virtualFile[1].disposeVirtualFile?.(value.virtualFile[0]);
 				}
-				sourceFileRegistry.delete(normalizeId(id)); // deleted
+				sourceFileRegistry.delete(id); // deleted
 				disposeVirtualFiles(value);
 			}
 		},
@@ -85,11 +83,11 @@ export function createFileProvider(languages: Language[], caseSensitive: boolean
 
 			updateVirtualFileMaps(virtualFile, sourceId => {
 				if (sourceId) {
-					const sourceFile = sourceFileRegistry.get(normalizeId(sourceId))!;
+					const sourceFile = sourceFileRegistry.get(sourceId)!;
 					return [sourceId, sourceFile.snapshot];
 				}
 				else {
-					const sourceFile = virtualFileRegistry.get(normalizeId(virtualFile.id))![1];
+					const sourceFile = virtualFileRegistry.get(virtualFile.id)![1];
 					return [sourceFile.id, sourceFile.snapshot];
 				}
 			}, virtualFileToMaps.get(virtualFile.snapshot));
@@ -98,13 +96,13 @@ export function createFileProvider(languages: Language[], caseSensitive: boolean
 		},
 		getSourceFile(id: string) {
 			sync(id);
-			return sourceFileRegistry.get(normalizeId(id));
+			return sourceFileRegistry.get(id);
 		},
 		getVirtualFile(id: string) {
-			let sourceAndVirtual = virtualFileRegistry.get(normalizeId(id));
+			let sourceAndVirtual = virtualFileRegistry.get(id);
 			if (sourceAndVirtual) {
 				sync(sourceAndVirtual[1].id);
-				sourceAndVirtual = virtualFileRegistry.get(normalizeId(id));
+				sourceAndVirtual = virtualFileRegistry.get(id);
 				if (sourceAndVirtual) {
 					return sourceAndVirtual;
 				}
@@ -116,7 +114,7 @@ export function createFileProvider(languages: Language[], caseSensitive: boolean
 	function disposeVirtualFiles(source: SourceFile) {
 		if (source.virtualFile) {
 			for (const file of forEachEmbeddedFile(source.virtualFile[0])) {
-				virtualFileRegistry.delete(normalizeId(file.id));
+				virtualFileRegistry.delete(file.id);
 			}
 		}
 	}
@@ -124,7 +122,7 @@ export function createFileProvider(languages: Language[], caseSensitive: boolean
 	function updateVirtualFiles(source: SourceFile) {
 		if (source.virtualFile) {
 			for (const file of forEachEmbeddedFile(source.virtualFile[0])) {
-				virtualFileRegistry.set(normalizeId(file.id), [file, source]);
+				virtualFileRegistry.set(file.id, [file, source]);
 			}
 		}
 	}

--- a/packages/language-core/lib/types.ts
+++ b/packages/language-core/lib/types.ts
@@ -72,6 +72,7 @@ export interface Language<T extends VirtualFile = VirtualFile> {
 	updateVirtualFile(virtualFile: T, snapshot: ts.IScriptSnapshot): void;
 	disposeVirtualFile?(virtualFile: T): void;
 	typescript?: {
+		resolveSourceFileName(tsFileName: string): string | undefined;
 		resolveModuleName?(path: string, impliedNodeFormat?: ts.ResolutionMode): string | undefined;
 		resolveLanguageServiceHost?(host: ts.LanguageServiceHost): ts.LanguageServiceHost;
 	};

--- a/packages/language-core/lib/utils.ts
+++ b/packages/language-core/lib/utils.ts
@@ -1,0 +1,39 @@
+export class FileMap<T> extends Map<string, T> {
+
+	private originalFileNames = new Map<string, string>();
+
+	constructor(private caseSensitive: boolean) {
+		super();
+	}
+
+	keys() {
+		return this.originalFileNames.values();
+	}
+
+	get(key: string) {
+		return super.get(this.normalizeId(key));
+	}
+
+	has(key: string) {
+		return super.has(this.normalizeId(key));
+	}
+
+	set(key: string, value: T) {
+		this.originalFileNames.set(this.normalizeId(key), key);
+		return super.set(this.normalizeId(key), value);
+	}
+
+	delete(key: string) {
+		this.originalFileNames.delete(this.normalizeId(key));
+		return super.delete(this.normalizeId(key));
+	}
+
+	clear() {
+		this.originalFileNames.clear();
+		return super.clear();
+	}
+
+	normalizeId(id: string) {
+		return this.caseSensitive ? id : id.toLowerCase();
+	}
+}

--- a/packages/typescript/lib/protocol/createProject.ts
+++ b/packages/typescript/lib/protocol/createProject.ts
@@ -296,11 +296,9 @@ export function createProject(
 
 		function syncSourceFile(tsFileName: string) {
 			for (const language of languages) {
-				if (language.typescript) {
-					const sourceFileName = language.typescript.resolveSourceFileName(tsFileName);
-					if (sourceFileName) {
-						fileProvider.getSourceFile(projectHost.getFileId(sourceFileName)); // trigger sync
-					}
+				const sourceFileName = language.typescript?.resolveSourceFileName(tsFileName);
+				if (sourceFileName) {
+					fileProvider.getSourceFile(projectHost.getFileId(sourceFileName)); // trigger sync
 				}
 			}
 		}

--- a/packages/typescript/lib/protocol/createProject.ts
+++ b/packages/typescript/lib/protocol/createProject.ts
@@ -209,7 +209,7 @@ export function createProject(
 				syncSourceFile(fileName);
 				return getScriptVersion(fileName) !== '';
 			},
-			readDirectory(dirName, extensions?, excludes?, includes?, depth?) {
+			readDirectory(dirName, extensions, excludes, includes, depth) {
 				syncProject();
 				let matches = matchFiles(
 					dirName,

--- a/packages/typescript/lib/protocol/createProject.ts
+++ b/packages/typescript/lib/protocol/createProject.ts
@@ -158,7 +158,6 @@ export function createProject(
 		let lastProjectVersion: number | string | undefined;
 		let tsProjectVersion = 0;
 		let tsFileRegistry = new FileMap<boolean>(sys.useCaseSensitiveFileNames);
-		let tsFileDirectoryRegistry = new FileMap<boolean>(sys.useCaseSensitiveFileNames);
 		let lastTsVirtualFileSnapshots = new Set<ts.IScriptSnapshot>();
 		let lastOtherVirtualFileSnapshots = new Set<ts.IScriptSnapshot>();
 
@@ -193,10 +192,6 @@ export function createProject(
 					...getVirtualFileDirectories(dirName),
 					...sys.getDirectories(dirName),
 				])];
-			},
-			directoryExists(dirName) {
-				syncProject();
-				return tsFileDirectoryRegistry.has(dirName) || sys.directoryExists(dirName);
 			},
 			readFile(fileName) {
 				syncSourceFile(fileName);
@@ -349,12 +344,6 @@ export function createProject(
 
 			for (const fileName of tsFileNamesSet) {
 				tsFileRegistry.set(fileName, true);
-			}
-
-			// Update tsDirectories for `directoryExists()`
-			tsFileDirectoryRegistry.clear();
-			for (const fileName of tsFileNamesSet) {
-				tsFileDirectoryRegistry.set(path.dirname(fileName), true);
 			}
 		}
 


### PR DESCRIPTION
Add the `resolveSourceFileName` API, requiring the integrator to implement the conversion method from virtual file name to source file name.

This will solve the use case of typescript parsing external files and vue-tsc project reference.

cc @blake-newman