### PR TITLE
fix(test-utils): allow unknown initialization options and expose `locale` option

### DIFF
--- a/packages/language-server/lib/types.ts
+++ b/packages/language-server/lib/types.ts
@@ -22,17 +22,10 @@ export enum DiagnosticModel {
 }
 
 export interface InitializationOptions {
-	typescript?: {
-		/**
-		 * Absolute path to node_modules/typescript/lib, available for node
-		 */
-		tsdk?: string;
-	};
 	l10n?: {
 		location: string; // uri
 	};
 	diagnosticModel?: DiagnosticModel;
-	locale?: string;
 	maxFileSize?: number;
 	/**
 	 * Extra semantic token types and modifiers that are supported by the client.

--- a/packages/language-server/lib/types.ts
+++ b/packages/language-server/lib/types.ts
@@ -22,10 +22,17 @@ export enum DiagnosticModel {
 }
 
 export interface InitializationOptions {
+	typescript?: {
+		/**
+		 * Absolute path to node_modules/typescript/lib, available for node
+		 */
+		tsdk?: string;
+	};
 	l10n?: {
 		location: string; // uri
 	};
 	diagnosticModel?: DiagnosticModel;
+	locale?: string;
 	maxFileSize?: number;
 	/**
 	 * Extra semantic token types and modifiers that are supported by the client.

--- a/packages/test-utils/index.ts
+++ b/packages/test-utils/index.ts
@@ -38,7 +38,12 @@ export function startLanguageServer(serverModule: string, cwd?: string | URL) {
 	return {
 		process: childProcess,
 		connection,
-		async initialize(rootUri: string, initializationOptions: _.InitializationOptions, capabilities: _.ClientCapabilities = {}) {
+		async initialize<T = _.InitializationOptions & Record<string, unknown>>(
+			rootUri: string,
+			initializationOptions: T,
+			capabilities: _.ClientCapabilities = {},
+			locale?: string,
+		) {
 			const result = await connection.sendRequest(
 				_.InitializeRequest.type,
 				{
@@ -46,6 +51,7 @@ export function startLanguageServer(serverModule: string, cwd?: string | URL) {
 					rootUri,
 					initializationOptions,
 					capabilities,
+					locale,
 				} satisfies _.InitializeParams
 			);
 			await connection.sendNotification(


### PR DESCRIPTION
This allows people to load TypeScript as suggested in #140. Since `initializationOptions` is of type `any` there, it doesn’t really matter. But the `InitializationOptions` interface is used by the test utils and prohibits the user from passing additional properties.

Also it’s nice if all Volar based language servers that do allow the client to pass the TypeScript SDK, do so in a consistent manner.