### PR TITLE
fix(language-service): transform markdown links in completion items

### DIFF
--- a/packages/language-service/lib/features/provideCompletionItems.ts
+++ b/packages/language-service/lib/features/provideCompletionItems.ts
@@ -91,6 +91,7 @@ export function register(context: ServiceContext) {
 								cacheData.list,
 								range => map.getSourceRange(range),
 								map.virtualFileDocument,
+								context,
 							);
 						}
 					}
@@ -208,6 +209,7 @@ export function register(context: ServiceContext) {
 							completionList,
 							range => map.getSourceRange(range, isCompletionEnabled),
 							document,
+							context,
 						);
 					}
 

--- a/packages/language-service/lib/features/provideDocumentLinks.ts
+++ b/packages/language-service/lib/features/provideDocumentLinks.ts
@@ -3,7 +3,7 @@ import type { ServiceContext } from '../types';
 import { NoneCancellationToken } from '../utils/cancellation';
 import { notEmpty } from '../utils/common';
 import { documentFeatureWorker } from '../utils/featureWorkers';
-import { transformDocumentLinkTarget } from './resolveDocumentLink';
+import { transformDocumentLinkTarget } from '../utils/transform';
 import { isDocumentLinkEnabled } from '@volar/language-core';
 
 export interface DocumentLinkData {

--- a/packages/language-service/lib/features/resolveCompletionItem.ts
+++ b/packages/language-service/lib/features/resolveCompletionItem.ts
@@ -33,6 +33,7 @@ export function register(context: ServiceContext) {
 							item,
 							embeddedRange => map.getSourceRange(embeddedRange),
 							map.virtualFileDocument,
+							context,
 						);
 					}
 				}

--- a/packages/language-service/lib/features/resolveDocumentLink.ts
+++ b/packages/language-service/lib/features/resolveDocumentLink.ts
@@ -1,9 +1,8 @@
 import type * as vscode from 'vscode-languageserver-protocol';
-import { URI } from 'vscode-uri';
 import type { ServiceContext } from '../types';
 import { NoneCancellationToken } from '../utils/cancellation';
+import { transformDocumentLinkTarget } from '../utils/transform';
 import type { DocumentLinkData } from './provideDocumentLinks';
-import { isDocumentLinkEnabled } from '@volar/language-core';
 
 export function register(context: ServiceContext) {
 
@@ -26,52 +25,4 @@ export function register(context: ServiceContext) {
 
 		return item;
 	};
-}
-
-export function transformDocumentLinkTarget(target: string, context: ServiceContext) {
-
-	const targetUri = URI.parse(target);
-	const clearUri = targetUri.with({ fragment: '' }).toString(true);
-	const [virtualCode] = context.documents.getVirtualCodeByUri(clearUri);
-
-	if (virtualCode) {
-		for (const map of context.documents.getMaps(virtualCode)) {
-
-			if (!map.map.mappings.some(mapping => isDocumentLinkEnabled(mapping.data))) {
-				continue;
-			}
-
-			target = map.sourceFileDocument.uri;
-
-			const hash = targetUri.fragment;
-			const range = hash.match(/^L(\d+)(,(\d+))?(-L(\d+)(,(\d+))?)?$/);
-
-			if (range) {
-				const startLine = Number(range[1]) - 1;
-				const startCharacter = Number(range[3] ?? 1) - 1;
-				if (range[5] !== undefined) {
-					const endLine = Number(range[5]) - 1;
-					const endCharacter = Number(range[7] ?? 1) - 1;
-					const sourceRange = map.getSourceRange({
-						start: { line: startLine, character: startCharacter },
-						end: { line: endLine, character: endCharacter },
-					});
-					if (sourceRange) {
-						target += '#L' + (sourceRange.start.line + 1) + ',' + (sourceRange.start.character + 1);
-						target += '-L' + (sourceRange.end.line + 1) + ',' + (sourceRange.end.character + 1);
-						break;
-					}
-				}
-				else {
-					const sourcePos = map.getSourcePosition({ line: startLine, character: startCharacter });
-					if (sourcePos) {
-						target += '#L' + (sourcePos.line + 1) + ',' + (sourcePos.character + 1);
-						break;
-					}
-				}
-			}
-		}
-	}
-
-	return target;
 }


### PR DESCRIPTION
This resolves completion item descriptions the same way as hover descriptions are resolved.

The `transformDocumentLinkTarget` and `transformMarkdown` functions were both moved into `utils/transform`, but their implementation remains the same.

The fix was verified to work in MDX analyzer.

Refs https://github.com/mdx-js/mdx-analyzer/issues/394