### PR TITLE
Make the Config languages and services keys required

### DIFF
--- a/packages/language-server/lib/config.ts
+++ b/packages/language-server/lib/config.ts
@@ -9,13 +9,13 @@ export async function getConfig(
 	projectCtx: ProjectContext,
 ) {
 
-	let config = (
-		env.workspaceFolder.uri.scheme === 'file' ? loadConfig(
+	let config: Config = (
+		env.workspaceFolder.uri.scheme === 'file' && loadConfig(
 			context.server.runtimeEnv.console,
 			context.server.runtimeEnv.uriToFileName(env.workspaceFolder.uri.toString()),
 			context.workspaces.initOptions.configFilePath,
-		) : {}
-	) ?? {};
+		) || { languages: Object.create(null), services: Object.create(null) }
+	);
 
 	for (const plugin of plugins) {
 		if (plugin.resolveConfig) {

--- a/packages/language-server/lib/project/simpleProject.ts
+++ b/packages/language-server/lib/project/simpleProject.ts
@@ -24,7 +24,7 @@ export async function createSimpleServerProject(
 
 	function getLanguageService() {
 		if (!languageService) {
-			const files = createFileProvider(Object.values(config.languages ?? {}), false, fileName => {
+			const files = createFileProvider(Object.values(config.languages), false, fileName => {
 				const uri = context.server.runtimeEnv.fileNameToUri(fileName);
 				const script = context.workspaces.documents.get(uri);
 				if (script) {
@@ -36,7 +36,7 @@ export async function createSimpleServerProject(
 			});
 			languageService = createLanguageService(
 				{ files },
-				Object.values(config.services ?? {}),
+				Object.values(config.services),
 				serviceEnv,
 			);
 		}

--- a/packages/language-server/lib/project/typescriptProject.ts
+++ b/packages/language-server/lib/project/typescriptProject.ts
@@ -94,13 +94,13 @@ export async function createTypeScriptServerProject(
 			const language = createLanguage(
 				ts,
 				sys,
-				Object.values(config.languages ?? {}),
+				Object.values(config.languages),
 				typeof tsconfig === 'string' ? tsconfig : undefined,
 				host,
 			);
 			languageService = createLanguageService(
 				language,
-				Object.values(config.services ?? {}),
+				Object.values(config.services),
 				serviceEnv,
 			);
 		}

--- a/packages/language-server/lib/server.ts
+++ b/packages/language-server/lib/server.ts
@@ -124,7 +124,7 @@ export function startLanguageServerBase<Plugin extends ServerPlugin>(
 			},
 		};
 
-		let config: Config = {};
+		let config: Config = { languages: Object.create(null), services: Object.create(null) };
 
 		for (const folder of workspaceFolderManager.getAll()) {
 			if (folder.uri.scheme === 'file') {
@@ -147,7 +147,7 @@ export function startLanguageServerBase<Plugin extends ServerPlugin>(
 			options,
 			plugins,
 			getSemanticTokensLegend(),
-			Object.values(config.services ?? {}),
+			Object.values(config.services),
 		);
 
 		projectProvider = createProjectProvider({

--- a/packages/language-server/lib/types.ts
+++ b/packages/language-server/lib/types.ts
@@ -3,8 +3,8 @@ import type * as ts from 'typescript/lib/tsserverlibrary';
 import type * as vscode from 'vscode-languageserver';
 
 export interface Config {
-	languages?: { [id: string]: LanguagePlugin; };
-	services?: { [id: string]: ServicePlugin; };
+	languages: { [id: string]: LanguagePlugin; };
+	services: { [id: string]: ServicePlugin; };
 }
 
 export interface Timer {


### PR DESCRIPTION
This provides a slightly more convenient interface for server plugins. The default is defined with a null prototype, so it doesn’t have predefined keys.

For example, this allows for the following change in the MDX language server:

```diff
- config.languages ||= {}
  config.languages.mdx = getLanguageModule(plugins)
- config.services ||= {}
  config.services.markdown = createMarkdownService()
  config.services.typescript = createTypeScriptService(modules.typescript)
```