### PR TITLE
refactor(language-core): `extraFileExtensions` option abstracte to `LanguagePlugin`

### DIFF
--- a/packages/kit/lib/createChecker.ts
+++ b/packages/kit/lib/createChecker.ts
@@ -10,7 +10,6 @@ export function createTypeScriptChecker(
 	languages: LanguagePlugin[],
 	services: ServicePlugin[],
 	tsconfig: string,
-	extraFileExtensions: ts.FileExtensionInfo[] = []
 ) {
 	const tsconfigPath = asPosix(tsconfig);
 	return createTypeScriptCheckerWorker(languages, services, tsconfigPath, env => {
@@ -24,7 +23,7 @@ export function createTypeScriptChecker(
 					undefined,
 					tsconfigPath,
 					undefined,
-					extraFileExtensions,
+					languages.map(plugin => plugin.typescript?.extraFileExtensions ?? []).flat(),
 				);
 				parsed.fileNames = parsed.fileNames.map(asPosix);
 				return parsed;

--- a/packages/language-core/lib/types.ts
+++ b/packages/language-core/lib/types.ts
@@ -55,6 +55,7 @@ export interface LanguagePlugin<T extends VirtualFile = VirtualFile> {
 	updateVirtualFile(virtualFile: T, snapshot: ts.IScriptSnapshot, files?: FileProvider): void;
 	disposeVirtualFile?(virtualFile: T, files?: FileProvider): void;
 	typescript?: {
+		extraFileExtensions: ts.FileExtensionInfo[];
 		resolveSourceFileName(tsFileName: string): string | undefined;
 		resolveModuleName?(path: string, impliedNodeFormat?: ts.ResolutionMode): string | undefined;
 		resolveLanguageServiceHost?(host: ts.LanguageServiceHost): ts.LanguageServiceHost;

--- a/packages/language-server/lib/project/typescriptProject.ts
+++ b/packages/language-server/lib/project/typescriptProject.ts
@@ -86,7 +86,7 @@ export async function createTypeScriptServerProject(
 			sys,
 			uriToFileName(serviceEnv.workspaceFolder.uri.toString()),
 			tsconfig,
-			serverOptions.typescript?.extraFileExtensions ?? [],
+			languagePlugins.map(plugin => plugin.typescript?.extraFileExtensions ?? []).flat(),
 		);
 		return parsedCommandLine.fileNames;
 	}

--- a/packages/language-server/lib/server.ts
+++ b/packages/language-server/lib/server.ts
@@ -9,7 +9,6 @@ import { setupCapabilities } from './setupCapabilities.js';
 import { createWorkspaceFolderManager } from './workspaceFolderManager.js';
 import type { WorkspacesContext } from './project/simpleProjectProvider.js';
 import { SnapshotDocument } from '@volar/snapshot-document';
-import type * as ts from 'typescript/lib/tsserverlibrary.js';
 
 export interface ServerContext {
 	server: {
@@ -31,9 +30,6 @@ export interface ProjectSetup {
 }
 
 export interface ServerOptions {
-	typescript?: {
-		extraFileExtensions?: ts.FileExtensionInfo[];
-	};
 	watchFileExtensions?: string[];
 	getServerCapabilitiesSetup(): ServerSetup | Promise<ServerSetup>;
 	getProjectSetup(serviceEnv: ServiceEnvironment, projectContext: ProjectContext): ProjectSetup | Promise<ProjectSetup>;


### PR DESCRIPTION
After `extraFileExtensions` is defined once by `LanguagePlugin`, the language server and kit checker no longer need to define it.