### PR TITLE
refactor(language-core): revert `VirtualFile.id` abstract

### DIFF
--- a/packages/kit/lib/createChecker.ts
+++ b/packages/kit/lib/createChecker.ts
@@ -128,7 +128,7 @@ function createTypeScriptCheckerWorker(
 	async function fixErrors(fileName: string, diagnostics: Diagnostic[], only: string[] | undefined, writeFile: (fileName: string, newText: string) => Promise<void>) {
 		fileName = asPosix(fileName);
 		const uri = fileNameToUri(fileName);
-		const sourceFile = service.context.language.files.getSourceFile(uri);
+		const sourceFile = service.context.language.files.getSourceFile(env.uriToFileName(uri));
 		if (sourceFile) {
 			const document = service.context.documents.get(uri, sourceFile.languageId, sourceFile.snapshot);
 			const range = { start: document.positionAt(0), end: document.positionAt(document.getText().length) };
@@ -144,7 +144,7 @@ function createTypeScriptCheckerWorker(
 					for (const uri in rootEdit.changes ?? {}) {
 						const edits = rootEdit.changes![uri];
 						if (edits.length) {
-							const editFile = service.context.language.files.getSourceFile(uri);
+							const editFile = service.context.language.files.getSourceFile(env.uriToFileName(uri));
 							if (editFile) {
 								const editDocument = service.context.documents.get(uri, editFile.languageId, editFile.snapshot);
 								const newString = TextDocument.applyEdits(editDocument, edits);
@@ -154,7 +154,7 @@ function createTypeScriptCheckerWorker(
 					}
 					for (const change of rootEdit.documentChanges ?? []) {
 						if ('textDocument' in change) {
-							const editFile = service.context.language.files.getSourceFile(change.textDocument.uri);
+							const editFile = service.context.language.files.getSourceFile(env.uriToFileName(change.textDocument.uri));
 							if (editFile) {
 								const editDocument = service.context.documents.get(change.textDocument.uri, editFile.languageId, editFile.snapshot);
 								const newString = TextDocument.applyEdits(editDocument, change.edits);
@@ -179,7 +179,7 @@ function createTypeScriptCheckerWorker(
 	function formatErrors(fileName: string, diagnostics: Diagnostic[], rootPath: string) {
 		fileName = asPosix(fileName);
 		const uri = fileNameToUri(fileName);
-		const sourceFile = service.context.language.files.getSourceFile(uri)!;
+		const sourceFile = service.context.language.files.getSourceFile(env.uriToFileName(uri))!;
 		const document = service.context.documents.get(uri, sourceFile.languageId, sourceFile.snapshot);
 		const errors: ts.Diagnostic[] = diagnostics.map<ts.Diagnostic>(diagnostic => ({
 			category: diagnostic.severity === 1 satisfies typeof DiagnosticSeverity.Error ? ts.DiagnosticCategory.Error : ts.DiagnosticCategory.Warning,
@@ -235,8 +235,6 @@ function createTypeScriptLanguageHost(
 			}
 			return scriptSnapshotsCache.get(fileName);
 		},
-		getFileName: env.uriToFileName,
-		getFileId: env.fileNameToUri,
 		getLanguageId: resolveCommonLanguageId,
 	};
 

--- a/packages/kit/lib/createFormatter.ts
+++ b/packages/kit/lib/createFormatter.ts
@@ -2,6 +2,7 @@ import { FormattingOptions, LanguagePlugin, ServicePlugin, createFileProvider, c
 import * as ts from 'typescript';
 import { TextDocument } from 'vscode-languageserver-textdocument';
 import { createServiceEnvironment } from './createServiceEnvironment';
+import { fileNameToUri } from './utils';
 
 export function createFormatter(
 	languages: LanguagePlugin[],
@@ -9,6 +10,7 @@ export function createFormatter(
 ) {
 
 	let fakeUri = 'file:///dummy.txt';
+	let fakeFileName = fileNameToUri(fakeUri);
 	let settings = {};
 
 	const env = createServiceEnvironment(() => settings);
@@ -35,7 +37,7 @@ export function createFormatter(
 	async function format(content: string, languageId: string, options: FormattingOptions): Promise<string> {
 
 		const snapshot = ts.ScriptSnapshot.fromString(content);
-		files.updateSourceFile(fakeUri, languageId, snapshot);
+		files.updateSourceFile(fakeFileName, languageId, snapshot);
 
 		const document = service.context.documents.get(fakeUri, languageId, snapshot)!;
 		const edits = await service.format(fakeUri, options, undefined, undefined);

--- a/packages/language-core/lib/types.ts
+++ b/packages/language-core/lib/types.ts
@@ -43,12 +43,7 @@ export interface CodeInformation {
 }
 
 export interface BaseFile {
-	/**
-	 * for language-server, kit, monaco, this is uri
-	 * 
-	 * for typescript server plugin, tsc, this is fileName
-	 */
-	id: string;
+	fileName: string;
 	languageId: string;
 	snapshot: ts.IScriptSnapshot;
 }
@@ -86,7 +81,5 @@ export interface TypeScriptProjectHost extends Pick<
 	| 'getScriptSnapshot'
 	| 'getCancellationToken'
 > {
-	getFileId(fileName: string): string;
-	getFileName(fileId: string): string;
-	getLanguageId(id: string): string;
+	getLanguageId(fileName: string): string;
 }

--- a/packages/language-server/lib/project/simpleProject.ts
+++ b/packages/language-server/lib/project/simpleProject.ts
@@ -24,13 +24,14 @@ export async function createSimpleServerProject(
 
 	function getLanguageService() {
 		if (!languageService) {
-			const files = createFileProvider(Object.values(config.languages ?? {}), false, (uri) => {
+			const files = createFileProvider(Object.values(config.languages ?? {}), false, fileName => {
+				const uri = context.server.runtimeEnv.fileNameToUri(fileName);
 				const script = context.workspaces.documents.get(uri);
 				if (script) {
-					files.updateSourceFile(uri, script.languageId, script.getSnapshot());
+					files.updateSourceFile(fileName, script.languageId, script.getSnapshot());
 				}
 				else {
-					files.deleteSourceFile(uri);
+					files.deleteSourceFile(fileName);
 				}
 			});
 			languageService = createLanguageService(

--- a/packages/language-server/lib/project/typescriptProject.ts
+++ b/packages/language-server/lib/project/typescriptProject.ts
@@ -48,8 +48,6 @@ export async function createTypeScriptServerProject(
 		getCompilationSettings: () => parsedCommandLine.options,
 		getLocalizedDiagnosticMessages: context.workspaces.tsLocalized ? () => context.workspaces.tsLocalized : undefined,
 		getProjectReferences: () => parsedCommandLine.projectReferences,
-		getFileName: serviceEnv.uriToFileName,
-		getFileId: serviceEnv.fileNameToUri,
 		getLanguageId: uri => context.workspaces.documents.get(uri)?.languageId ?? resolveCommonLanguageId(uri),
 	};
 	const sys = createSys(ts, serviceEnv, host.getCurrentDirectory());

--- a/packages/language-service/lib/features/provideCallHierarchyItems.ts
+++ b/packages/language-service/lib/features/provideCallHierarchyItems.ts
@@ -69,7 +69,7 @@ export function register(context: ServiceContext) {
 
 				if (data.virtualDocumentUri) {
 
-					const [virtualFile] = context.language.files.getVirtualFile(data.virtualDocumentUri);
+					const [virtualFile] = context.language.files.getVirtualFile(context.env.uriToFileName(data.virtualDocumentUri));
 
 					if (virtualFile) {
 
@@ -127,7 +127,7 @@ export function register(context: ServiceContext) {
 
 				if (data.virtualDocumentUri) {
 
-					const [virtualFile] = context.language.files.getVirtualFile(data.virtualDocumentUri);
+					const [virtualFile] = context.language.files.getVirtualFile(context.env.uriToFileName(data.virtualDocumentUri));
 
 					if (virtualFile) {
 
@@ -172,7 +172,7 @@ export function register(context: ServiceContext) {
 
 	function transformCallHierarchyItem(tsItem: vscode.CallHierarchyItem, tsRanges: vscode.Range[]): [vscode.CallHierarchyItem, vscode.Range[]] | undefined {
 
-		const [virtualFile] = context.language.files.getVirtualFile(tsItem.uri);
+		const [virtualFile] = context.language.files.getVirtualFile(context.env.uriToFileName(tsItem.uri));
 
 		if (!virtualFile)
 			return [tsItem, tsRanges];

--- a/packages/language-service/lib/features/provideCodeActions.ts
+++ b/packages/language-service/lib/features/provideCodeActions.ts
@@ -19,7 +19,7 @@ export function register(context: ServiceContext) {
 
 	return async (uri: string, range: vscode.Range, codeActionContext: vscode.CodeActionContext, token = NoneCancellationToken) => {
 
-		const sourceFile = context.language.files.getSourceFile(uri);
+		const sourceFile = context.language.files.getSourceFile(context.env.uriToFileName(uri));
 		if (!sourceFile)
 			return;
 

--- a/packages/language-service/lib/features/provideCompletionItems.ts
+++ b/packages/language-service/lib/features/provideCompletionItems.ts
@@ -34,7 +34,7 @@ export function register(context: ServiceContext) {
 		token = NoneCancellationToken,
 	) => {
 
-		const sourceFile = context.language.files.getSourceFile(uri);
+		const sourceFile = context.language.files.getSourceFile(context.env.uriToFileName(uri));
 
 		if (
 			completionContext?.triggerKind === 3 satisfies typeof vscode.CompletionTriggerKind.TriggerForIncompleteCompletions
@@ -48,7 +48,7 @@ export function register(context: ServiceContext) {
 
 				if (cacheData.virtualDocumentUri) {
 
-					const [virtualFile] = context.language.files.getVirtualFile(cacheData.virtualDocumentUri);
+					const [virtualFile] = context.language.files.getVirtualFile(context.env.uriToFileName(cacheData.virtualDocumentUri));
 					if (!virtualFile)
 						continue;
 
@@ -114,7 +114,7 @@ export function register(context: ServiceContext) {
 		}
 		else {
 
-			const rootVirtualFile = context.language.files.getSourceFile(uri)?.virtualFile?.[0];
+			const rootVirtualFile = context.language.files.getSourceFile(context.env.uriToFileName(uri))?.virtualFile?.[0];
 
 			cache = {
 				uri,

--- a/packages/language-service/lib/features/provideDefinition.ts
+++ b/packages/language-service/lib/features/provideDefinition.ts
@@ -53,7 +53,7 @@ export function register(
 
 						recursiveChecker.add({ uri: definition.targetUri, range: { start: definition.targetRange.start, end: definition.targetRange.start } });
 
-						const [virtualFile] = context.language.files.getVirtualFile(definition.targetUri);
+						const [virtualFile] = context.language.files.getVirtualFile(context.env.uriToFileName(definition.targetUri));
 						const mirrorMap = virtualFile ? context.documents.getLinkedCodeMap(virtualFile) : undefined;
 
 						if (mirrorMap) {
@@ -97,7 +97,7 @@ export function register(
 
 				let foundTargetSelectionRange = false;
 
-				const [targetVirtualFile] = context.language.files.getVirtualFile(link.targetUri);
+				const [targetVirtualFile] = context.language.files.getVirtualFile(context.env.uriToFileName(link.targetUri));
 
 				if (targetVirtualFile) {
 

--- a/packages/language-service/lib/features/provideDiagnostics.ts
+++ b/packages/language-service/lib/features/provideDiagnostics.ts
@@ -153,7 +153,7 @@ export function register(context: ServiceContext) {
 		response?: (result: vscode.Diagnostic[]) => void,
 	) => {
 
-		const sourceFile = context.language.files.getSourceFile(uri);
+		const sourceFile = context.language.files.getSourceFile(context.env.uriToFileName(uri));
 		if (!sourceFile)
 			return [];
 
@@ -316,7 +316,7 @@ export function register(context: ServiceContext) {
 
 				for (const info of _error.relatedInformation) {
 
-					const [virtualFile] = context.language.files.getVirtualFile(info.location.uri);
+					const [virtualFile] = context.language.files.getVirtualFile(context.env.uriToFileName(info.location.uri));
 
 					if (virtualFile) {
 						for (const map of context.documents.getMaps(virtualFile)) {

--- a/packages/language-service/lib/features/provideDocumentHighlights.ts
+++ b/packages/language-service/lib/features/provideDocumentHighlights.ts
@@ -47,7 +47,7 @@ export function register(context: ServiceContext) {
 
 						recursiveChecker.add({ uri: document.uri, range: { start: reference.range.start, end: reference.range.start } });
 
-						const [virtualFile] = context.language.files.getVirtualFile(document.uri);
+						const [virtualFile] = context.language.files.getVirtualFile(context.env.uriToFileName(document.uri));
 						const mirrorMap = virtualFile ? context.documents.getLinkedCodeMap(virtualFile) : undefined;
 
 						if (mirrorMap) {

--- a/packages/language-service/lib/features/provideDocumentSemanticTokens.ts
+++ b/packages/language-service/lib/features/provideDocumentSemanticTokens.ts
@@ -16,7 +16,7 @@ export function register(context: ServiceContext) {
 		_reportProgress?: (tokens: vscode.SemanticTokens) => void, // TODO
 	): Promise<vscode.SemanticTokens | undefined> => {
 
-		const sourceFile = context.language.files.getSourceFile(uri);
+		const sourceFile = context.language.files.getSourceFile(context.env.uriToFileName(uri));
 		if (!sourceFile)
 			return;
 

--- a/packages/language-service/lib/features/provideFileReferences.ts
+++ b/packages/language-service/lib/features/provideFileReferences.ts
@@ -23,7 +23,7 @@ export function register(context: ServiceContext) {
 			(data) => data
 				.map(reference => {
 
-					const [virtualFile] = context.language.files.getVirtualFile(reference.uri);
+					const [virtualFile] = context.language.files.getVirtualFile(context.env.uriToFileName(reference.uri));
 					if (!virtualFile) {
 						return reference;
 					}

--- a/packages/language-service/lib/features/provideFileRenameEdits.ts
+++ b/packages/language-service/lib/features/provideFileRenameEdits.ts
@@ -9,15 +9,15 @@ export function register(context: ServiceContext) {
 
 	return async (oldUri: string, newUri: string, token = NoneCancellationToken) => {
 
-		const sourceFile = context.language.files.getSourceFile(oldUri);
+		const sourceFile = context.language.files.getSourceFile(context.env.uriToFileName(oldUri));
 
 		if (sourceFile?.virtualFile) {
 
 			let tsExt: string | undefined;
 
 			for (const virtualFile of forEachEmbeddedFile(sourceFile.virtualFile[0])) {
-				if (virtualFile.typescript && virtualFile.id.replace(sourceFile.id, '').match(/^\.(js|ts)x?$/)) {
-					tsExt = virtualFile.id.substring(virtualFile.id.lastIndexOf('.'));
+				if (virtualFile.typescript && virtualFile.fileName.substring(sourceFile.fileName.length).match(/^\.(js|ts)x?$/)) {
+					tsExt = virtualFile.fileName.substring(virtualFile.fileName.lastIndexOf('.'));
 				}
 			}
 

--- a/packages/language-service/lib/features/provideInlayHints.ts
+++ b/packages/language-service/lib/features/provideInlayHints.ts
@@ -16,7 +16,7 @@ export function register(context: ServiceContext) {
 
 	return async (uri: string, range: vscode.Range, token = NoneCancellationToken) => {
 
-		const sourceFile = context.language.files.getSourceFile(uri);
+		const sourceFile = context.language.files.getSourceFile(context.env.uriToFileName(uri));
 		if (!sourceFile)
 			return;
 

--- a/packages/language-service/lib/features/provideReferences.ts
+++ b/packages/language-service/lib/features/provideReferences.ts
@@ -45,7 +45,7 @@ export function register(context: ServiceContext) {
 
 						recursiveChecker.add({ uri: reference.uri, range: { start: reference.range.start, end: reference.range.start } });
 
-						const [virtualFile] = context.language.files.getVirtualFile(reference.uri);
+						const [virtualFile] = context.language.files.getVirtualFile(context.env.uriToFileName(reference.uri));
 						const mirrorMap = virtualFile ? context.documents.getLinkedCodeMap(virtualFile) : undefined;
 
 						if (mirrorMap) {
@@ -73,7 +73,7 @@ export function register(context: ServiceContext) {
 
 				for (const reference of data) {
 
-					const [virtualFile] = context.language.files.getVirtualFile(reference.uri);
+					const [virtualFile] = context.language.files.getVirtualFile(context.env.uriToFileName(reference.uri));
 
 					if (virtualFile) {
 						for (const map of context.documents.getMaps(virtualFile)) {

--- a/packages/language-service/lib/features/provideRenameEdits.ts
+++ b/packages/language-service/lib/features/provideRenameEdits.ts
@@ -70,7 +70,7 @@ export function register(context: ServiceContext) {
 
 								recursiveChecker.add({ uri: editUri, range: { start: textEdit.range.start, end: textEdit.range.start } });
 
-								const [virtualFile] = context.language.files.getVirtualFile(editUri);
+								const [virtualFile] = context.language.files.getVirtualFile(context.env.uriToFileName(editUri));
 								const mirrorMap = virtualFile ? context.documents.getLinkedCodeMap(virtualFile) : undefined;
 
 								if (mirrorMap) {

--- a/packages/language-service/lib/features/provideWorkspaceSymbols.ts
+++ b/packages/language-service/lib/features/provideWorkspaceSymbols.ts
@@ -23,7 +23,7 @@ export function register(context: ServiceContext) {
 			}
 			const symbols = embeddedSymbols.map(symbol => transformWorkspaceSymbol(symbol, loc => {
 
-				const [virtualFile] = context.language.files.getVirtualFile(loc.uri);
+				const [virtualFile] = context.language.files.getVirtualFile(context.env.uriToFileName(loc.uri));
 
 				if (virtualFile) {
 					for (const map of context.documents.getMaps(virtualFile)) {

--- a/packages/language-service/lib/features/resolveCodeLens.ts
+++ b/packages/language-service/lib/features/resolveCodeLens.ts
@@ -31,14 +31,15 @@ export function register(context: ServiceContext) {
 			const service = context.services[data.serviceIndex];
 
 			if (service[1].resolveReferencesCodeLensLocations) {
-				const virtualFile = context.language.files.getVirtualFile(data.workerFileUri)[0];
-				const sourceFile = context.language.files.getSourceFile(data.workerFileUri);
+				const workerFileName = context.env.uriToFileName(data.workerFileUri);
+				const virtualFile = context.language.files.getVirtualFile(workerFileName)[0];
+				const sourceFile = context.language.files.getSourceFile(workerFileName);
 				if (virtualFile) {
-					const document = context.documents.get(virtualFile.id, virtualFile.languageId, virtualFile.snapshot);
+					const document = context.documents.get(context.env.fileNameToUri(virtualFile.fileName), virtualFile.languageId, virtualFile.snapshot);
 					references = await service[1].resolveReferencesCodeLensLocations(document, data.workerFileRange, references, token);
 				}
 				else if (sourceFile && !sourceFile?.virtualFile) {
-					const document = context.documents.get(sourceFile.id, sourceFile.languageId, sourceFile.snapshot);
+					const document = context.documents.get(context.env.fileNameToUri(sourceFile.fileName), sourceFile.languageId, sourceFile.snapshot);
 					references = await service[1].resolveReferencesCodeLensLocations(document, data.workerFileRange, references, token);
 				}
 			}

--- a/packages/language-service/lib/features/resolveCompletionItem.ts
+++ b/packages/language-service/lib/features/resolveCompletionItem.ts
@@ -21,7 +21,7 @@ export function register(context: ServiceContext) {
 
 			if (data.virtualDocumentUri) {
 
-				const [virtualFile] = context.language.files.getVirtualFile(data.virtualDocumentUri);
+				const [virtualFile] = context.language.files.getVirtualFile(context.env.uriToFileName(data.virtualDocumentUri));
 
 				if (virtualFile) {
 

--- a/packages/language-service/lib/features/resolveDocumentLink.ts
+++ b/packages/language-service/lib/features/resolveDocumentLink.ts
@@ -31,7 +31,7 @@ export function transformDocumentLinkTarget(target: string, context: ServiceCont
 
 	const targetUri = URI.parse(target);
 	const clearUri = targetUri.with({ fragment: '' }).toString();
-	const [virtualFile] = context.language.files.getVirtualFile(clearUri);
+	const [virtualFile] = context.language.files.getVirtualFile(context.env.uriToFileName(clearUri));
 
 	if (virtualFile) {
 		for (const map of context.documents.getMaps(virtualFile)) {

--- a/packages/language-service/lib/languageService.ts
+++ b/packages/language-service/lib/languageService.ts
@@ -93,7 +93,7 @@ export function createLanguageService(
 
 	function createServiceContext() {
 
-		const documents = createDocumentProvider(language.files);
+		const documents = createDocumentProvider(env, language.files);
 		const context: ServiceContext = {
 			env,
 			language: language,

--- a/packages/language-service/lib/utils/featureWorkers.ts
+++ b/packages/language-service/lib/utils/featureWorkers.ts
@@ -36,7 +36,7 @@ export async function languageFeatureWorker<T, K>(
 	combineResult?: (results: T[]) => T,
 ) {
 
-	const sourceFile = context.language.files.getSourceFile(uri);
+	const sourceFile = context.language.files.getSourceFile(context.env.uriToFileName(uri));
 	if (!sourceFile)
 		return;
 
@@ -127,7 +127,7 @@ export async function visitEmbedded(
 	}
 
 	for (const map of context.documents.getMaps(current)) {
-		const sourceFile = context.language.files.getSourceFile(map.sourceFileDocument.uri);
+		const sourceFile = context.language.files.getSourceFile(context.env.uriToFileName(map.sourceFileDocument.uri));
 		if (sourceFile?.virtualFile?.[0] === rootFile) {
 			if (!await cb(current, map)) {
 				return false;

--- a/packages/language-service/lib/utils/transform.ts
+++ b/packages/language-service/lib/utils/transform.ts
@@ -238,7 +238,7 @@ export function transformWorkspaceSymbol(symbol: vscode.WorkspaceSymbol, getOthe
 
 export function transformWorkspaceEdit(
 	edit: vscode.WorkspaceEdit,
-	{ documents, language: project }: ServiceContext,
+	{ documents, language: project, env }: ServiceContext,
 	mode: 'fileName' | 'rename' | 'codeAction' | undefined,
 	versions: Record<string, number> = {},
 ) {
@@ -251,7 +251,7 @@ export function transformWorkspaceEdit(
 		sourceResult.changeAnnotations ??= {};
 
 		const tsAnno = edit.changeAnnotations[tsUri];
-		const [virtualFile] = project.files.getVirtualFile(tsUri);
+		const [virtualFile] = project.files.getVirtualFile(env.uriToFileName(tsUri));
 
 		if (virtualFile) {
 			for (const map of documents.getMaps(virtualFile)) {
@@ -268,7 +268,7 @@ export function transformWorkspaceEdit(
 
 		sourceResult.changes ??= {};
 
-		const [virtualFile] = project.files.getVirtualFile(tsUri);
+		const [virtualFile] = project.files.getVirtualFile(env.uriToFileName(tsUri));
 
 		if (virtualFile) {
 			for (const map of documents.getMaps(virtualFile)) {
@@ -316,7 +316,7 @@ export function transformWorkspaceEdit(
 			let sourceEdit: typeof tsDocEdit | undefined;
 			if ('textDocument' in tsDocEdit) {
 
-				const [virtualFile] = project.files.getVirtualFile(tsDocEdit.textDocument.uri);
+				const [virtualFile] = project.files.getVirtualFile(env.fileNameToUri(tsDocEdit.textDocument.uri));
 
 				if (virtualFile) {
 					for (const map of documents.getMaps(virtualFile)) {
@@ -368,7 +368,7 @@ export function transformWorkspaceEdit(
 			}
 			else if (tsDocEdit.kind === 'rename') {
 
-				const [virtualFile] = project.files.getVirtualFile(tsDocEdit.oldUri);
+				const [virtualFile] = project.files.getVirtualFile(env.uriToFileName(tsDocEdit.oldUri));
 
 				if (virtualFile) {
 					for (const map of documents.getMaps(virtualFile)) {
@@ -388,7 +388,7 @@ export function transformWorkspaceEdit(
 			}
 			else if (tsDocEdit.kind === 'delete') {
 
-				const [virtualFile] = project.files.getVirtualFile(tsDocEdit.uri);
+				const [virtualFile] = project.files.getVirtualFile(env.uriToFileName(tsDocEdit.uri));
 
 				if (virtualFile) {
 					for (const map of documents.getMaps(virtualFile)) {

--- a/packages/typescript/lib/node/decorateLanguageService.ts
+++ b/packages/typescript/lib/node/decorateLanguageService.ts
@@ -677,7 +677,7 @@ export function decorateLanguageService(virtualFiles: FileProvider, languageServ
 		if (source) {
 			return {
 				...changes,
-				fileName: source.id,
+				fileName: source.fileName,
 				textChanges: changes.textChanges.map(c => {
 					const span = transformSpan(changes.fileName, c.span, filter);
 					if (span) {
@@ -700,7 +700,7 @@ export function decorateLanguageService(virtualFiles: FileProvider, languageServ
 			const [virtualFile, source] = getVirtualFileAndMap(documentSpan.fileName);
 			if (virtualFile) {
 				textSpan = {
-					fileName: source.id,
+					fileName: source.fileName,
 					textSpan: { start: 0, length: 0 },
 				};
 			}
@@ -733,7 +733,7 @@ export function decorateLanguageService(virtualFiles: FileProvider, languageServ
 					for (const sourceEnd of map.getSourceOffsets(textSpan.start + textSpan.length - (isTsPlugin ? sourceFile.snapshot.getLength() : 0))) {
 						if (filter(sourceEnd[1].data)) {
 							return {
-								fileName: sourceFile.id,
+								fileName: sourceFile.fileName,
 								textSpan: {
 									start: sourceStart[0],
 									length: sourceEnd[0] - sourceStart[0],
@@ -757,7 +757,7 @@ export function decorateLanguageService(virtualFiles: FileProvider, languageServ
 			const sourceFile = virtualFiles.getSourceFile(fileName);
 			if (sourceFile?.virtualFile) {
 				for (const virtualFile of forEachEmbeddedFile(sourceFile.virtualFile[0])) {
-					const ext = virtualFile.id.substring(fileName.length);
+					const ext = virtualFile.fileName.substring(fileName.length);
 					if (virtualFile.typescript && (ext === '.d.ts' || ext.match(/^\.(js|ts)x?$/))) {
 						for (const map of virtualFiles.getMaps(virtualFile)) {
 							if (map[1][0] === sourceFile.snapshot) {

--- a/packages/typescript/lib/node/decorateLanguageServiceHost.ts
+++ b/packages/typescript/lib/node/decorateLanguageServiceHost.ts
@@ -171,7 +171,7 @@ export function decorateLanguageServiceHost(
 					const text = snapshot.getText(0, snapshot.getLength());
 					let patchedText = text.split('\n').map(line => ' '.repeat(line.length)).join('\n');
 					for (const file of forEachEmbeddedFile(sourceFile.virtualFile[0])) {
-						const ext = file.id.substring(fileName.length);
+						const ext = file.fileName.substring(fileName.length);
 						if (file.typescript && (ext === '.d.ts' || ext.match(/^\.(js|ts)x?$/))) {
 							extension = ext;
 							scriptKind = file.typescript.scriptKind;

--- a/packages/typescript/lib/protocol/getProgram.ts
+++ b/packages/typescript/lib/protocol/getProgram.ts
@@ -4,10 +4,6 @@ import type * as ts from 'typescript/lib/tsserverlibrary';
 export function getProgram(
 	ts: typeof import('typescript/lib/tsserverlibrary'),
 	files: FileProvider,
-	{ getFileId, getFileName }: {
-		getFileId(fileName: string): string;
-		getFileName(id: string): string;
-	},
 	ls: ts.LanguageService,
 	sys: ts.System,
 ): ts.Program {
@@ -71,8 +67,7 @@ export function getProgram(
 
 		if (sourceFile) {
 
-			const uri = getFileId(sourceFile.fileName);
-			const [virtualFile, source] = files.getVirtualFile(uri);
+			const [virtualFile, source] = files.getVirtualFile(sourceFile.fileName);
 
 			if (virtualFile && source) {
 
@@ -111,14 +106,11 @@ export function getProgram(
 				&& diagnostic.length !== undefined
 			) {
 
-				const uri = getFileId(diagnostic.file.fileName);
-				const [virtualFile, source] = files.getVirtualFile(uri);
+				const [virtualFile, source] = files.getVirtualFile(diagnostic.file.fileName);
 
 				if (virtualFile && source) {
 
-					const sourceFileName = getFileName(source.id);
-
-					if (sys.fileExists?.(sourceFileName) === false)
+					if (sys.fileExists?.(source.fileName) === false)
 						continue;
 
 					for (const [_, [sourceSnapshot, map]] of files.getMaps(virtualFile)) {
@@ -136,7 +128,7 @@ export function getProgram(
 								if (!shouldReportDiagnostics(end[1].data))
 									continue;
 
-								onMapping(diagnostic, sourceFileName, start[0], end[0], source.snapshot.getText(0, source.snapshot.getLength()));
+								onMapping(diagnostic, source.fileName, start[0], end[0], source.snapshot.getText(0, source.snapshot.getLength()));
 								break;
 							}
 							break;
@@ -166,8 +158,7 @@ export function getProgram(
 			if (!file) {
 
 				if (docText === undefined) {
-					const uri = getFileId(fileName);
-					const snapshot = files.getSourceFile(uri)?.snapshot;
+					const snapshot = files.getSourceFile(fileName)?.snapshot;
 					if (snapshot) {
 						docText = snapshot.getText(0, snapshot.getLength());
 					}


### PR DESCRIPTION
This PR restores some of the changes in #86. `id` no longer represents `fileName` or `uri`. I found that the agreed `VirtualFile.id` can better solve our problems.