### PR TITLE
refactor(language-server): remove `fullCompletionList` init option

### DIFF
--- a/packages/language-server/lib/server.ts
+++ b/packages/language-server/lib/server.ts
@@ -175,10 +175,8 @@ export function createServerBase(
 			connection,
 			projects,
 			params,
-			context.initializeParams.initializationOptions ?? {},
 			getSemanticTokensLegend(),
 			context.runtimeEnv,
-			documents,
 		);
 
 		try {

--- a/packages/language-server/lib/types.ts
+++ b/packages/language-server/lib/types.ts
@@ -53,12 +53,6 @@ export interface InitializationOptions {
 		location: string; // uri
 	};
 	diagnosticModel?: DiagnosticModel;
-	/**
-	 * For better JSON parsing performance language server will filter CompletionList.
-	 * 
-	 * Enable this option if you want to get complete CompletionList in language client.
-	 */
-	fullCompletionList?: boolean;
 	// for resolve https://github.com/sublimelsp/LSP-volar/issues/114
 	ignoreTriggerCharacters?: string[];
 	reverseConfigFilePriority?: boolean;


### PR DESCRIPTION
`@volar/language-server` introduced the `fullCompletionList` option in https://github.com/volarjs/volar.js/commit/fd0e24ca67f622aee2cad987221e21163e7aa963 to solve JSON parsing performance issues in certain IDEs.

Since version 2.0, these performance issues can be avoided by integrating with the TS plugin, making the workaround provided by `@volar/language-server` no longer necessary.