### PR TITLE
refactor(language-server): no longer requiring project-specific service plugins

### DIFF
--- a/packages/language-server/lib/project/simpleProject.ts
+++ b/packages/language-server/lib/project/simpleProject.ts
@@ -1,4 +1,4 @@
-import { LanguageService, ServiceEnvironment, createFileProvider, createLanguageService } from '@volar/language-service';
+import { LanguageService, ServiceEnvironment, ServicePlugin, createFileProvider, createLanguageService } from '@volar/language-service';
 import type { ServerOptions } from '../server';
 import type { ServerProject } from '../types';
 import type { WorkspacesContext } from './simpleProjectProvider';
@@ -7,11 +7,12 @@ export async function createSimpleServerProject(
 	context: WorkspacesContext,
 	serviceEnv: ServiceEnvironment,
 	serverOptions: ServerOptions,
+	servicePlugins: ServicePlugin[],
 ): Promise<ServerProject> {
 
 	let languageService: LanguageService | undefined;
 
-	const { languagePlugins, servicePlugins } = await serverOptions.getProjectSetup(serviceEnv, {});
+	const languagePlugins = await serverOptions.getLanguagePlugins(serviceEnv, {});
 
 	return {
 		serviceEnv,

--- a/packages/language-server/lib/project/simpleProjectProvider.ts
+++ b/packages/language-server/lib/project/simpleProjectProvider.ts
@@ -3,8 +3,8 @@ import type { SnapshotDocument } from '@volar/snapshot-document';
 import type * as ts from 'typescript';
 import type { TextDocuments } from 'vscode-languageserver';
 import { URI } from 'vscode-uri';
-import type { ServerContext, ServerOptions } from '../server';
-import type { InitializationOptions, ServerProject, ServerProjectProvider } from '../types';
+import type { ServerContext } from '../server';
+import type { InitializationOptions, ServerProject, ServerProjectProvider, ServerProjectProviderFactory } from '../types';
 import { isFileInDir } from '../utils/isFileInDir';
 import type { WorkspaceFolderManager } from '../workspaceFolderManager';
 import { createSimpleServerProject } from './simpleProject';
@@ -21,7 +21,7 @@ export interface WorkspacesContext extends ServerContext {
 	};
 }
 
-export function createSimpleProjectProvider(context: WorkspacesContext, serverOptions: ServerOptions): ServerProjectProvider {
+export const createSimpleProjectProvider: ServerProjectProviderFactory = (context, serverOptions, servicePlugins): ServerProjectProvider => {
 
 	const projects = new Map<ServiceEnvironment['workspaceFolder'], Promise<ServerProject>>();
 
@@ -33,7 +33,7 @@ export function createSimpleProjectProvider(context: WorkspacesContext, serverOp
 			let projectPromise = projects.get(workspaceFolder);
 			if (!projectPromise) {
 				const serviceEnv = createServiceEnvironment(context, workspaceFolder);
-				projectPromise = createSimpleServerProject(context, serviceEnv, serverOptions);
+				projectPromise = createSimpleServerProject(context, serviceEnv, serverOptions, servicePlugins);
 				projects.set(workspaceFolder, projectPromise);
 			}
 
@@ -53,7 +53,7 @@ export function createSimpleProjectProvider(context: WorkspacesContext, serverOp
 			context.workspaces.reloadDiagnostics();
 		},
 	};
-}
+};
 
 export function createServiceEnvironment(context: WorkspacesContext, workspaceFolder: ServiceEnvironment['workspaceFolder']) {
 	const env: ServiceEnvironment = {

--- a/packages/language-server/lib/project/typescriptProject.ts
+++ b/packages/language-server/lib/project/typescriptProject.ts
@@ -1,4 +1,4 @@
-import { LanguagePlugin, LanguageService, ServiceEnvironment, TypeScriptProjectHost, createLanguageService, resolveCommonLanguageId } from '@volar/language-service';
+import { LanguagePlugin, LanguageService, ServiceEnvironment, ServicePlugin, TypeScriptProjectHost, createLanguageService, resolveCommonLanguageId } from '@volar/language-service';
 import { createLanguage, createSys } from '@volar/typescript';
 import * as path from 'path-browserify';
 import type * as ts from 'typescript';
@@ -19,6 +19,7 @@ export async function createTypeScriptServerProject(
 	context: WorkspacesContext,
 	serviceEnv: ServiceEnvironment,
 	serverOptions: ServerOptions,
+	servicePlugins: ServicePlugin[],
 ): Promise<TypeScriptServerProject> {
 
 	if (!context.workspaces.ts) {
@@ -48,7 +49,7 @@ export async function createTypeScriptServerProject(
 		getLanguageId: uri => context.workspaces.documents.get(uri)?.languageId ?? resolveCommonLanguageId(uri),
 	};
 	const sys = createSys(ts, serviceEnv, host.getCurrentDirectory());
-	const { languagePlugins, servicePlugins } = await serverOptions.getProjectSetup(serviceEnv, {
+	const languagePlugins = await serverOptions.getLanguagePlugins(serviceEnv, {
 		typescript: {
 			configFileName: typeof tsconfig === 'string' ? tsconfig : undefined,
 		},

--- a/packages/language-server/lib/types.ts
+++ b/packages/language-server/lib/types.ts
@@ -1,5 +1,7 @@
-import type { Console, FileSystem, LanguageService, ServiceEnvironment } from '@volar/language-service';
+import type { Console, FileSystem, LanguageService, ServiceEnvironment, ServicePlugin } from '@volar/language-service';
 import type * as vscode from 'vscode-languageserver';
+import type { WorkspacesContext } from './project/simpleProjectProvider.js';
+import type { ServerOptions } from './server';
 
 export interface Timer {
 	setImmediate(callback: (...args: any[]) => void, ...args: any[]): vscode.Disposable;
@@ -77,4 +79,12 @@ export interface ServerProjectProvider {
 	getProject(uri: string): Promise<ServerProject>;
 	getProjects(): Promise<ServerProject[]>;
 	reloadProjects(): Promise<void> | void;
+}
+
+export interface ServerProjectProviderFactory {
+	(
+		context: WorkspacesContext,
+		serverOptions: ServerOptions,
+		servicePlugins: ServicePlugin[],
+	): ServerProjectProvider;
 }


### PR DESCRIPTION
After internal discussions, we believe that getProjectSetup and getServerCapabilitiesSetup can be simplified. Now, only implementing getServicePlugins and getLanguagePlugins is required.

This is an example after the astro update:

```ts
export function createServerOptions(
	connection: Connection,
	server: ReturnType<typeof createServer>
): ServerOptions {
	return {
		watchFileExtensions: [
			'js',
			'cjs',
			'mjs',
			'ts',
			'cts',
			'mts',
			'jsx',
			'tsx',
			'json',
			'astro',
			'vue',
			'svelte',
		],
		getServicePlugins() {
			const ts = getTypeScriptModule();
			const servicePlugins: ServicePlugin[] = [
				createHtmlService(),
				createCssService(),
				createEmmetService(),
				createTypeScriptService(ts),
				createTypeScriptTwoSlashService(),
				createTypescriptAddonsService(),
				createAstroService(ts),
				getPrettierService(),
			];

			return servicePlugins;
		},
		getLanguagePlugins(serviceEnv, projectContext) {
			const ts = getTypeScriptModule();
			const languagePlugins: LanguagePlugin<VirtualFile>[] = [
				getVueLanguageModule(),
				getSvelteLanguageModule(),
			];

			if (projectContext.typescript) {
				const rootPath = projectContext.typescript.configFileName
					? projectContext.typescript.configFileName.split('/').slice(0, -1).join('/')
					: serviceEnv.uriToFileName(serviceEnv.workspaceFolder.uri.toString());
				const nearestPackageJson = server.modules.typescript?.findConfigFile(
					rootPath,
					ts.sys.fileExists,
					'package.json'
				);

				const astroInstall = getAstroInstall([rootPath], {
					nearestPackageJson: nearestPackageJson,
					readDirectory: ts.sys.readDirectory,
				});

				if (astroInstall === 'not-found') {
					connection.sendNotification(ShowMessageNotification.type, {
						message: `Couldn't find Astro in workspace "${rootPath}". Experience might be degraded. For the best experience, please make sure Astro is installed into your project and restart the language server.`,
						type: MessageType.Warning,
					});
				}

				languagePlugins.unshift(
					getLanguageModule(typeof astroInstall === 'string' ? undefined : astroInstall, ts)
				);
			}

			return languagePlugins;
		},
	};

	function getTypeScriptModule() {
		const tsModule = server.modules.typescript;
		if (!tsModule) {
			throw new Error('TypeScript module is missing');
		}
		return tsModule;
	}

	function getPrettierService() {
		let prettier: typeof import('prettier') | undefined;
		let prettierPluginPath: string | undefined;

		return createPrettierService({
			getPrettier: env => {
				const workspacePath = env.uriToFileName(env.workspaceFolder.uri.toString());
				prettier = importPrettier(workspacePath);
				prettierPluginPath = getPrettierPluginPath(workspacePath);
				if (!prettier) {
					connection.sendNotification(ShowMessageNotification.type, {
						message:
							"Couldn't load `prettier` or `prettier-plugin-astro`. Formatting will not work. Please make sure those two packages are installed into your project.",
						type: MessageType.Warning,
					});
				}
				return prettier;
			},
			languages: ['astro'],
			ignoreIdeOptions: true,
			useIdeOptionsFallback: true,
			resolveConfigOptions: {
				// This seems to be broken since Prettier 3, and it'll always use its cumbersome cache. Hopefully it works one day.
				useCache: false,
			},
			additionalOptions: async (resolvedConfig) => {
				async function getAstroPrettierPlugin() {
					if (!prettier || !prettierPluginPath) {
						return [];
					}

					const hasPluginLoadedAlready =
						(await prettier.getSupportInfo()).languages.some((l: any) => l.name === 'astro') ||
						resolvedConfig.plugins?.includes('prettier-plugin-astro'); // getSupportInfo doesn't seems to work very well in Prettier 3 for plugins

					return hasPluginLoadedAlready ? [] : [prettierPluginPath];
				}

				const plugins = [...(await getAstroPrettierPlugin()), ...(resolvedConfig.plugins ?? [])];

				return {
					...resolvedConfig,
					plugins: plugins,
					parser: 'astro',
				};
			},
		});
	}
}
```