### PR TITLE
Partial fix for custom extensions not working in VS Code extension.

### DIFF
--- a/packages/typescript/lib/node/proxyCreateProgram.ts
+++ b/packages/typescript/lib/node/proxyCreateProgram.ts
@@ -15,6 +15,7 @@ export function proxyCreateProgram(
 			assert(!!options.host, '!!options.host');
 
 			const sourceFileToSnapshotMap = new WeakMap<ts.SourceFile, ts.IScriptSnapshot>();
+			const customExtensions = extensions.map(ext => ext.slice(1));
 			const language = createLanguage(
 				getLanguagePlugins(ts, options),
 				ts.sys.useCaseSensitiveFileNames,
@@ -40,7 +41,11 @@ export function proxyCreateProgram(
 						}
 					}
 					if (snapshot) {
-						language.scripts.set(fileName, resolveCommonLanguageId(fileName), snapshot);
+						let languageId = resolveCommonLanguageId(fileName);
+						if (customExtensions.some(ext => ext === languageId)) {
+							languageId = 'vue';
+						}
+						language.scripts.set(fileName, languageId, snapshot);
 					}
 					else {
 						language.scripts.delete(fileName);


### PR DESCRIPTION
This is an attempt to fix vuejs/language-tools#4072. The only way I could find to test these changes was with doing a lot of `pnpm link` commands to the language-tools repo so VS Code would use the updated files. Meaning, I'm not 100% sure this is correct but I'm like 99% sure.

This fixed takeover mode (hybrid mode disabled in settings) as far as I was able to test with a small test project and then a quick look through of our larger production repo. The import statements now work correctly, no red squiggly lines, and the intellisense tooltips show up and describe the component and properties correctly.

It's possible this will also fix custom extensions with hybrid mode. Hybrid mode was still acting like I hadn't done anything - which could mean I missed an `pnpm link` command somewhere.

I am submitting another PR to the language-tools repo that adds two unit tests for custom extensions.