### PR TITLE
feat(language-service): add provide generic to ServicePlugin type

### DIFF
--- a/packages/language-service/lib/types.ts
+++ b/packages/language-service/lib/types.ts
@@ -67,13 +67,13 @@ export type Result<T> = T | Thenable<T>;
 export type NullableResult<T> = Result<T | undefined | null>;
 export type SemanticToken = [number, number, number, number, number];
 
-export interface ServicePlugin {
+export interface ServicePlugin<P = any> {
 	name?: string;
 	triggerCharacters?: string[];
 	signatureHelpTriggerCharacters?: string[];
 	signatureHelpRetriggerCharacters?: string[];
 	autoFormatTriggerCharacters?: string[];
-	create(context: ServiceContext): ServicePluginInstance;
+	create(context: ServiceContext): ServicePluginInstance<P>;
 }
 
 export interface EmbeddedCodeFormattingOptions {


### PR DESCRIPTION
This allows a service plugin instance provide value to be inferred without the need for an explicit type annotation on the `create` method.