### PR TITLE
fix(language-service): fix caching of semantic diagnostics

### DIFF
--- a/packages/language-service/lib/features/provideDiagnostics.ts
+++ b/packages/language-service/lib/features/provideDiagnostics.ts
@@ -116,7 +116,7 @@ type CacheMap = Map<
 		string,
 		{
 			documentVersion: number,
-			errors: vscode.Diagnostic[] | undefined | null,
+			errors: vscode.Diagnostic[],
 		}
 	>
 >;
@@ -252,9 +252,9 @@ export function register(context: ServiceContext) {
 						return cache.errors;
 					}
 
-					const errors = await service[1][api]?.(document, token);
+					const errors = await service[1][api]?.(document, token) || [];
 
-					errors?.forEach(error => {
+					errors.forEach(error => {
 						error.data = {
 							uri,
 							version: document.version,


### PR DESCRIPTION
This fixes a caching issue regarding semanric diagnostics. I don’t fully understand why. Returning an empty array from https://github.com/mdx-js/mdx-analyzer/blob/f6a43853d5ae0509b93001fdf6f58e1466106605/packages/language-service/lib/service-plugin.js#L163 fixed the issue, so I figured this was an upstream problem in Volar.

Refs https://github.com/mdx-js/mdx-analyzer/issues/400