### PR TITLE
feat(language-service): auto insert feature does not abstract selection

### DIFF
--- a/packages/language-server/lib/register/registerLanguageFeatures.ts
+++ b/packages/language-server/lib/register/registerLanguageFeatures.ts
@@ -279,7 +279,7 @@ export function registerLanguageFeatures(
 	});
 	connection.onRequest(AutoInsertRequest.type, async (params, token) => {
 		return worker(params.textDocument.uri, token, service => {
-			return service.doAutoInsert(params.textDocument.uri, params.position, params.lastChange, token);
+			return service.doAutoInsert(params.textDocument.uri, params.selection, params.change, token);
 		});
 	});
 

--- a/packages/language-server/protocol.ts
+++ b/packages/language-server/protocol.ts
@@ -39,13 +39,17 @@ export namespace GetMatchTsConfigRequest {
 }
 
 export namespace AutoInsertRequest {
-	export type ParamsType = vscode.TextDocumentPositionParams & {
-		lastChange: {
+	export type ParamsType = {
+		textDocument: vscode.TextDocumentIdentifier;
+		selection: vscode.Position;
+		change: {
 			range: vscode.Range;
+			rangeOffset: number;
+			rangeLength: number;
 			text: string;
 		};
 	};
-	export type ResponseType = string | vscode.TextEdit | null | undefined;
+	export type ResponseType = string | null | undefined;
 	export type ErrorType = never;
 	export const type = new vscode.RequestType<ParamsType, ResponseType, ErrorType>('volar/client/autoInsert');
 }

--- a/packages/language-service/lib/types.ts
+++ b/packages/language-service/lib/types.ts
@@ -131,7 +131,7 @@ export interface LanguageServicePluginInstance<P = any> {
 	provideSemanticDiagnostics?(document: TextDocument, token: vscode.CancellationToken): NullableProviderResult<vscode.Diagnostic[]>;
 	provideFileReferences?(document: TextDocument, token: vscode.CancellationToken): NullableProviderResult<vscode.Location[]>; // volar specific
 	provideReferencesCodeLensRanges?(document: TextDocument, token: vscode.CancellationToken): NullableProviderResult<vscode.Range[]>; // volar specific
-	provideAutoInsertionEdit?(document: TextDocument, position: vscode.Position, lastChange: { range: vscode.Range; text: string; }, token: vscode.CancellationToken): NullableProviderResult<string | vscode.TextEdit>; // volar specific
+	provideAutoInsertionEdit?(document: TextDocument, position: vscode.Position, lastChange: { rangeOffset: number; rangeLength: number; text: string; }, token: vscode.CancellationToken): NullableProviderResult<string | vscode.TextEdit>; // volar specific
 	provideFileRenameEdits?(oldUri: string, newUri: string, token: vscode.CancellationToken): NullableProviderResult<vscode.WorkspaceEdit>; // volar specific
 	provideDocumentDropEdits?(document: TextDocument, position: vscode.Position, dataTransfer: Map<string, DataTransferItem>, token: vscode.CancellationToken): NullableProviderResult<DocumentDropEdit>; // volar specific
 	resolveCodeLens?(codeLens: vscode.CodeLens, token: vscode.CancellationToken): ProviderResult<vscode.CodeLens>;

--- a/packages/monaco/lib/editor.ts
+++ b/packages/monaco/lib/editor.ts
@@ -1,6 +1,6 @@
 import type { LanguageService } from '@volar/language-service';
 import type { editor, IDisposable, MonacoEditor, Uri } from 'monaco-types';
-import { fromPosition, fromRange, toMarkerData, toTextEdit } from 'monaco-languageserver-types';
+import { fromPosition, toMarkerData, toTextEdit } from 'monaco-languageserver-types';
 import { markers } from './markers.js';
 
 interface IInternalEditorModel extends editor.IModel {
@@ -189,8 +189,9 @@ export function activateAutoInsertion(
 						column: lastChange.range.startColumn + lastChange.text.length,
 					}),
 					{
-						range: fromRange(lastChange.range),
 						text: lastChange.text,
+						rangeOffset: lastChange.rangeOffset,
+						rangeLength: lastChange.rangeLength,
 					},
 				);
 				if (model.getVersionId() !== version) {


### PR DESCRIPTION
In the previous auto insertion implementation, `@volar/vscode` always issued requests with the end position of the changed range as a parameter. Based on whether the current selections include the end position of the changed range, it determines whether to insert the text into the selections or the end position of the changed range.

Now it is changed to always issue requests with the selection position and always insert the text into the selections. `LanguageServicePlugin` are responsible for determining whether the selection is at the end position of the changed range to determine whether to provide auto insert text.

This will resolve the limitation of not being able to achieve https://github.com/vuejs/language-tools/issues/4140 downstream.