### PR TITLE
feat(typescript): re-support extra virtual scripts for LSP and Kit

### DIFF
--- a/packages/language-core/lib/types.ts
+++ b/packages/language-core/lib/types.ts
@@ -53,18 +53,37 @@ export interface CodeInformation {
 	format: boolean;
 }
 
+export interface ServiceScript {
+	code: VirtualCode;
+	extension: '.ts' | '.js' | '.mts' | '.mjs' | '.cjs' | '.cts' | '.d.ts' | string;
+	scriptKind: ts.ScriptKind;
+}
+
+export interface ExtraServiceScript extends ServiceScript {
+	fileName: string;
+}
+
 export interface LanguagePlugin<T extends VirtualCode = VirtualCode> {
 	createVirtualCode(fileId: string, languageId: string, snapshot: ts.IScriptSnapshot, files?: FileRegistry): T | undefined;
 	updateVirtualCode(fileId: string, virtualCode: T, newSnapshot: ts.IScriptSnapshot, files?: FileRegistry): T;
 	disposeVirtualCode?(fileId: string, virtualCode: T, files?: FileRegistry): void;
 	typescript?: {
+		/**
+		 * LSP + TS Plugin
+		 */
 		extraFileExtensions: ts.FileExtensionInfo[];
+		/**
+		 * LSP + TS Plugin
+		 */
+		getScript(rootVirtualCode: T): ServiceScript | undefined;
+		/**
+		 * LSP only
+		 */
+		getExtraScripts?(fileName: string, rootVirtualCode: T): ExtraServiceScript[];
+		/**
+		 * LSP only
+		 */
 		resolveLanguageServiceHost?(host: ts.LanguageServiceHost): ts.LanguageServiceHost;
-		getScript(rootVirtualCode: T): {
-			code: VirtualCode;
-			extension: '.ts' | '.js' | '.mts' | '.mjs' | '.cjs' | '.cts' | '.d.ts' | string;
-			scriptKind: ts.ScriptKind;
-		} | undefined;
 	};
 }
 
@@ -75,6 +94,7 @@ export interface LanguageContext {
 		sys: ts.System & { sync?(): Promise<number>; };
 		projectHost: TypeScriptProjectHost;
 		languageServiceHost: ts.LanguageServiceHost;
+		getExtraScript(fileName: string): ExtraServiceScript | undefined;
 	};
 }
 

--- a/packages/language-server/lib/register/registerEditorFeatures.ts
+++ b/packages/language-server/lib/register/registerEditorFeatures.ts
@@ -132,10 +132,16 @@ export function registerEditorFeatures(
 					if (uri.startsWith(rootUri)) {
 						const sourceFile = languageService.context.language.files.get(uri);
 						if (sourceFile?.generated) {
-							const virtualFile = sourceFile.generated.languagePlugin.typescript?.getScript(sourceFile.generated.code);
-							if (virtualFile) {
-								const { snapshot } = virtualFile.code;
-								fs.writeFile(uri + virtualFile.extension, snapshot.getText(0, snapshot.getLength()), () => { });
+							const mainScript = sourceFile.generated.languagePlugin.typescript?.getScript(sourceFile.generated.code);
+							if (mainScript) {
+								const { snapshot } = mainScript.code;
+								fs.writeFile(fileName + mainScript.extension, snapshot.getText(0, snapshot.getLength()), () => { });
+							}
+							if (sourceFile.generated.languagePlugin.typescript?.getExtraScripts) {
+								for (const extraScript of sourceFile.generated.languagePlugin.typescript.getExtraScripts(uri, sourceFile.generated.code)) {
+									const { snapshot } = extraScript.code;
+									fs.writeFile(fileName, snapshot.getText(0, snapshot.getLength()), () => { });
+								}
 							}
 						}
 					}

--- a/packages/typescript/lib/node/decorateLanguageServiceHost.ts
+++ b/packages/typescript/lib/node/decorateLanguageServiceHost.ts
@@ -180,6 +180,9 @@ export function decorateLanguageServiceHost(
 						patchedText += script.code.snapshot.getText(0, script.code.snapshot.getLength());
 					}
 					snapshotSnapshot = ts.ScriptSnapshot.fromString(patchedText);
+					if (sourceFile.generated.languagePlugin.typescript?.getExtraScripts) {
+						console.warn('getExtraScripts() is not available in this use case.');
+					}
 				}
 			}
 			else if (virtualFiles.get(fileName)) {

--- a/packages/typescript/lib/node/proxyCreateProgram.ts
+++ b/packages/typescript/lib/node/proxyCreateProgram.ts
@@ -83,11 +83,15 @@ export function proxyCreateProgram(
 						assert(!!sourceFile, '!!sourceFile');
 						let patchedText = originalSourceFile.text.split('\n').map(line => ' '.repeat(line.length)).join('\n');
 						let scriptKind = ts.ScriptKind.TS;
-						if (sourceFile.generated) {
-							const script = sourceFile.generated.languagePlugin.typescript?.getScript(sourceFile.generated.code);
+						if (sourceFile.generated?.languagePlugin.typescript) {
+							const { getScript, getExtraScripts } = sourceFile.generated.languagePlugin.typescript;
+							const script = getScript(sourceFile.generated.code);
 							if (script) {
 								scriptKind = script.scriptKind;
 								patchedText += script.code.snapshot.getText(0, script.code.snapshot.getLength());
+							}
+							if (getExtraScripts) {
+								console.warn('getExtraScripts() is not available in this use case.');
 							}
 						}
 						sourceFile2 = ts.createSourceFile(


### PR DESCRIPTION
Due to an upstream limitation, tsserver will throw when encountering a file name that does not exist in the file system, so Volar 2.0.0 no longer supports generating multiple virtual TS files from a single source file.

Since this breaks Astro's module syntax, generating multiple virtual TS files will now be supported again.

This only works for `@volar/language-server` and `@volar/kit`, but not for TS plugins executed in tsserver. This means that Astro is currently unable to migrate to the TS plugin.

## Changes

- `LanguagePlugin.typescript` add a new `getExtraScripts()` API for returning extra scripts
- `LanguageContext.typescript` add a new `getExtraScript()` method