### PR TITLE
refactor(language-core): make embeddedCodes optional in VirtualCode

### DIFF
--- a/packages/language-core/lib/fileRegistry.ts
+++ b/packages/language-core/lib/fileRegistry.ts
@@ -151,7 +151,9 @@ export function updateVirtualCodeMaps(
 
 export function* forEachEmbeddedCode(code: VirtualCode): Generator<VirtualCode> {
 	yield code;
-	for (const embeddedCode of code.embeddedCodes) {
-		yield* forEachEmbeddedCode(embeddedCode);
+	if (code.embeddedCodes) {
+		for (const embeddedCode of code.embeddedCodes) {
+			yield* forEachEmbeddedCode(embeddedCode);
+		}
 	}
 }

--- a/packages/language-core/lib/types.ts
+++ b/packages/language-core/lib/types.ts
@@ -22,7 +22,7 @@ export interface VirtualCode<T extends string = string> {
 	languageId: string;
 	snapshot: ts.IScriptSnapshot;
 	mappings: CodeMapping[];
-	embeddedCodes: VirtualCode[];
+	embeddedCodes?: VirtualCode[];
 	codegenStacks?: Stack[];
 	linkedCodeMappings?: Mapping[];
 }

--- a/packages/language-server/lib/register/registerEditorFeatures.ts
+++ b/packages/language-server/lib/register/registerEditorFeatures.ts
@@ -80,7 +80,7 @@ export function registerEditorFeatures(
 				fileUri: sourceFile!.id,
 				virtualCodeId: code.id,
 				languageId: code.languageId,
-				embeddedCodes: code.embeddedCodes.map(prune),
+				embeddedCodes: code.embeddedCodes?.map(prune) || [],
 				version,
 				disabled: languageService.context.disabledVirtualFileUris.has(uri),
 			};

--- a/packages/language-service/lib/utils/featureWorkers.ts
+++ b/packages/language-service/lib/utils/featureWorkers.ts
@@ -130,8 +130,10 @@ export function* eachEmbeddedDocument(
 	rootCode = current,
 ): Generator<SourceMapWithDocuments<CodeInformation>> {
 
-	for (const embeddedCode of current.embeddedCodes) {
-		yield* eachEmbeddedDocument(context, embeddedCode, rootCode);
+	if (current.embeddedCodes) {
+		for (const embeddedCode of current.embeddedCodes) {
+			yield* eachEmbeddedDocument(context, embeddedCode, rootCode);
+		}
 	}
 
 	for (const map of context.documents.getMaps(current)) {
@@ -155,10 +157,16 @@ export function getEmbeddedFilesByLevel(context: ServiceContext, sourceFileUri: 
 			return embeddedFilesByLevel[level];
 		}
 
-		let nextLevel: VirtualCode[] = [];
+		const nextLevel: VirtualCode[] = [];
 
 		for (const file of embeddedFilesByLevel[embeddedFilesByLevel.length - 1]) {
-			nextLevel = nextLevel.concat(file.embeddedCodes.filter(file => !context.disabledVirtualFileUris.has(context.documents.getVirtualCodeUri(sourceFileUri, file.id))));
+			if (file.embeddedCodes) {
+				for (const embedded of file.embeddedCodes) {
+					if (!context.disabledVirtualFileUris.has(context.documents.getVirtualCodeUri(sourceFileUri, embedded.id))) {
+						nextLevel.push(embedded);
+					}
+				}
+			}
 		}
 
 		embeddedFilesByLevel.push(nextLevel);


### PR DESCRIPTION
In many cases `embeddedCodes` is always empty. It might as well be optional.