### PR TITLE
feat(language-service): create `DataTransferFile` by `DocumentDropEdit`

### DIFF
--- a/packages/language-service/lib/types.ts
+++ b/packages/language-service/lib/types.ts
@@ -138,6 +138,7 @@ export interface DocumentDropEdit {
 	insertText: string;
 	insertTextFormat: vscode.InsertTextFormat;
 	additionalEdit?: vscode.WorkspaceEdit;
+	createDataTransferFile?: (vscode.CreateFile & { contentsMimeType: string; })[];
 }
 
 export interface DataTransferItem {

--- a/packages/vscode/lib/features/documentDropEdits.ts
+++ b/packages/vscode/lib/features/documentDropEdits.ts
@@ -43,6 +43,22 @@ export function activate(selector: vscode.DocumentSelector, client: BaseLanguage
 						if (result.additionalEdit) {
 							edit.additionalEdit = await client.protocol2CodeConverter.asWorkspaceEdit(result.additionalEdit);
 						}
+						if (result.createDataTransferFile) {
+							edit.additionalEdit ??= new vscode.WorkspaceEdit();
+							for (const create of result.createDataTransferFile) {
+								const file = dataTransfer.get(create.contentsMimeType)?.asFile();
+								if (file) {
+									edit.additionalEdit.createFile(
+										client.protocol2CodeConverter.asUri(create.uri),
+										{
+											ignoreIfExists: create.options?.ignoreIfExists,
+											overwrite: create.options?.overwrite,
+											contents: await file.data(),
+										},
+									);
+								}
+							}
+						}
 						return edit;
 					}
 				},


### PR DESCRIPTION
Added `createDataTransferFile` option to `DocumentDropEdit` to support creating file with contents provided by dataTransfer. This should resolve MDX drop edit's inability to create image file.