### PR TITLE
Update monaco-languageserver-types

### DIFF
--- a/packages/monaco/lib/provider.ts
+++ b/packages/monaco/lib/provider.ts
@@ -27,10 +27,11 @@ import {
 	toHover,
 	toInlayHint,
 	toLink,
+	toLinkedEditingRanges,
 	toLocation,
 	toLocationLink,
-	toRange,
 	toSelectionRange,
+	toSemanticTokens,
 	toSignatureHelp,
 	toTextEdit,
 	toWorkspaceEdit,
@@ -94,20 +95,14 @@ export async function createLanguageFeaturesProvider(
 				standardSemanticTokensLegend,
 			);
 			if (codeResult) {
-				return {
-					resultId: codeResult.resultId,
-					data: Uint32Array.from(codeResult.data),
-				};
+				return toSemanticTokens(codeResult);
 			}
 		},
 		async provideDocumentRangeSemanticTokens(model, range) {
 			const languageService = await worker.withSyncedResources(getSyncUris());
 			const codeResult = await languageService.getSemanticTokens(model.uri.toString(), fromRange(range), standardSemanticTokensLegend);
 			if (codeResult) {
-				return {
-					resultId: codeResult.resultId,
-					data: Uint32Array.from(codeResult.data),
-				};
+				return toSemanticTokens(codeResult);
 			}
 		},
 		releaseDocumentSemanticTokens() { },
@@ -135,12 +130,7 @@ export async function createLanguageFeaturesProvider(
 				fromPosition(position),
 			);
 			if (codeResult) {
-				return {
-					ranges: codeResult.ranges.map(toRange),
-					wordPattern: codeResult.wordPattern
-						? new RegExp(codeResult.wordPattern)
-						: undefined,
-				};
+				return toLinkedEditingRanges(codeResult);
 			}
 		},
 		async provideDefinition(model, position) {

--- a/packages/monaco/package.json
+++ b/packages/monaco/package.json
@@ -15,7 +15,7 @@
 	"dependencies": {
 		"@volar/language-service": "2.0.0-alpha.2",
 		"@volar/typescript": "2.0.0-alpha.2",
-		"monaco-languageserver-types": "^0.3.1",
+		"monaco-languageserver-types": "^0.3.2",
 		"monaco-types": "^0.1.0",
 		"vscode-uri": "^3.0.8"
 	},

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -155,8 +155,8 @@ importers:
         specifier: 2.0.0-alpha.2
         version: link:../typescript
       monaco-languageserver-types:
-        specifier: ^0.3.1
-        version: 0.3.1
+        specifier: ^0.3.2
+        version: 0.3.2
       monaco-types:
         specifier: ^0.1.0
         version: 0.1.0
@@ -3516,8 +3516,8 @@ packages:
     resolution: {integrity: sha512-gPhXfbi0RCnIRXMUzkvjRc8tUiD56lkuw7uRr2dUv00owYthFRlyot2R0ECFuA5F3YKei4OlFjALDahxIC/6Jg==}
     dev: true
 
-  /monaco-languageserver-types@0.3.1:
-    resolution: {integrity: sha512-piidSsgV+NTConaTgVCw1Cgi0TAoslRbCHcw4Aeyx/fg9umSsB2vvlqhJ2iFhqb68KdtnhmoQ5m7hGTtttmV6Q==}
+  /monaco-languageserver-types@0.3.2:
+    resolution: {integrity: sha512-KiGVYK/DiX1pnacnOjGNlM85bhV3ZTyFlM+ce7B8+KpWCbF1XJVovu51YyuGfm+K7+K54mIpT4DFX16xmi+tYA==}
     dependencies:
       monaco-types: 0.1.0
       vscode-languageserver-protocol: 3.17.5


### PR DESCRIPTION
It now supports conversion of linked editing ranges and semantic tokens.