### PR TITLE
refactor(language-service): stricter context isolation for `Service` interface

### DIFF
--- a/packages/kit/lib/createChecker.ts
+++ b/packages/kit/lib/createChecker.ts
@@ -1,4 +1,4 @@
-import { CodeActionTriggerKind, Diagnostic, DiagnosticSeverity, DidChangeWatchedFilesParams, FileChangeType, LanguagePlugin, NotificationHandler, ServicePluginFactory, ServiceEnvironment, createLanguageService, mergeWorkspaceEdits, resolveCommonLanguageId } from '@volar/language-service';
+import { CodeActionTriggerKind, Diagnostic, DiagnosticSeverity, DidChangeWatchedFilesParams, FileChangeType, LanguagePlugin, NotificationHandler, ServicePlugin, ServiceEnvironment, createLanguageService, mergeWorkspaceEdits, resolveCommonLanguageId } from '@volar/language-service';
 import * as path from 'typesafe-path/posix';
 import * as ts from 'typescript';
 import { TextDocument } from 'vscode-languageserver-textdocument';
@@ -8,7 +8,7 @@ import { createLanguage, LanguageHost } from '@volar/typescript';
 
 export function createTypeScriptChecker(
 	languages: LanguagePlugin[],
-	services: ServicePluginFactory[],
+	services: ServicePlugin[],
 	tsconfig: string,
 	extraFileExtensions: ts.FileExtensionInfo[] = []
 ) {
@@ -35,7 +35,7 @@ export function createTypeScriptChecker(
 
 export function createTypeScriptInferredChecker(
 	languages: LanguagePlugin[],
-	services: ServicePluginFactory[],
+	services: ServicePlugin[],
 	getScriptFileNames: () => string[],
 	compilerOptions = defaultCompilerOptions
 ) {
@@ -52,7 +52,7 @@ export function createTypeScriptInferredChecker(
 
 function createTypeScriptCheckerWorker(
 	languages: LanguagePlugin[],
-	services: ServicePluginFactory[],
+	services: ServicePlugin[],
 	configFileName: string | undefined,
 	getLanguageHost: (env: ServiceEnvironment) => LanguageHost
 ) {

--- a/packages/kit/lib/createChecker.ts
+++ b/packages/kit/lib/createChecker.ts
@@ -1,4 +1,4 @@
-import { CodeActionTriggerKind, Diagnostic, DiagnosticSeverity, DidChangeWatchedFilesParams, FileChangeType, LanguagePlugin, NotificationHandler, Service, ServiceEnvironment, createLanguageService, mergeWorkspaceEdits, resolveCommonLanguageId } from '@volar/language-service';
+import { CodeActionTriggerKind, Diagnostic, DiagnosticSeverity, DidChangeWatchedFilesParams, FileChangeType, LanguagePlugin, NotificationHandler, ServicePluginFactory, ServiceEnvironment, createLanguageService, mergeWorkspaceEdits, resolveCommonLanguageId } from '@volar/language-service';
 import * as path from 'typesafe-path/posix';
 import * as ts from 'typescript';
 import { TextDocument } from 'vscode-languageserver-textdocument';
@@ -8,7 +8,7 @@ import { createLanguage, LanguageHost } from '@volar/typescript';
 
 export function createTypeScriptChecker(
 	languages: LanguagePlugin[],
-	services: Service[],
+	services: ServicePluginFactory[],
 	tsconfig: string,
 	extraFileExtensions: ts.FileExtensionInfo[] = []
 ) {
@@ -35,7 +35,7 @@ export function createTypeScriptChecker(
 
 export function createTypeScriptInferredChecker(
 	languages: LanguagePlugin[],
-	services: Service[],
+	services: ServicePluginFactory[],
 	getScriptFileNames: () => string[],
 	compilerOptions = defaultCompilerOptions
 ) {
@@ -52,7 +52,7 @@ export function createTypeScriptInferredChecker(
 
 function createTypeScriptCheckerWorker(
 	languages: LanguagePlugin[],
-	services: Service[],
+	services: ServicePluginFactory[],
 	configFileName: string | undefined,
 	getLanguageHost: (env: ServiceEnvironment) => LanguageHost
 ) {
@@ -72,7 +72,7 @@ function createTypeScriptCheckerWorker(
 	};
 
 	const projectHost = getLanguageHost(env);
-	const project = createLanguage(
+	const language = createLanguage(
 		ts as any,
 		ts.sys,
 		languages,
@@ -80,10 +80,9 @@ function createTypeScriptCheckerWorker(
 		projectHost,
 	);
 	const service = createLanguageService(
-		{ typescript: ts as any },
+		language,
 		services,
 		env,
-		project,
 	);
 
 	return {

--- a/packages/kit/lib/createFormatter.ts
+++ b/packages/kit/lib/createFormatter.ts
@@ -1,11 +1,11 @@
-import { FormattingOptions, LanguagePlugin, Service, createFileProvider, createLanguageService } from '@volar/language-service';
+import { FormattingOptions, LanguagePlugin, ServicePluginFactory, createFileProvider, createLanguageService } from '@volar/language-service';
 import * as ts from 'typescript';
 import { TextDocument } from 'vscode-languageserver-textdocument';
 import { createServiceEnvironment } from './createServiceEnvironment';
 
 export function createFormatter(
 	languages: LanguagePlugin[],
-	services: Service[]
+	services: ServicePluginFactory[]
 ) {
 
 	let fakeUri = 'file:///dummy.txt';
@@ -14,10 +14,9 @@ export function createFormatter(
 	const env = createServiceEnvironment(() => settings);
 	const files = createFileProvider(languages, false, () => { });
 	const service = createLanguageService(
-		{ typescript: ts as any },
+		{ files },
 		services,
 		env,
-		{ files },
 	);
 
 	return {

--- a/packages/kit/lib/createFormatter.ts
+++ b/packages/kit/lib/createFormatter.ts
@@ -1,11 +1,11 @@
-import { FormattingOptions, LanguagePlugin, ServicePluginFactory, createFileProvider, createLanguageService } from '@volar/language-service';
+import { FormattingOptions, LanguagePlugin, ServicePlugin, createFileProvider, createLanguageService } from '@volar/language-service';
 import * as ts from 'typescript';
 import { TextDocument } from 'vscode-languageserver-textdocument';
 import { createServiceEnvironment } from './createServiceEnvironment';
 
 export function createFormatter(
 	languages: LanguagePlugin[],
-	services: ServicePluginFactory[]
+	services: ServicePlugin[]
 ) {
 
 	let fakeUri = 'file:///dummy.txt';

--- a/packages/language-server/lib/project/simpleProject.ts
+++ b/packages/language-server/lib/project/simpleProject.ts
@@ -1,7 +1,7 @@
 import { LanguageService, ServiceEnvironment, createFileProvider, createLanguageService } from '@volar/language-service';
-import type { SimpleServerPlugin, ServerProject } from '../types';
-import type { WorkspacesContext } from './simpleProjectProvider';
 import { getConfig } from '../config';
+import type { ServerProject, SimpleServerPlugin } from '../types';
+import type { WorkspacesContext } from './simpleProjectProvider';
 
 export async function createSimpleServerProject(
 	context: WorkspacesContext,
@@ -34,10 +34,9 @@ export async function createSimpleServerProject(
 				}
 			});
 			languageService = createLanguageService(
-				{ typescript: context.workspaces.ts },
+				{ files },
 				Object.values(config.services ?? {}),
 				serviceEnv,
-				{ files },
 			);
 		}
 		return languageService;

--- a/packages/language-server/lib/project/simpleProjectProvider.ts
+++ b/packages/language-server/lib/project/simpleProjectProvider.ts
@@ -1,13 +1,13 @@
 import type { ServiceEnvironment } from '@volar/language-service';
+import type { SnapshotDocument } from '@volar/snapshot-document';
 import type * as ts from 'typescript/lib/tsserverlibrary';
+import type { TextDocuments } from 'vscode-languageserver';
 import { URI } from 'vscode-uri';
 import type { ServerContext } from '../server';
+import type { InitializationOptions, ServerProject, ServerProjectProvider, SimpleServerPlugin } from '../types';
 import { isFileInDir } from '../utils/isFileInDir';
 import type { WorkspaceFolderManager } from '../workspaceFolderManager';
-import type { InitializationOptions, ServerProject, ServerProjectProvider, SimpleServerPlugin } from '../types';
 import { createSimpleServerProject } from './simpleProject';
-import type { TextDocuments } from 'vscode-languageserver';
-import type { SnapshotDocument } from '@volar/snapshot-document';
 
 export interface WorkspacesContext extends ServerContext {
 	workspaces: {

--- a/packages/language-server/lib/project/typescriptProject.ts
+++ b/packages/language-server/lib/project/typescriptProject.ts
@@ -109,10 +109,9 @@ export async function createTypeScriptServerProject(
 				host,
 			);
 			languageService = createLanguageService(
-				{ typescript: context.workspaces.ts },
+				language,
 				Object.values(config.services ?? {}),
 				serviceEnv,
-				language,
 			);
 		}
 		return languageService;

--- a/packages/language-server/lib/setupCapabilities.ts
+++ b/packages/language-server/lib/setupCapabilities.ts
@@ -1,4 +1,4 @@
-import type { ServicePluginFactory } from '@volar/language-service';
+import type { ServicePlugin } from '@volar/language-service';
 import { DiagnosticModel, SimpleServerPlugin, InitializationOptions, ServerMode } from './types';
 import * as vscode from 'vscode-languageserver';
 
@@ -7,7 +7,7 @@ export function setupCapabilities(
 	initOptions: InitializationOptions,
 	plugins: ReturnType<SimpleServerPlugin>[],
 	semanticTokensLegend: vscode.SemanticTokensLegend,
-	services: ServicePluginFactory[],
+	services: ServicePlugin[],
 ) {
 
 	const serverMode = initOptions.serverMode ?? ServerMode.Semantic;

--- a/packages/language-server/lib/setupCapabilities.ts
+++ b/packages/language-server/lib/setupCapabilities.ts
@@ -1,4 +1,4 @@
-import type { Service } from '@volar/language-service';
+import type { ServicePluginFactory } from '@volar/language-service';
 import { DiagnosticModel, SimpleServerPlugin, InitializationOptions, ServerMode } from './types';
 import * as vscode from 'vscode-languageserver';
 
@@ -7,10 +7,9 @@ export function setupCapabilities(
 	initOptions: InitializationOptions,
 	plugins: ReturnType<SimpleServerPlugin>[],
 	semanticTokensLegend: vscode.SemanticTokensLegend,
-	services: Service[],
+	services: ServicePluginFactory[],
 ) {
 
-	const serviceInstances = services.map(service => service(undefined, undefined));
 	const serverMode = initOptions.serverMode ?? ServerMode.Semantic;
 
 	if (serverMode === ServerMode.Semantic || serverMode === ServerMode.Syntactic) {
@@ -21,7 +20,7 @@ export function setupCapabilities(
 		server.documentSymbolProvider = true;
 		server.documentFormattingProvider = true;
 		server.documentRangeFormattingProvider = true;
-		const characters = [...new Set(serviceInstances.map(service => service.autoFormatTriggerCharacters ?? []).flat())];
+		const characters = [...new Set(services.map(service => service.autoFormatTriggerCharacters ?? []).flat())];
 		if (characters.length) {
 			server.documentOnTypeFormattingProvider = {
 				firstTriggerCharacter: characters[0],
@@ -41,11 +40,11 @@ export function setupCapabilities(
 			prepareProvider: true,
 		};
 		server.signatureHelpProvider = {
-			triggerCharacters: [...new Set(serviceInstances.map(service => service.signatureHelpTriggerCharacters ?? []).flat())],
-			retriggerCharacters: [...new Set(serviceInstances.map(service => service.signatureHelpRetriggerCharacters ?? []).flat())],
+			triggerCharacters: [...new Set(services.map(service => service.signatureHelpTriggerCharacters ?? []).flat())],
+			retriggerCharacters: [...new Set(services.map(service => service.signatureHelpRetriggerCharacters ?? []).flat())],
 		};
 		server.completionProvider = {
-			triggerCharacters: [...new Set(serviceInstances.map(service => service.triggerCharacters ?? []).flat())],
+			triggerCharacters: [...new Set(services.map(service => service.triggerCharacters ?? []).flat())],
 			resolveProvider: true,
 		};
 		if (initOptions.ignoreTriggerCharacters) {

--- a/packages/language-server/lib/types.ts
+++ b/packages/language-server/lib/types.ts
@@ -1,10 +1,10 @@
-import type { Console, FileSystem, LanguagePlugin, LanguageService, ServicePluginFactory, ServiceEnvironment, SharedModules } from '@volar/language-service';
+import type { Console, FileSystem, LanguagePlugin, LanguageService, ServicePlugin, ServiceEnvironment, SharedModules } from '@volar/language-service';
 import type * as ts from 'typescript/lib/tsserverlibrary';
 import type * as vscode from 'vscode-languageserver';
 
 export interface Config {
 	languages?: { [id: string]: LanguagePlugin; };
-	services?: { [id: string]: ServicePluginFactory; };
+	services?: { [id: string]: ServicePlugin; };
 }
 
 export interface Timer {

--- a/packages/language-server/lib/types.ts
+++ b/packages/language-server/lib/types.ts
@@ -1,10 +1,10 @@
-import type { Console, FileSystem, LanguagePlugin, LanguageService, Service, ServiceEnvironment, SharedModules } from '@volar/language-service';
+import type { Console, FileSystem, LanguagePlugin, LanguageService, ServicePluginFactory, ServiceEnvironment, SharedModules } from '@volar/language-service';
 import type * as ts from 'typescript/lib/tsserverlibrary';
 import type * as vscode from 'vscode-languageserver';
 
 export interface Config {
 	languages?: { [id: string]: LanguagePlugin; };
-	services?: { [id: string]: Service; };
+	services?: { [id: string]: ServicePluginFactory; };
 }
 
 export interface Timer {

--- a/packages/language-service/lib/documentFeatures/colorPresentations.ts
+++ b/packages/language-service/lib/documentFeatures/colorPresentations.ts
@@ -22,7 +22,7 @@ export function register(context: ServiceContext) {
 				if (token.isCancellationRequested) {
 					return;
 				}
-				return service.provideColorPresentations?.(document, color, range, token);
+				return service[1].provideColorPresentations?.(document, color, range, token);
 			},
 			(data, map) => {
 				if (!map) {

--- a/packages/language-service/lib/documentFeatures/documentColors.ts
+++ b/packages/language-service/lib/documentFeatures/documentColors.ts
@@ -17,7 +17,7 @@ export function register(context: ServiceContext) {
 				if (token.isCancellationRequested) {
 					return;
 				}
-				return service.provideDocumentColors?.(document, token);
+				return service[1].provideDocumentColors?.(document, token);
 			},
 			(data, map) => {
 				if (!map) {

--- a/packages/language-service/lib/documentFeatures/documentSymbols.ts
+++ b/packages/language-service/lib/documentFeatures/documentSymbols.ts
@@ -18,7 +18,7 @@ export function register(context: ServiceContext) {
 				if (token.isCancellationRequested) {
 					return;
 				}
-				return service.provideDocumentSymbols?.(document, token);
+				return service[1].provideDocumentSymbols?.(document, token);
 			},
 			(data, map) => {
 				if (!map) {

--- a/packages/language-service/lib/documentFeatures/foldingRanges.ts
+++ b/packages/language-service/lib/documentFeatures/foldingRanges.ts
@@ -18,7 +18,7 @@ export function register(context: ServiceContext) {
 				if (token.isCancellationRequested) {
 					return;
 				}
-				return service.provideFoldingRanges?.(document, token);
+				return service[1].provideFoldingRanges?.(document, token);
 			},
 			(data, map) => {
 				if (!map) {

--- a/packages/language-service/lib/documentFeatures/format.ts
+++ b/packages/language-service/lib/documentFeatures/format.ts
@@ -1,7 +1,7 @@
 import { SourceMap, VirtualFile, forEachEmbeddedFile, isFormattingEnabled, resolveCommonLanguageId, updateVirtualFileMaps } from '@volar/language-core';
 import type * as vscode from 'vscode-languageserver-protocol';
 import { TextDocument } from 'vscode-languageserver-textdocument';
-import type { ServiceContext, Service } from '../types';
+import type { ServiceContext, ServicePlugin } from '../types';
 import { isInsideRange, stringToSnapshot } from '../utils/common';
 import { NoneCancellationToken } from '../utils/cancellation';
 import { SourceMapWithDocuments } from '../documents';
@@ -57,7 +57,7 @@ export function register(context: ServiceContext) {
 			const toPatchIndent: {
 				virtualFileUri: string;
 				isCodeBlock: boolean;
-				service: ReturnType<Service>;
+				service: ServicePlugin;
 			}[] = [];
 
 			for (const file of embeddedFiles) {
@@ -102,7 +102,7 @@ export function register(context: ServiceContext) {
 				toPatchIndent.push({
 					virtualFileUri: file.id,
 					isCodeBlock,
-					service: embeddedCodeResult.service,
+					service: embeddedCodeResult.service[1],
 				});
 
 				for (const textEdit of embeddedCodeResult.edits) {
@@ -152,7 +152,7 @@ export function register(context: ServiceContext) {
 
 					const indentSensitiveLines = new Set<number>();
 
-					for (const service of item.service.provideFormattingIndentSensitiveLines ? [item.service] : context.services) {
+					for (const service of item.service.provideFormattingIndentSensitiveLines ? [item.service] : context.services.map(service => service[1])) {
 
 						if (token.isCancellationRequested)
 							break;
@@ -252,12 +252,12 @@ export function register(context: ServiceContext) {
 
 				try {
 					if (ch !== undefined && 'line' in formatRange && 'character' in formatRange) {
-						if (service.autoFormatTriggerCharacters?.includes(ch)) {
-							edits = await service.provideOnTypeFormattingEdits?.(document, formatRange, ch, options, token);
+						if (service[0].autoFormatTriggerCharacters?.includes(ch)) {
+							edits = await service[1].provideOnTypeFormattingEdits?.(document, formatRange, ch, options, token);
 						}
 					}
 					else if (ch === undefined && 'start' in formatRange && 'end' in formatRange) {
-						edits = await service.provideDocumentFormattingEdits?.(document, formatRange, options, token);
+						edits = await service[1].provideDocumentFormattingEdits?.(document, formatRange, options, token);
 					}
 				}
 				catch (err) {

--- a/packages/language-service/lib/documentFeatures/format.ts
+++ b/packages/language-service/lib/documentFeatures/format.ts
@@ -1,7 +1,7 @@
 import { SourceMap, VirtualFile, forEachEmbeddedFile, isFormattingEnabled, resolveCommonLanguageId, updateVirtualFileMaps } from '@volar/language-core';
 import type * as vscode from 'vscode-languageserver-protocol';
 import { TextDocument } from 'vscode-languageserver-textdocument';
-import type { ServiceContext, ServicePlugin } from '../types';
+import type { ServiceContext, Service } from '../types';
 import { isInsideRange, stringToSnapshot } from '../utils/common';
 import { NoneCancellationToken } from '../utils/cancellation';
 import { SourceMapWithDocuments } from '../documents';
@@ -57,7 +57,7 @@ export function register(context: ServiceContext) {
 			const toPatchIndent: {
 				virtualFileUri: string;
 				isCodeBlock: boolean;
-				service: ServicePlugin;
+				service: Service;
 			}[] = [];
 
 			for (const file of embeddedFiles) {

--- a/packages/language-service/lib/documentFeatures/linkedEditingRanges.ts
+++ b/packages/language-service/lib/documentFeatures/linkedEditingRanges.ts
@@ -23,7 +23,7 @@ export function register(context: ServiceContext) {
 				if (token.isCancellationRequested)
 					return;
 
-				return service.provideLinkedEditingRanges?.(document, position, token);
+				return service[1].provideLinkedEditingRanges?.(document, position, token);
 			},
 			(ranges, map) => {
 				if (!map) {

--- a/packages/language-service/lib/documentFeatures/selectionRanges.ts
+++ b/packages/language-service/lib/documentFeatures/selectionRanges.ts
@@ -27,7 +27,7 @@ export function register(context: ServiceContext) {
 				if (token.isCancellationRequested)
 					return;
 
-				return service.provideSelectionRanges?.(document, positions, token);
+				return service[1].provideSelectionRanges?.(document, positions, token);
 			},
 			(data, map) => {
 				if (!map) {

--- a/packages/language-service/lib/languageFeatures/autoInsert.ts
+++ b/packages/language-service/lib/languageFeatures/autoInsert.ts
@@ -36,7 +36,7 @@ export function register(context: ServiceContext) {
 				if (token.isCancellationRequested) {
 					return;
 				}
-				return service.provideAutoInsertionEdit?.(document, arg.position, arg.autoInsertContext, token);
+				return service[1].provideAutoInsertionEdit?.(document, arg.position, arg.autoInsertContext, token);
 			},
 			(item, map) => {
 				if (!map || typeof item === 'string') {

--- a/packages/language-service/lib/languageFeatures/callHierarchy.ts
+++ b/packages/language-service/lib/languageFeatures/callHierarchy.ts
@@ -28,7 +28,7 @@ export function register(context: ServiceContext) {
 					if (token.isCancellationRequested) {
 						return;
 					}
-					const items = await service.provideCallHierarchyItems?.(document, position, token);
+					const items = await service[1].provideCallHierarchyItems?.(document, position, token);
 					items?.forEach(item => {
 						item.data = {
 							uri,
@@ -62,7 +62,7 @@ export function register(context: ServiceContext) {
 
 				const service = context.services[data.serviceIndex];
 
-				if (!service.provideCallHierarchyIncomingCalls)
+				if (!service[1].provideCallHierarchyIncomingCalls)
 					return incomingItems;
 
 				Object.assign(item, data.original);
@@ -73,7 +73,7 @@ export function register(context: ServiceContext) {
 
 					if (virtualFile) {
 
-						const _calls = await service.provideCallHierarchyIncomingCalls(item, token);
+						const _calls = await service[1].provideCallHierarchyIncomingCalls(item, token);
 
 						for (const _call of _calls) {
 
@@ -91,7 +91,7 @@ export function register(context: ServiceContext) {
 				}
 				else {
 
-					const _calls = await service.provideCallHierarchyIncomingCalls(item, token);
+					const _calls = await service[1].provideCallHierarchyIncomingCalls(item, token);
 
 					for (const _call of _calls) {
 
@@ -120,7 +120,7 @@ export function register(context: ServiceContext) {
 
 				const service = context.services[data.serviceIndex];
 
-				if (!service.provideCallHierarchyOutgoingCalls)
+				if (!service[1].provideCallHierarchyOutgoingCalls)
 					return items;
 
 				Object.assign(item, data.original);
@@ -131,7 +131,7 @@ export function register(context: ServiceContext) {
 
 					if (virtualFile) {
 
-						const _calls = await service.provideCallHierarchyOutgoingCalls(item, token);
+						const _calls = await service[1].provideCallHierarchyOutgoingCalls(item, token);
 
 						for (const call of _calls) {
 
@@ -149,7 +149,7 @@ export function register(context: ServiceContext) {
 				}
 				else {
 
-					const _calls = await service.provideCallHierarchyOutgoingCalls(item, token);
+					const _calls = await service[1].provideCallHierarchyOutgoingCalls(item, token);
 
 					for (const call of _calls) {
 

--- a/packages/language-service/lib/languageFeatures/codeActionResolve.ts
+++ b/packages/language-service/lib/languageFeatures/codeActionResolve.ts
@@ -13,13 +13,13 @@ export function register(context: ServiceContext) {
 		if (data) {
 
 			const service = context.services[data.serviceIndex];
-			if (!service.resolveCodeAction)
+			if (!service[1].resolveCodeAction)
 				return item;
 
 			Object.assign(item, data.original);
 
-			item = await service.resolveCodeAction(item, token);
-			item = service.transformCodeAction?.(item)
+			item = await service[1].resolveCodeAction(item, token);
+			item = service[1].transformCodeAction?.(item)
 				?? (
 					item.edit
 						? {

--- a/packages/language-service/lib/languageFeatures/codeActions.ts
+++ b/packages/language-service/lib/languageFeatures/codeActions.ts
@@ -96,7 +96,7 @@ export function register(context: ServiceContext) {
 					};
 				});
 
-				const codeActions = await service.provideCodeActions?.(document, range, {
+				const codeActions = await service[1].provideCodeActions?.(document, range, {
 					...codeActionContext,
 					diagnostics,
 				}, token);
@@ -113,9 +113,9 @@ export function register(context: ServiceContext) {
 					} satisfies ServiceCodeActionData;
 				});
 
-				if (codeActions && service.transformCodeAction) {
+				if (codeActions && service[1].transformCodeAction) {
 					for (let i = 0; i < codeActions.length; i++) {
-						const transformed = service.transformCodeAction(codeActions[i]);
+						const transformed = service[1].transformCodeAction(codeActions[i]);
 						if (transformed) {
 							codeActions[i] = transformed;
 							transformedCodeActions.add(transformed);

--- a/packages/language-service/lib/languageFeatures/codeLens.ts
+++ b/packages/language-service/lib/languageFeatures/codeLens.ts
@@ -32,7 +32,7 @@ export function register(context: ServiceContext) {
 				if (token.isCancellationRequested) {
 					return;
 				}
-				let codeLens = await service.provideCodeLenses?.(document, token);
+				let codeLens = await service[1].provideCodeLenses?.(document, token);
 
 				const serviceIndex = context.services.indexOf(service);
 
@@ -47,7 +47,7 @@ export function register(context: ServiceContext) {
 					} satisfies ServiceCodeLensData;
 				});
 
-				const ranges = await service.provideReferencesCodeLensRanges?.(document, token);
+				const ranges = await service[1].provideReferencesCodeLensRanges?.(document, token);
 				const referencesCodeLens = ranges?.map<vscode.CodeLens>(range => ({
 					range,
 					data: {

--- a/packages/language-service/lib/languageFeatures/codeLensResolve.ts
+++ b/packages/language-service/lib/languageFeatures/codeLensResolve.ts
@@ -15,11 +15,11 @@ export function register(context: ServiceContext) {
 		if (data?.kind === 'normal') {
 
 			const service = context.services[data.serviceIndex];
-			if (!service.resolveCodeLens)
+			if (!service[1].resolveCodeLens)
 				return item;
 
 			Object.assign(item, data.original);
-			item = await service.resolveCodeLens(item, token);
+			item = await service[1].resolveCodeLens(item, token);
 
 			// item.range already transformed in codeLens request
 		}
@@ -30,16 +30,16 @@ export function register(context: ServiceContext) {
 
 			const service = context.services[data.serviceIndex];
 
-			if (service.resolveReferencesCodeLensLocations) {
+			if (service[1].resolveReferencesCodeLensLocations) {
 				const virtualFile = context.language.files.getVirtualFile(data.workerFileUri)[0];
 				const sourceFile = context.language.files.getSourceFile(data.workerFileUri);
 				if (virtualFile) {
 					const document = context.documents.get(virtualFile.id, virtualFile.languageId, virtualFile.snapshot);
-					references = await service.resolveReferencesCodeLensLocations(document, data.workerFileRange, references, token);
+					references = await service[1].resolveReferencesCodeLensLocations(document, data.workerFileRange, references, token);
 				}
 				else if (sourceFile && !sourceFile?.virtualFile) {
 					const document = context.documents.get(sourceFile.id, sourceFile.languageId, sourceFile.snapshot);
-					references = await service.resolveReferencesCodeLensLocations(document, data.workerFileRange, references, token);
+					references = await service[1].resolveReferencesCodeLensLocations(document, data.workerFileRange, references, token);
 				}
 			}
 

--- a/packages/language-service/lib/languageFeatures/complete.ts
+++ b/packages/language-service/lib/languageFeatures/complete.ts
@@ -1,6 +1,6 @@
 import { isCompletionEnabled, type CodeInformation } from '@volar/language-core';
 import type * as vscode from 'vscode-languageserver-protocol';
-import type { ServiceContext, ServicePlugin } from '../types';
+import type { ServiceContext, Service } from '../types';
 import { NoneCancellationToken } from '../utils/cancellation';
 import { transformCompletionList } from '../utils/transform';
 import { visitEmbedded } from '../utils/featureWorkers';
@@ -18,7 +18,7 @@ export function register(context: ServiceContext) {
 		uri: string,
 		data: {
 			virtualDocumentUri: string | undefined,
-			service: ServicePlugin,
+			service: Service,
 			serviceIndex: number,
 			list: vscode.CompletionList,
 		}[],
@@ -265,7 +265,7 @@ export function register(context: ServiceContext) {
 
 		return combineCompletionList(cache.data.map(cacheData => cacheData.list));
 
-		function sortServices(a: ServicePlugin, b: ServicePlugin) {
+		function sortServices(a: Service, b: Service) {
 			return (b.isAdditionalCompletion ? -1 : 1) - (a.isAdditionalCompletion ? -1 : 1);
 		}
 

--- a/packages/language-service/lib/languageFeatures/complete.ts
+++ b/packages/language-service/lib/languageFeatures/complete.ts
@@ -1,6 +1,6 @@
 import { isCompletionEnabled, type CodeInformation } from '@volar/language-core';
 import type * as vscode from 'vscode-languageserver-protocol';
-import type { Service, ServiceContext } from '../types';
+import type { ServiceContext, ServicePlugin } from '../types';
 import { NoneCancellationToken } from '../utils/cancellation';
 import { transformCompletionList } from '../utils/transform';
 import { visitEmbedded } from '../utils/featureWorkers';
@@ -18,7 +18,8 @@ export function register(context: ServiceContext) {
 		uri: string,
 		data: {
 			virtualDocumentUri: string | undefined,
-			service: ReturnType<Service>,
+			service: ServicePlugin,
+			serviceIndex: number,
 			list: vscode.CompletionList,
 		}[],
 		mainCompletion: {
@@ -76,7 +77,7 @@ export function register(context: ServiceContext) {
 										textEdit: oldItem.textEdit,
 										data: oldItem.data,
 									},
-									serviceIndex: context.services.indexOf(cacheData.service),
+									serviceIndex: cacheData.serviceIndex,
 									virtualDocumentUri: map.virtualFileDocument.uri,
 								} satisfies ServiceCompletionData,
 							);
@@ -104,7 +105,7 @@ export function register(context: ServiceContext) {
 								textEdit: item.textEdit,
 								data: item.data,
 							},
-							serviceIndex: context.services.indexOf(cacheData.service),
+							serviceIndex: cacheData.serviceIndex,
 							virtualDocumentUri: undefined,
 						} satisfies ServiceCompletionData;
 					});
@@ -128,7 +129,7 @@ export function register(context: ServiceContext) {
 
 				await visitEmbedded(context, rootVirtualFile, async (_, map) => {
 
-					const services = [...context.services].sort(sortServices);
+					const services = [...context.services].sort((a, b) => sortServices(a[1], b[1]));
 
 					let _data: CodeInformation | undefined;
 
@@ -142,25 +143,25 @@ export function register(context: ServiceContext) {
 							if (token.isCancellationRequested)
 								break;
 
-							if (!service.provideCompletionItems)
+							if (!service[1].provideCompletionItems)
 								continue;
 
-							if (service.isAdditionalCompletion && !isFirstMapping)
+							if (service[1].isAdditionalCompletion && !isFirstMapping)
 								continue;
 
-							if (completionContext?.triggerCharacter && !service.triggerCharacters?.includes(completionContext.triggerCharacter))
+							if (completionContext?.triggerCharacter && !service[0].triggerCharacters?.includes(completionContext.triggerCharacter))
 								continue;
 
-							const isAdditional = _data && typeof _data.completion === 'object' && _data.completion.isAdditional || service.isAdditionalCompletion;
+							const isAdditional = _data && typeof _data.completion === 'object' && _data.completion.isAdditional || service[1].isAdditionalCompletion;
 
 							if (cache!.mainCompletion && (!isAdditional || cache?.mainCompletion.documentUri !== map.virtualFileDocument.uri))
 								continue;
 
 							// avoid duplicate items with .vue and .vue.html
-							if (service.isAdditionalCompletion && cache?.data.some(data => data.service === service))
+							if (service[1].isAdditionalCompletion && cache?.data.some(data => data.service === service))
 								continue;
 
-							const embeddedCompletionList = await service.provideCompletionItems(map.virtualFileDocument, mapped, completionContext!, token);
+							const embeddedCompletionList = await service[1].provideCompletionItems(map.virtualFileDocument, mapped, completionContext!, token);
 
 							if (!embeddedCompletionList || !embeddedCompletionList.items.length)
 								continue;
@@ -191,7 +192,8 @@ export function register(context: ServiceContext) {
 
 							cache!.data.push({
 								virtualDocumentUri: map.virtualFileDocument.uri,
-								service: service,
+								service: service[1],
+								serviceIndex: context.services.indexOf(service),
 								list: completionList,
 							});
 						}
@@ -206,35 +208,35 @@ export function register(context: ServiceContext) {
 			if (sourceFile) {
 
 				const document = context.documents.get(uri, sourceFile.languageId, sourceFile.snapshot);
-				const services = [...context.services].sort(sortServices);
+				const services = [...context.services].sort((a, b) => sortServices(a[1], b[1]));
 
 				for (const service of services) {
 
 					if (token.isCancellationRequested)
 						break;
 
-					if (!service.provideCompletionItems)
+					if (!service[1].provideCompletionItems)
 						continue;
 
-					if (service.isAdditionalCompletion && !isFirstMapping)
+					if (service[1].isAdditionalCompletion && !isFirstMapping)
 						continue;
 
-					if (completionContext?.triggerCharacter && !service.triggerCharacters?.includes(completionContext.triggerCharacter))
+					if (completionContext?.triggerCharacter && !service[0].triggerCharacters?.includes(completionContext.triggerCharacter))
 						continue;
 
-					if (cache.mainCompletion && (!service.isAdditionalCompletion || cache.mainCompletion.documentUri !== document.uri))
+					if (cache.mainCompletion && (!service[1].isAdditionalCompletion || cache.mainCompletion.documentUri !== document.uri))
 						continue;
 
 					// avoid duplicate items with .vue and .vue.html
-					if (service.isAdditionalCompletion && cache?.data.some(data => data.service === service))
+					if (service[1].isAdditionalCompletion && cache?.data.some(data => data.service === service))
 						continue;
 
-					const completionList = await service.provideCompletionItems(document, position, completionContext, token);
+					const completionList = await service[1].provideCompletionItems(document, position, completionContext, token);
 
 					if (!completionList || !completionList.items.length)
 						continue;
 
-					if (!service.isAdditionalCompletion) {
+					if (!service[1].isAdditionalCompletion) {
 						cache.mainCompletion = { documentUri: document.uri };
 					}
 
@@ -253,7 +255,8 @@ export function register(context: ServiceContext) {
 
 					cache.data.push({
 						virtualDocumentUri: undefined,
-						service: service,
+						service: service[1],
+						serviceIndex: context.services.indexOf(service),
 						list: completionList,
 					});
 				}
@@ -262,7 +265,7 @@ export function register(context: ServiceContext) {
 
 		return combineCompletionList(cache.data.map(cacheData => cacheData.list));
 
-		function sortServices(a: ReturnType<Service>, b: ReturnType<Service>) {
+		function sortServices(a: ServicePlugin, b: ServicePlugin) {
 			return (b.isAdditionalCompletion ? -1 : 1) - (a.isAdditionalCompletion ? -1 : 1);
 		}
 

--- a/packages/language-service/lib/languageFeatures/completeResolve.ts
+++ b/packages/language-service/lib/languageFeatures/completeResolve.ts
@@ -14,7 +14,7 @@ export function register(context: ServiceContext) {
 
 			const service = context.services[data.serviceIndex];
 
-			if (!service.resolveCompletionItem)
+			if (!service[1].resolveCompletionItem)
 				return item;
 
 			item = Object.assign(item, data.original);
@@ -27,8 +27,8 @@ export function register(context: ServiceContext) {
 
 					for (const map of context.documents.getMaps(virtualFile)) {
 
-						item = await service.resolveCompletionItem(item, token);
-						item = service.transformCompletionItem?.(item) ?? transformCompletionItem(
+						item = await service[1].resolveCompletionItem(item, token);
+						item = service[1].transformCompletionItem?.(item) ?? transformCompletionItem(
 							item,
 							embeddedRange => map.toSourceRange(embeddedRange),
 							map.virtualFileDocument,
@@ -37,7 +37,7 @@ export function register(context: ServiceContext) {
 				}
 			}
 			else {
-				item = await service.resolveCompletionItem(item, token);
+				item = await service[1].resolveCompletionItem(item, token);
 			}
 		}
 

--- a/packages/language-service/lib/languageFeatures/definition.ts
+++ b/packages/language-service/lib/languageFeatures/definition.ts
@@ -36,7 +36,7 @@ export function register(
 
 				async function withMirrors(document: TextDocument, position: vscode.Position, originDefinition: vscode.LocationLink | undefined) {
 
-					const api = service[apiName];
+					const api = service[1][apiName];
 					if (!api)
 						return;
 

--- a/packages/language-service/lib/languageFeatures/documentDrop.ts
+++ b/packages/language-service/lib/languageFeatures/documentDrop.ts
@@ -21,7 +21,7 @@ export function register(context: ServiceContext) {
 				if (token.isCancellationRequested) {
 					return;
 				}
-				return service.provideDocumentDropEdits?.(document, arg, dataTransfer, token);
+				return service[1].provideDocumentDropEdits?.(document, arg, dataTransfer, token);
 			},
 			(edit) => {
 				if (edit.additionalEdit) {

--- a/packages/language-service/lib/languageFeatures/documentHighlights.ts
+++ b/packages/language-service/lib/languageFeatures/documentHighlights.ts
@@ -31,7 +31,7 @@ export function register(context: ServiceContext) {
 
 				async function withMirrors(document: TextDocument, position: vscode.Position) {
 
-					if (!service.provideDocumentHighlights)
+					if (!service[1].provideDocumentHighlights)
 						return;
 
 					if (recursiveChecker.has({ uri: document.uri, range: { start: position, end: position } }))
@@ -39,7 +39,7 @@ export function register(context: ServiceContext) {
 
 					recursiveChecker.add({ uri: document.uri, range: { start: position, end: position } });
 
-					const references = await service.provideDocumentHighlights(document, position, token) ?? [];
+					const references = await service[1].provideDocumentHighlights(document, position, token) ?? [];
 
 					for (const reference of references) {
 

--- a/packages/language-service/lib/languageFeatures/documentLinkResolve.ts
+++ b/packages/language-service/lib/languageFeatures/documentLinkResolve.ts
@@ -12,11 +12,11 @@ export function register(context: ServiceContext) {
 		const data: DocumentLinkData | undefined = item.data;
 		if (data) {
 			const service = context.services[data.serviceIndex];
-			if (!service.resolveDocumentLink)
+			if (!service[1].resolveDocumentLink)
 				return item;
 
 			Object.assign(item, data.original);
-			item = await service.resolveDocumentLink(item, token);
+			item = await service[1].resolveDocumentLink(item, token);
 
 			if (item.target) {
 				item.target = transformDocumentLinkTarget(item.target, context);

--- a/packages/language-service/lib/languageFeatures/documentLinks.ts
+++ b/packages/language-service/lib/languageFeatures/documentLinks.ts
@@ -26,7 +26,7 @@ export function register(context: ServiceContext) {
 					return;
 				}
 
-				const links = await service.provideDocumentLinks?.(document, token);
+				const links = await service[1].provideDocumentLinks?.(document, token);
 
 				for (const link of links ?? []) {
 					link.data = {

--- a/packages/language-service/lib/languageFeatures/documentSemanticTokens.ts
+++ b/packages/language-service/lib/languageFeatures/documentSemanticTokens.ts
@@ -76,7 +76,7 @@ export function register(context: ServiceContext) {
 				if (token?.isCancellationRequested)
 					return;
 
-				return service.provideDocumentSemanticTokens?.(
+				return service[1].provideDocumentSemanticTokens?.(
 					document,
 					range,
 					legend,

--- a/packages/language-service/lib/languageFeatures/fileReferences.ts
+++ b/packages/language-service/lib/languageFeatures/fileReferences.ts
@@ -18,7 +18,7 @@ export function register(context: ServiceContext) {
 				if (token.isCancellationRequested) {
 					return;
 				}
-				return await service.provideFileReferences?.(document, token) ?? [];
+				return await service[1].provideFileReferences?.(document, token) ?? [];
 			},
 			(data) => data
 				.map(reference => {

--- a/packages/language-service/lib/languageFeatures/fileRename.ts
+++ b/packages/language-service/lib/languageFeatures/fileRename.ts
@@ -34,10 +34,10 @@ export function register(context: ServiceContext) {
 			if (token.isCancellationRequested)
 				break;
 
-			if (!service.provideFileRenameEdits)
+			if (!service[1].provideFileRenameEdits)
 				continue;
 
-			const workspaceEdit = await service.provideFileRenameEdits(oldUri, newUri, token);
+			const workspaceEdit = await service[1].provideFileRenameEdits(oldUri, newUri, token);
 
 			if (workspaceEdit) {
 

--- a/packages/language-service/lib/languageFeatures/hover.ts
+++ b/packages/language-service/lib/languageFeatures/hover.ts
@@ -19,7 +19,7 @@ export function register(context: ServiceContext) {
 				if (token.isCancellationRequested) {
 					return;
 				}
-				return service.provideHover?.(document, position, token);
+				return service[1].provideHover?.(document, position, token);
 			},
 			(item, map) => {
 				if (!map || !item.range) {

--- a/packages/language-service/lib/languageFeatures/inlayHintResolve.ts
+++ b/packages/language-service/lib/languageFeatures/inlayHintResolve.ts
@@ -10,11 +10,11 @@ export function register(context: ServiceContext) {
 		const data: InlayHintData | undefined = item.data;
 		if (data) {
 			const service = context.services[data.serviceIndex];
-			if (!service.resolveInlayHint)
+			if (!service[1].resolveInlayHint)
 				return item;
 
 			Object.assign(item, data.original);
-			item = await service.resolveInlayHint(item, token);
+			item = await service[1].resolveInlayHint(item, token);
 		}
 
 		return item;

--- a/packages/language-service/lib/languageFeatures/inlayHints.ts
+++ b/packages/language-service/lib/languageFeatures/inlayHints.ts
@@ -72,7 +72,7 @@ export function register(context: ServiceContext) {
 				if (token.isCancellationRequested) {
 					return;
 				}
-				const hints = await service.provideInlayHints?.(document, arg, token);
+				const hints = await service[1].provideInlayHints?.(document, arg, token);
 				hints?.forEach(link => {
 					link.data = {
 						uri,

--- a/packages/language-service/lib/languageFeatures/references.ts
+++ b/packages/language-service/lib/languageFeatures/references.ts
@@ -29,7 +29,7 @@ export function register(context: ServiceContext) {
 
 				async function withMirrors(document: TextDocument, position: vscode.Position) {
 
-					if (!service.provideReferences)
+					if (!service[1].provideReferences)
 						return;
 
 					if (recursiveChecker.has({ uri: document.uri, range: { start: position, end: position } }))
@@ -37,7 +37,7 @@ export function register(context: ServiceContext) {
 
 					recursiveChecker.add({ uri: document.uri, range: { start: position, end: position } });
 
-					const references = await service.provideReferences(document, position, token) ?? [];
+					const references = await service[1].provideReferences(document, position, token) ?? [];
 
 					for (const reference of references) {
 

--- a/packages/language-service/lib/languageFeatures/rename.ts
+++ b/packages/language-service/lib/languageFeatures/rename.ts
@@ -42,7 +42,7 @@ export function register(context: ServiceContext) {
 
 				async function withMirrors(document: TextDocument, position: vscode.Position, newName: string) {
 
-					if (!service.provideRenameEdits)
+					if (!service[1].provideRenameEdits)
 						return;
 
 					if (recursiveChecker.has({ uri: document.uri, range: { start: position, end: position } }))
@@ -50,7 +50,7 @@ export function register(context: ServiceContext) {
 
 					recursiveChecker.add({ uri: document.uri, range: { start: position, end: position } });
 
-					const workspaceEdit = await service.provideRenameEdits(document, position, newName, token);
+					const workspaceEdit = await service[1].provideRenameEdits(document, position, newName, token);
 
 					if (!workspaceEdit)
 						return;

--- a/packages/language-service/lib/languageFeatures/renamePrepare.ts
+++ b/packages/language-service/lib/languageFeatures/renamePrepare.ts
@@ -17,7 +17,7 @@ export function register(context: ServiceContext) {
 				if (token.isCancellationRequested) {
 					return;
 				}
-				return service.provideRenameRange?.(document, position, token);
+				return service[1].provideRenameRange?.(document, position, token);
 			},
 			(item, map) => {
 				if (!map) {

--- a/packages/language-service/lib/languageFeatures/signatureHelp.ts
+++ b/packages/language-service/lib/languageFeatures/signatureHelp.ts
@@ -30,13 +30,13 @@ export function register(context: ServiceContext) {
 					&& signatureHelpContext.triggerCharacter
 					&& !(
 						signatureHelpContext.isRetrigger
-							? service.signatureHelpRetriggerCharacters
-							: service.signatureHelpTriggerCharacters
+							? service[0].signatureHelpRetriggerCharacters
+							: service[0].signatureHelpTriggerCharacters
 					)?.includes(signatureHelpContext.triggerCharacter)
 				) {
 					return;
 				}
-				return service.provideSignatureHelp?.(document, position, signatureHelpContext!, token);
+				return service[1].provideSignatureHelp?.(document, position, signatureHelpContext!, token);
 			},
 			(data) => data,
 		);

--- a/packages/language-service/lib/languageFeatures/validation.ts
+++ b/packages/language-service/lib/languageFeatures/validation.ts
@@ -220,7 +220,7 @@ export function register(context: ServiceContext) {
 			errorMarkups[uri] = [];
 			for (const error of errors) {
 				for (const service of context.services) {
-					const markup = await service.provideDiagnosticMarkupContent?.(error, token);
+					const markup = await service[1].provideDiagnosticMarkupContent?.(error, token);
 					if (markup) {
 						errorMarkups[uri].push({ error, markup });
 					}
@@ -258,7 +258,7 @@ export function register(context: ServiceContext) {
 						return cache.errors;
 					}
 
-					const errors = await service[api]?.(document, token);
+					const errors = await service[1][api]?.(document, token);
 
 					errors?.forEach(error => {
 						error.data = {

--- a/packages/language-service/lib/languageFeatures/workspaceSymbols.ts
+++ b/packages/language-service/lib/languageFeatures/workspaceSymbols.ts
@@ -14,10 +14,10 @@ export function register(context: ServiceContext) {
 			if (token.isCancellationRequested) {
 				break;
 			}
-			if (!service.provideWorkspaceSymbols) {
+			if (!service[1].provideWorkspaceSymbols) {
 				continue;
 			}
-			const embeddedSymbols = await service.provideWorkspaceSymbols(query, token);
+			const embeddedSymbols = await service[1].provideWorkspaceSymbols(query, token);
 			if (!embeddedSymbols) {
 				continue;
 			}

--- a/packages/language-service/lib/languageService.ts
+++ b/packages/language-service/lib/languageService.ts
@@ -25,7 +25,7 @@ import * as signatureHelp from './languageFeatures/signatureHelp';
 import * as diagnostics from './languageFeatures/validation';
 import * as workspaceSymbol from './languageFeatures/workspaceSymbols';
 import * as documentDrop from './languageFeatures/documentDrop';
-import type { ServicePluginFactory, ServiceContext, ServiceEnvironment } from './types';
+import type { ServicePlugin, ServiceContext, ServiceEnvironment } from './types';
 
 import type * as vscode from 'vscode-languageserver-protocol';
 import * as colorPresentations from './documentFeatures/colorPresentations';
@@ -40,7 +40,7 @@ export type LanguageService = ReturnType<typeof createLanguageService>;
 
 export function createLanguageService(
 	language: Language,
-	servicePlugins: ServicePluginFactory[],
+	servicePlugins: ServicePlugin[],
 	env: ServiceEnvironment,
 ) {
 

--- a/packages/language-service/lib/languageService.ts
+++ b/packages/language-service/lib/languageService.ts
@@ -25,7 +25,7 @@ import * as signatureHelp from './languageFeatures/signatureHelp';
 import * as diagnostics from './languageFeatures/validation';
 import * as workspaceSymbol from './languageFeatures/workspaceSymbols';
 import * as documentDrop from './languageFeatures/documentDrop';
-import type { Service, ServiceContext, ServiceEnvironment, SharedModules } from './types';
+import type { ServicePluginFactory, ServiceContext, ServiceEnvironment } from './types';
 
 import type * as vscode from 'vscode-languageserver-protocol';
 import * as colorPresentations from './documentFeatures/colorPresentations';
@@ -39,20 +39,19 @@ import * as selectionRanges from './documentFeatures/selectionRanges';
 export type LanguageService = ReturnType<typeof createLanguageService>;
 
 export function createLanguageService(
-	modules: SharedModules,
-	services: Service[],
-	env: ServiceEnvironment,
 	language: Language,
+	servicePlugins: ServicePluginFactory[],
+	env: ServiceEnvironment,
 ) {
 
 	const context = createServiceContext();
 
 	return {
 
-		getTriggerCharacters: () => context.services.map(service => service.triggerCharacters ?? []).flat(),
-		getAutoFormatTriggerCharacters: () => context.services.map(service => service.autoFormatTriggerCharacters ?? []).flat(),
-		getSignatureHelpTriggerCharacters: () => context.services.map(service => service.signatureHelpTriggerCharacters ?? []).flat(),
-		getSignatureHelpRetriggerCharacters: () => context.services.map(service => service.signatureHelpRetriggerCharacters ?? []).flat(),
+		getTriggerCharacters: () => context.services.map(service => service[0].triggerCharacters ?? []).flat(),
+		getAutoFormatTriggerCharacters: () => context.services.map(service => service[0].autoFormatTriggerCharacters ?? []).flat(),
+		getSignatureHelpTriggerCharacters: () => context.services.map(service => service[0].signatureHelpTriggerCharacters ?? []).flat(),
+		getSignatureHelpRetriggerCharacters: () => context.services.map(service => service[0].signatureHelpRetriggerCharacters ?? []).flat(),
 
 		format: format.register(context),
 		getFoldingRanges: foldingRanges.register(context),
@@ -89,7 +88,7 @@ export function createLanguageService(
 		getInlayHints: inlayHints.register(context),
 		doInlayHintResolve: inlayHintResolve.register(context),
 		callHierarchy: callHierarchy.register(context),
-		dispose: () => context.services.forEach(service => service.dispose?.()),
+		dispose: () => context.services.forEach(service => service[1].dispose?.()),
 		context,
 	};
 
@@ -101,7 +100,7 @@ export function createLanguageService(
 			language: language,
 			inject: (key, ...args) => {
 				for (const service of context.services) {
-					const provide = service.provide?.[key as any];
+					const provide = service[1].provide?.[key as any];
 					if (provide) {
 						return provide(...args as any);
 					}
@@ -164,8 +163,8 @@ export function createLanguageService(
 			},
 		};
 
-		for (const service of services) {
-			context.services.push(service(context, modules));
+		for (const servicePlugin of servicePlugins) {
+			context.services.push([servicePlugin, servicePlugin.create(context)]);
 		}
 
 		return context;

--- a/packages/language-service/lib/types.ts
+++ b/packages/language-service/lib/types.ts
@@ -71,7 +71,7 @@ export interface ServiceContext<Provide = any> {
 		setSelection: Command<(position: vscode.Position) => vscode.Command | undefined>;
 	};
 	documents: DocumentProvider;
-	services: [ServicePluginFactory, ServicePlugin][];
+	services: [ServicePlugin, Service][];
 }
 
 export type Result<T> = T | Thenable<T>;
@@ -80,15 +80,15 @@ export type SemanticToken = [number, number, number, number, number];
 
 type ServiceProvide<P> = P extends undefined ? { provide?: undefined; } : { provide: P; };
 
-export interface ServicePluginFactory<P = any> {
+export interface ServicePlugin<P = any> {
 	triggerCharacters?: string[];
 	signatureHelpTriggerCharacters?: string[];
 	signatureHelpRetriggerCharacters?: string[];
 	autoFormatTriggerCharacters?: string[];
-	create(context: ServiceContext): ServicePlugin<P>;
+	create(context: ServiceContext): Service<P>;
 }
 
-export type ServicePlugin<P = any> = ServiceProvide<P> & {
+export type Service<P = any> = ServiceProvide<P> & {
 	isAdditionalCompletion?: boolean; // volar specific
 	provideHover?(document: TextDocument, position: vscode.Position, token: vscode.CancellationToken): NullableResult<vscode.Hover>,
 	provideDocumentSymbols?(document: TextDocument, token: vscode.CancellationToken): NullableResult<vscode.DocumentSymbol[]>;

--- a/packages/language-service/lib/types.ts
+++ b/packages/language-service/lib/types.ts
@@ -71,7 +71,7 @@ export interface ServiceContext<Provide = any> {
 		setSelection: Command<(position: vscode.Position) => vscode.Command | undefined>;
 	};
 	documents: DocumentProvider;
-	services: ReturnType<Service>[];
+	services: [ServicePluginFactory, ServicePlugin][];
 }
 
 export type Result<T> = T | Thenable<T>;
@@ -80,60 +80,62 @@ export type SemanticToken = [number, number, number, number, number];
 
 type ServiceProvide<P> = P extends undefined ? { provide?: undefined; } : { provide: P; };
 
-export interface Service<P = any> {
-	(context: ServiceContext | undefined, modules: SharedModules | undefined): {
-		isAdditionalCompletion?: boolean; // volar specific
-		triggerCharacters?: string[];
-		signatureHelpTriggerCharacters?: string[];
-		signatureHelpRetriggerCharacters?: string[];
-		autoFormatTriggerCharacters?: string[];
-		provideHover?(document: TextDocument, position: vscode.Position, token: vscode.CancellationToken): NullableResult<vscode.Hover>,
-		provideDocumentSymbols?(document: TextDocument, token: vscode.CancellationToken): NullableResult<vscode.DocumentSymbol[]>;
-		provideDocumentHighlights?(document: TextDocument, position: vscode.Position, token: vscode.CancellationToken): NullableResult<vscode.DocumentHighlight[]>;
-		provideLinkedEditingRanges?(document: TextDocument, position: vscode.Position, token: vscode.CancellationToken): NullableResult<vscode.LinkedEditingRanges>;
-		provideDefinition?(document: TextDocument, position: vscode.Position, token: vscode.CancellationToken): NullableResult<vscode.LocationLink[]>;
-		provideTypeDefinition?(document: TextDocument, position: vscode.Position, token: vscode.CancellationToken): NullableResult<vscode.LocationLink[]>;
-		provideImplementation?(document: TextDocument, position: vscode.Position, token: vscode.CancellationToken): NullableResult<vscode.LocationLink[]>;
-		provideCodeLenses?(document: TextDocument, token: vscode.CancellationToken): NullableResult<vscode.CodeLens[]>;
-		provideCodeActions?(document: TextDocument, range: vscode.Range, context: vscode.CodeActionContext, token: vscode.CancellationToken): NullableResult<vscode.CodeAction[]>;
-		provideDocumentFormattingEdits?(document: TextDocument, range: vscode.Range, options: vscode.FormattingOptions, token: vscode.CancellationToken): NullableResult<vscode.TextEdit[]>;
-		provideOnTypeFormattingEdits?(document: TextDocument, position: vscode.Position, key: string, options: vscode.FormattingOptions, token: vscode.CancellationToken): NullableResult<vscode.TextEdit[]>;
-		provideDocumentLinks?(document: TextDocument, token: vscode.CancellationToken): NullableResult<vscode.DocumentLink[]>;
-		provideCompletionItems?(document: TextDocument, position: vscode.Position, context: vscode.CompletionContext, token: vscode.CancellationToken): NullableResult<vscode.CompletionList>,
-		provideDocumentColors?(document: TextDocument, token: vscode.CancellationToken): NullableResult<vscode.ColorInformation[]>;
-		provideColorPresentations?(document: TextDocument, color: vscode.Color, range: vscode.Range, token: vscode.CancellationToken): NullableResult<vscode.ColorPresentation[]>;
-		provideFoldingRanges?(document: TextDocument, token: vscode.CancellationToken): NullableResult<vscode.FoldingRange[]>;
-		provideSignatureHelp?(document: TextDocument, position: vscode.Position, context: vscode.SignatureHelpContext, token: vscode.CancellationToken): NullableResult<vscode.SignatureHelp>;
-		provideRenameRange?(document: TextDocument, position: vscode.Position, token: vscode.CancellationToken): NullableResult<vscode.Range | { range: vscode.Range; placeholder: string; } | { message: string; }>;
-		provideRenameEdits?(document: TextDocument, position: vscode.Position, newName: string, token: vscode.CancellationToken): NullableResult<vscode.WorkspaceEdit>;
-		provideReferences?(document: TextDocument, position: vscode.Position, token: vscode.CancellationToken): NullableResult<vscode.Location[]>;
-		provideSelectionRanges?(document: TextDocument, positions: vscode.Position[], token: vscode.CancellationToken): NullableResult<vscode.SelectionRange[]>;
-		provideInlayHints?(document: TextDocument, range: vscode.Range, token: vscode.CancellationToken): NullableResult<vscode.InlayHint[]>,
-		provideCallHierarchyItems?(document: TextDocument, position: vscode.Position, token: vscode.CancellationToken): NullableResult<vscode.CallHierarchyItem[]>;
-		provideCallHierarchyIncomingCalls?(item: vscode.CallHierarchyItem, token: vscode.CancellationToken): Result<vscode.CallHierarchyIncomingCall[]>;
-		provideCallHierarchyOutgoingCalls?(item: vscode.CallHierarchyItem, token: vscode.CancellationToken): Result<vscode.CallHierarchyOutgoingCall[]>;
-		provideDocumentSemanticTokens?(document: TextDocument, range: vscode.Range, legend: vscode.SemanticTokensLegend, token: vscode.CancellationToken): NullableResult<SemanticToken[]>;
-		provideWorkspaceSymbols?(query: string, token: vscode.CancellationToken): NullableResult<vscode.WorkspaceSymbol[]>;
-		provideDiagnostics?(document: TextDocument, token: vscode.CancellationToken): NullableResult<vscode.Diagnostic[]>;
-		provideSemanticDiagnostics?(document: TextDocument, token: vscode.CancellationToken): NullableResult<vscode.Diagnostic[]>;
-		provideDiagnosticMarkupContent?(diagnostic: vscode.Diagnostic, token: vscode.CancellationToken): NullableResult<vscode.MarkupContent>;
-		provideFileReferences?(document: TextDocument, token: vscode.CancellationToken): NullableResult<vscode.Location[]>; // volar specific
-		provideReferencesCodeLensRanges?(document: TextDocument, token: vscode.CancellationToken): NullableResult<vscode.Range[]>; // volar specific
-		provideAutoInsertionEdit?(document: TextDocument, position: vscode.Position, context: AutoInsertionContext, token: vscode.CancellationToken): NullableResult<string | vscode.TextEdit>; // volar specific
-		provideFileRenameEdits?(oldUri: string, newUri: string, token: vscode.CancellationToken): NullableResult<vscode.WorkspaceEdit>; // volar specific
-		provideFormattingIndentSensitiveLines?(document: TextDocument, token: vscode.CancellationToken): NullableResult<number[]>; // volar specific
-		provideDocumentDropEdits?(document: TextDocument, position: vscode.Position, dataTransfer: Map<string, DataTransferItem>, token: vscode.CancellationToken): NullableResult<DocumentDropEdit>; // volar specific
-		resolveCodeLens?(codeLens: vscode.CodeLens, token: vscode.CancellationToken): Result<vscode.CodeLens>;
-		resolveCodeAction?(codeAction: vscode.CodeAction, token: vscode.CancellationToken): Result<vscode.CodeAction>;
-		resolveCompletionItem?(item: vscode.CompletionItem, token: vscode.CancellationToken): Result<vscode.CompletionItem>,
-		resolveDocumentLink?(link: vscode.DocumentLink, token: vscode.CancellationToken): Result<vscode.DocumentLink>;
-		resolveInlayHint?(inlayHint: vscode.InlayHint, token: vscode.CancellationToken): Result<vscode.InlayHint>;
-		resolveReferencesCodeLensLocations?(document: TextDocument, range: vscode.Range, references: vscode.Location[], token: vscode.CancellationToken): Result<vscode.Location[]>; // volar specific
-		transformCompletionItem?(item: vscode.CompletionItem): vscode.CompletionItem | undefined; // volar specific
-		transformCodeAction?(item: vscode.CodeAction): vscode.CodeAction | undefined; // volar specific
-		dispose?(): void;
-	} & ServiceProvide<P>;
+export interface ServicePluginFactory<P = any> {
+	triggerCharacters?: string[];
+	signatureHelpTriggerCharacters?: string[];
+	signatureHelpRetriggerCharacters?: string[];
+	autoFormatTriggerCharacters?: string[];
+	create(context: ServiceContext): ServicePlugin<P>;
 }
+
+export type ServicePlugin<P = any> = ServiceProvide<P> & {
+	isAdditionalCompletion?: boolean; // volar specific
+	provideHover?(document: TextDocument, position: vscode.Position, token: vscode.CancellationToken): NullableResult<vscode.Hover>,
+	provideDocumentSymbols?(document: TextDocument, token: vscode.CancellationToken): NullableResult<vscode.DocumentSymbol[]>;
+	provideDocumentHighlights?(document: TextDocument, position: vscode.Position, token: vscode.CancellationToken): NullableResult<vscode.DocumentHighlight[]>;
+	provideLinkedEditingRanges?(document: TextDocument, position: vscode.Position, token: vscode.CancellationToken): NullableResult<vscode.LinkedEditingRanges>;
+	provideDefinition?(document: TextDocument, position: vscode.Position, token: vscode.CancellationToken): NullableResult<vscode.LocationLink[]>;
+	provideTypeDefinition?(document: TextDocument, position: vscode.Position, token: vscode.CancellationToken): NullableResult<vscode.LocationLink[]>;
+	provideImplementation?(document: TextDocument, position: vscode.Position, token: vscode.CancellationToken): NullableResult<vscode.LocationLink[]>;
+	provideCodeLenses?(document: TextDocument, token: vscode.CancellationToken): NullableResult<vscode.CodeLens[]>;
+	provideCodeActions?(document: TextDocument, range: vscode.Range, context: vscode.CodeActionContext, token: vscode.CancellationToken): NullableResult<vscode.CodeAction[]>;
+	provideDocumentFormattingEdits?(document: TextDocument, range: vscode.Range, options: vscode.FormattingOptions, token: vscode.CancellationToken): NullableResult<vscode.TextEdit[]>;
+	provideOnTypeFormattingEdits?(document: TextDocument, position: vscode.Position, key: string, options: vscode.FormattingOptions, token: vscode.CancellationToken): NullableResult<vscode.TextEdit[]>;
+	provideDocumentLinks?(document: TextDocument, token: vscode.CancellationToken): NullableResult<vscode.DocumentLink[]>;
+	provideCompletionItems?(document: TextDocument, position: vscode.Position, context: vscode.CompletionContext, token: vscode.CancellationToken): NullableResult<vscode.CompletionList>,
+	provideDocumentColors?(document: TextDocument, token: vscode.CancellationToken): NullableResult<vscode.ColorInformation[]>;
+	provideColorPresentations?(document: TextDocument, color: vscode.Color, range: vscode.Range, token: vscode.CancellationToken): NullableResult<vscode.ColorPresentation[]>;
+	provideFoldingRanges?(document: TextDocument, token: vscode.CancellationToken): NullableResult<vscode.FoldingRange[]>;
+	provideSignatureHelp?(document: TextDocument, position: vscode.Position, context: vscode.SignatureHelpContext, token: vscode.CancellationToken): NullableResult<vscode.SignatureHelp>;
+	provideRenameRange?(document: TextDocument, position: vscode.Position, token: vscode.CancellationToken): NullableResult<vscode.Range | { range: vscode.Range; placeholder: string; } | { message: string; }>;
+	provideRenameEdits?(document: TextDocument, position: vscode.Position, newName: string, token: vscode.CancellationToken): NullableResult<vscode.WorkspaceEdit>;
+	provideReferences?(document: TextDocument, position: vscode.Position, token: vscode.CancellationToken): NullableResult<vscode.Location[]>;
+	provideSelectionRanges?(document: TextDocument, positions: vscode.Position[], token: vscode.CancellationToken): NullableResult<vscode.SelectionRange[]>;
+	provideInlayHints?(document: TextDocument, range: vscode.Range, token: vscode.CancellationToken): NullableResult<vscode.InlayHint[]>,
+	provideCallHierarchyItems?(document: TextDocument, position: vscode.Position, token: vscode.CancellationToken): NullableResult<vscode.CallHierarchyItem[]>;
+	provideCallHierarchyIncomingCalls?(item: vscode.CallHierarchyItem, token: vscode.CancellationToken): Result<vscode.CallHierarchyIncomingCall[]>;
+	provideCallHierarchyOutgoingCalls?(item: vscode.CallHierarchyItem, token: vscode.CancellationToken): Result<vscode.CallHierarchyOutgoingCall[]>;
+	provideDocumentSemanticTokens?(document: TextDocument, range: vscode.Range, legend: vscode.SemanticTokensLegend, token: vscode.CancellationToken): NullableResult<SemanticToken[]>;
+	provideWorkspaceSymbols?(query: string, token: vscode.CancellationToken): NullableResult<vscode.WorkspaceSymbol[]>;
+	provideDiagnostics?(document: TextDocument, token: vscode.CancellationToken): NullableResult<vscode.Diagnostic[]>;
+	provideSemanticDiagnostics?(document: TextDocument, token: vscode.CancellationToken): NullableResult<vscode.Diagnostic[]>;
+	provideDiagnosticMarkupContent?(diagnostic: vscode.Diagnostic, token: vscode.CancellationToken): NullableResult<vscode.MarkupContent>;
+	provideFileReferences?(document: TextDocument, token: vscode.CancellationToken): NullableResult<vscode.Location[]>; // volar specific
+	provideReferencesCodeLensRanges?(document: TextDocument, token: vscode.CancellationToken): NullableResult<vscode.Range[]>; // volar specific
+	provideAutoInsertionEdit?(document: TextDocument, position: vscode.Position, context: AutoInsertionContext, token: vscode.CancellationToken): NullableResult<string | vscode.TextEdit>; // volar specific
+	provideFileRenameEdits?(oldUri: string, newUri: string, token: vscode.CancellationToken): NullableResult<vscode.WorkspaceEdit>; // volar specific
+	provideFormattingIndentSensitiveLines?(document: TextDocument, token: vscode.CancellationToken): NullableResult<number[]>; // volar specific
+	provideDocumentDropEdits?(document: TextDocument, position: vscode.Position, dataTransfer: Map<string, DataTransferItem>, token: vscode.CancellationToken): NullableResult<DocumentDropEdit>; // volar specific
+	resolveCodeLens?(codeLens: vscode.CodeLens, token: vscode.CancellationToken): Result<vscode.CodeLens>;
+	resolveCodeAction?(codeAction: vscode.CodeAction, token: vscode.CancellationToken): Result<vscode.CodeAction>;
+	resolveCompletionItem?(item: vscode.CompletionItem, token: vscode.CancellationToken): Result<vscode.CompletionItem>,
+	resolveDocumentLink?(link: vscode.DocumentLink, token: vscode.CancellationToken): Result<vscode.DocumentLink>;
+	resolveInlayHint?(inlayHint: vscode.InlayHint, token: vscode.CancellationToken): Result<vscode.InlayHint>;
+	resolveReferencesCodeLensLocations?(document: TextDocument, range: vscode.Range, references: vscode.Location[], token: vscode.CancellationToken): Result<vscode.Location[]>; // volar specific
+	transformCompletionItem?(item: vscode.CompletionItem): vscode.CompletionItem | undefined; // volar specific
+	transformCodeAction?(item: vscode.CodeAction): vscode.CodeAction | undefined; // volar specific
+	dispose?(): void;
+};
 
 export interface DocumentDropEdit {
 	insertText: string;

--- a/packages/language-service/lib/utils/featureWorkers.ts
+++ b/packages/language-service/lib/utils/featureWorkers.ts
@@ -1,13 +1,13 @@
 import type { CodeInformation, VirtualFile } from '@volar/language-core';
 import type { TextDocument } from 'vscode-languageserver-textdocument';
 import type { SourceMapWithDocuments } from '../documents';
-import type { ServiceContext, ServicePlugin, ServicePluginFactory } from '../types';
+import type { ServiceContext, Service, ServicePlugin } from '../types';
 
 export async function documentFeatureWorker<T>(
 	context: ServiceContext,
 	uri: string,
 	valid: (map: SourceMapWithDocuments<CodeInformation>) => boolean,
-	worker: (service: [ServicePluginFactory, ServicePlugin], document: TextDocument) => Thenable<T | null | undefined> | T | null | undefined,
+	worker: (service: [ServicePlugin, Service], document: TextDocument) => Thenable<T | null | undefined> | T | null | undefined,
 	transformResult: (result: T, map?: SourceMapWithDocuments<CodeInformation>) => T | undefined,
 	combineResult?: (results: T[]) => T,
 ) {
@@ -31,7 +31,7 @@ export async function languageFeatureWorker<T, K>(
 	uri: string,
 	getReadDocParams: () => K,
 	eachVirtualDocParams: (map: SourceMapWithDocuments<CodeInformation>) => Generator<K>,
-	worker: (service: [ServicePluginFactory, ServicePlugin], document: TextDocument, params: K, map?: SourceMapWithDocuments<CodeInformation>) => Thenable<T | null | undefined> | T | null | undefined,
+	worker: (service: [ServicePlugin, Service], document: TextDocument, params: K, map?: SourceMapWithDocuments<CodeInformation>) => Thenable<T | null | undefined> | T | null | undefined,
 	transformResult: (result: T, map?: SourceMapWithDocuments<CodeInformation>) => T | undefined,
 	combineResult?: (results: T[]) => T,
 ) {

--- a/packages/language-service/lib/utils/featureWorkers.ts
+++ b/packages/language-service/lib/utils/featureWorkers.ts
@@ -1,13 +1,13 @@
 import type { CodeInformation, VirtualFile } from '@volar/language-core';
 import type { TextDocument } from 'vscode-languageserver-textdocument';
 import type { SourceMapWithDocuments } from '../documents';
-import type { Service, ServiceContext } from '../types';
+import type { ServiceContext, ServicePlugin, ServicePluginFactory } from '../types';
 
 export async function documentFeatureWorker<T>(
 	context: ServiceContext,
 	uri: string,
 	valid: (map: SourceMapWithDocuments<CodeInformation>) => boolean,
-	worker: (service: ReturnType<Service>, document: TextDocument) => Thenable<T | null | undefined> | T | null | undefined,
+	worker: (service: [ServicePluginFactory, ServicePlugin], document: TextDocument) => Thenable<T | null | undefined> | T | null | undefined,
 	transformResult: (result: T, map?: SourceMapWithDocuments<CodeInformation>) => T | undefined,
 	combineResult?: (results: T[]) => T,
 ) {
@@ -31,7 +31,7 @@ export async function languageFeatureWorker<T, K>(
 	uri: string,
 	getReadDocParams: () => K,
 	eachVirtualDocParams: (map: SourceMapWithDocuments<CodeInformation>) => Generator<K>,
-	worker: (service: ReturnType<Service>, document: TextDocument, params: K, map?: SourceMapWithDocuments<CodeInformation>) => Thenable<T | null | undefined> | T | null | undefined,
+	worker: (service: [ServicePluginFactory, ServicePlugin], document: TextDocument, params: K, map?: SourceMapWithDocuments<CodeInformation>) => Thenable<T | null | undefined> | T | null | undefined,
 	transformResult: (result: T, map?: SourceMapWithDocuments<CodeInformation>) => T | undefined,
 	combineResult?: (results: T[]) => T,
 ) {

--- a/packages/monaco/worker.ts
+++ b/packages/monaco/worker.ts
@@ -1,13 +1,12 @@
 import {
 	LanguagePlugin,
 	Language,
-	Service,
+	ServicePluginFactory,
 	createLanguageService as _createLanguageService,
 	createFileProvider,
 	resolveCommonLanguageId,
 	type LanguageService,
 	type ServiceEnvironment,
-	type SharedModules,
 } from '@volar/language-service';
 import type * as monaco from 'monaco-editor-core';
 import type * as ts from 'typescript/lib/tsserverlibrary.js';
@@ -15,14 +14,12 @@ import { URI } from 'vscode-uri';
 import { createLanguage, createSys, LanguageHost } from '@volar/typescript';
 
 export function createSimpleWorkerService<T = {}>(
-	modules: SharedModules,
 	languages: LanguagePlugin[],
-	services: Service[],
+	services: ServicePluginFactory[],
 	getMirrorModels: monaco.worker.IWorkerContext<any>['getMirrorModels'],
 	extraApis: T = {} as any,
 ) {
 	return createWorkerService(
-		modules,
 		services,
 		() => {
 			const snapshots = new Map<monaco.worker.IMirrorModel, readonly [number, ts.IScriptSnapshot]>();
@@ -60,13 +57,12 @@ export function createSimpleWorkerService<T = {}>(
 export function createTypeScriptWorkerService<T = {}>(
 	ts: typeof import('typescript/lib/tsserverlibrary.js'),
 	languages: LanguagePlugin[],
-	services: Service[],
+	services: ServicePluginFactory[],
 	getMirrorModels: monaco.worker.IWorkerContext<any>['getMirrorModels'],
 	compilerOptions: ts.CompilerOptions,
 	extraApis: T = {} as any,
 ) {
 	return createWorkerService(
-		{ typescript: ts as any },
 		services,
 		env => {
 
@@ -136,8 +132,7 @@ export function createTypeScriptWorkerService<T = {}>(
 }
 
 function createWorkerService<T = {}>(
-	modules: SharedModules,
-	services: Service[],
+	services: ServicePluginFactory[],
 	getLanguage: (env: ServiceEnvironment) => Language,
 	extraApis: T = {} as any,
 ): LanguageService & T {
@@ -153,10 +148,9 @@ function createWorkerService<T = {}>(
 	};
 	const language = getLanguage(env);
 	const languageService = _createLanguageService(
-		modules,
+		language,
 		services,
 		env,
-		language,
 	);
 
 	class WorkerService {

--- a/packages/monaco/worker.ts
+++ b/packages/monaco/worker.ts
@@ -1,7 +1,7 @@
 import {
 	LanguagePlugin,
 	Language,
-	ServicePluginFactory,
+	ServicePlugin,
 	createLanguageService as _createLanguageService,
 	createFileProvider,
 	resolveCommonLanguageId,
@@ -15,7 +15,7 @@ import { createLanguage, createSys, LanguageHost } from '@volar/typescript';
 
 export function createSimpleWorkerService<T = {}>(
 	languages: LanguagePlugin[],
-	services: ServicePluginFactory[],
+	services: ServicePlugin[],
 	getMirrorModels: monaco.worker.IWorkerContext<any>['getMirrorModels'],
 	extraApis: T = {} as any,
 ) {
@@ -57,7 +57,7 @@ export function createSimpleWorkerService<T = {}>(
 export function createTypeScriptWorkerService<T = {}>(
 	ts: typeof import('typescript/lib/tsserverlibrary.js'),
 	languages: LanguagePlugin[],
-	services: ServicePluginFactory[],
+	services: ServicePlugin[],
 	getMirrorModels: monaco.worker.IWorkerContext<any>['getMirrorModels'],
 	compilerOptions: ts.CompilerOptions,
 	extraApis: T = {} as any,
@@ -132,7 +132,7 @@ export function createTypeScriptWorkerService<T = {}>(
 }
 
 function createWorkerService<T = {}>(
-	services: ServicePluginFactory[],
+	services: ServicePlugin[],
 	getLanguage: (env: ServiceEnvironment) => Language,
 	extraApis: T = {} as any,
 ): LanguageService & T {


### PR DESCRIPTION
## Changes

- `Service` interface has been renamed to `ServicePlugin`
- Trigger characters are no longer exposed when creating a service plugin instance, but are exposed in advance as properties of `ServicePluginFactory`. Therefore the language server no longer needs to create fake service plugin instances in order to collect trigger characters.
- Services are no longer coupled with `SharedModules`, and the modules that the service depends on should be exposed through the parameters of the create function