### PR TITLE
refactor(language-service): use `ReferenceContext` and replace `resolveReferencesCodeLensLocations`

### DIFF
--- a/packages/language-server/lib/register/registerLanguageFeatures.ts
+++ b/packages/language-server/lib/register/registerLanguageFeatures.ts
@@ -175,7 +175,7 @@ export function registerLanguageFeatures(
 	});
 	connection.onReferences(async (params, token) => {
 		return worker(params.textDocument.uri, token, service => {
-			return service.findReferences(params.textDocument.uri, params.position, token);
+			return service.findReferences(params.textDocument.uri, params.position, { includeDeclaration: true }, token);
 		});
 	});
 	connection.onRequest(FindFileReferenceRequest.type, async (params, token) => {

--- a/packages/language-service/lib/features/provideReferences.ts
+++ b/packages/language-service/lib/features/provideReferences.ts
@@ -8,7 +8,7 @@ import { isReferencesEnabled } from '@volar/language-core';
 
 export function register(context: ServiceContext) {
 
-	return (uri: string, position: vscode.Position, token = NoneCancellationToken) => {
+	return (uri: string, position: vscode.Position, referenceContext: vscode.ReferenceContext, token = NoneCancellationToken) => {
 
 		return languageFeatureWorker(
 			context,
@@ -37,7 +37,7 @@ export function register(context: ServiceContext) {
 
 					recursiveChecker.add({ uri: document.uri, range: { start: position, end: position } });
 
-					const references = await service[1].provideReferences(document, position, token) ?? [];
+					const references = await service[1].provideReferences(document, position, referenceContext, token) ?? [];
 
 					for (const reference of references) {
 

--- a/packages/language-service/lib/features/resolveCodeLens.ts
+++ b/packages/language-service/lib/features/resolveCodeLens.ts
@@ -26,23 +26,7 @@ export function register(context: ServiceContext) {
 
 		if (data?.kind === 'references') {
 
-			let references = await findReferences(data.sourceFileUri, item.range.start, token) ?? [];
-
-			const service = context.services[data.serviceIndex];
-
-			if (service[1].resolveReferencesCodeLensLocations) {
-				const workerFileName = context.env.uriToFileName(data.workerFileUri);
-				const virtualFile = context.language.files.getVirtualFile(workerFileName)[0];
-				const sourceFile = context.language.files.getSourceFile(workerFileName);
-				if (virtualFile) {
-					const document = context.documents.get(context.env.fileNameToUri(virtualFile.fileName), virtualFile.languageId, virtualFile.snapshot);
-					references = await service[1].resolveReferencesCodeLensLocations(document, data.workerFileRange, references, token);
-				}
-				else if (sourceFile && !sourceFile?.virtualFile) {
-					const document = context.documents.get(context.env.fileNameToUri(sourceFile.fileName), sourceFile.languageId, sourceFile.snapshot);
-					references = await service[1].resolveReferencesCodeLensLocations(document, data.workerFileRange, references, token);
-				}
-			}
+			const references = await findReferences(data.sourceFileUri, item.range.start, { includeDeclaration: false }, token) ?? [];
 
 			item.command = context.commands.showReferences.create(data.sourceFileUri, item.range.start, references);
 		}

--- a/packages/language-service/lib/types.ts
+++ b/packages/language-service/lib/types.ts
@@ -107,7 +107,7 @@ export interface ServicePluginInstance<P = any> {
 	provideSignatureHelp?(document: TextDocument, position: vscode.Position, context: vscode.SignatureHelpContext, token: vscode.CancellationToken): NullableResult<vscode.SignatureHelp>;
 	provideRenameRange?(document: TextDocument, position: vscode.Position, token: vscode.CancellationToken): NullableResult<vscode.Range | { range: vscode.Range; placeholder: string; } | { message: string; }>;
 	provideRenameEdits?(document: TextDocument, position: vscode.Position, newName: string, token: vscode.CancellationToken): NullableResult<vscode.WorkspaceEdit>;
-	provideReferences?(document: TextDocument, position: vscode.Position, token: vscode.CancellationToken): NullableResult<vscode.Location[]>;
+	provideReferences?(document: TextDocument, position: vscode.Position, context: vscode.ReferenceContext, token: vscode.CancellationToken): NullableResult<vscode.Location[]>;
 	provideSelectionRanges?(document: TextDocument, positions: vscode.Position[], token: vscode.CancellationToken): NullableResult<vscode.SelectionRange[]>;
 	provideInlayHints?(document: TextDocument, range: vscode.Range, token: vscode.CancellationToken): NullableResult<vscode.InlayHint[]>,
 	provideCallHierarchyItems?(document: TextDocument, position: vscode.Position, token: vscode.CancellationToken): NullableResult<vscode.CallHierarchyItem[]>;
@@ -129,7 +129,6 @@ export interface ServicePluginInstance<P = any> {
 	resolveCompletionItem?(item: vscode.CompletionItem, token: vscode.CancellationToken): Result<vscode.CompletionItem>,
 	resolveDocumentLink?(link: vscode.DocumentLink, token: vscode.CancellationToken): Result<vscode.DocumentLink>;
 	resolveInlayHint?(inlayHint: vscode.InlayHint, token: vscode.CancellationToken): Result<vscode.InlayHint>;
-	resolveReferencesCodeLensLocations?(document: TextDocument, range: vscode.Range, references: vscode.Location[], token: vscode.CancellationToken): Result<vscode.Location[]>; // volar specific
 	transformCompletionItem?(item: vscode.CompletionItem): vscode.CompletionItem | undefined; // volar specific
 	transformCodeAction?(item: vscode.CodeAction): vscode.CodeAction | undefined; // volar specific
 	dispose?(): void;

--- a/packages/monaco/lib/provider.ts
+++ b/packages/monaco/lib/provider.ts
@@ -414,6 +414,7 @@ export async function createLanguageFeaturesProvider(
 			const codeResult = await languageService.findReferences(
 				model.uri.toString(),
 				fromPosition(position),
+				{ includeDeclaration: true },
 			);
 			if (codeResult) {
 				return codeResult.map(toLocation);


### PR DESCRIPTION
`resolveReferencesCodeLensLocations` is used to exclude definitions for `referncesCodeLens` result. This logic can move to the services side after adding the `ReferenceContext` param.