### PR TITLE
fix: vue-tsc does not show ts errors in the terminal with `--incremental`

### DIFF
--- a/packages/typescript/lib/node/decorateProgram.ts
+++ b/packages/typescript/lib/node/decorateProgram.ts
@@ -1,6 +1,6 @@
 import type { Language } from '@volar/language-core';
 import type * as ts from 'typescript';
-import { notEmpty } from './utils';
+import { getServiceScript, notEmpty } from './utils';
 import { transformDiagnostic } from './transform';
 
 export function decorateProgram(language: Language, program: ts.Program) {
@@ -52,8 +52,8 @@ export function decorateProgram(language: Language, program: ts.Program) {
 	program.getSourceFileByPath = path => {
 		const sourceFile = getSourceFileByPath(path);
 		if (sourceFile) {
-			const sourceScript = language.scripts.get(sourceFile.fileName);
-			if (sourceScript?.generated) {
+			const [serviceScript, sourceScript] = getServiceScript(language, sourceFile.fileName);
+			if (serviceScript) {
 				sourceFile.text = sourceScript.snapshot.getText(0, sourceScript.snapshot.getLength())
 					+ sourceFile.text.substring(sourceScript.snapshot.getLength());
 			}

--- a/packages/typescript/lib/node/decorateProgram.ts
+++ b/packages/typescript/lib/node/decorateProgram.ts
@@ -11,6 +11,7 @@ export function decorateProgram(language: Language, program: ts.Program) {
 	const getSyntacticDiagnostics = program.getSyntacticDiagnostics;
 	const getSemanticDiagnostics = program.getSemanticDiagnostics;
 	const getGlobalDiagnostics = program.getGlobalDiagnostics;
+	const getSourceFileByPath = program.getSourceFileByPath;
 
 	// for tsc --noEmit --watch
 	// @ts-ignore
@@ -45,5 +46,18 @@ export function decorateProgram(language: Language, program: ts.Program) {
 		return (getBindAndCheckDiagnostics as typeof getSyntacticDiagnostics)(sourceFile, cancellationToken)
 			.map(d => transformDiagnostic(language, d))
 			.filter(notEmpty);
+	};
+
+	// fix https://github.com/vuejs/language-tools/issues/4099
+	program.getSourceFileByPath = path => {
+		const sourceFile = getSourceFileByPath(path);
+		if (sourceFile) {
+			const sourceScript = language.scripts.get(sourceFile.fileName);
+			if (sourceScript?.generated) {
+				sourceFile.text = sourceScript.snapshot.getText(0, sourceScript.snapshot.getLength())
+					+ sourceFile.text.substring(sourceScript.snapshot.getLength());
+			}
+		}
+		return sourceFile;
 	};
 }

--- a/packages/typescript/lib/node/proxyCreateProgram.ts
+++ b/packages/typescript/lib/node/proxyCreateProgram.ts
@@ -2,7 +2,6 @@ import type * as ts from 'typescript';
 import { decorateProgram } from './decorateProgram';
 import { Language, LanguagePlugin, createLanguage } from '@volar/language-core';
 import { createResolveModuleName } from '../resolveModuleName';
-import { transformSourceFile } from './transform';
 
 let language: Language;
 
@@ -156,25 +155,4 @@ function assert(condition: unknown, message: string): asserts condition {
 		console.error(message);
 		throw new Error(message);
 	}
-}
-
-export function proxyConvertToDiagnosticRelatedInformation(
-	original: Function,
-) {
-	return new Proxy(original, {
-		apply: (target, thisArg, args) => {
-			const diagnostic = Reflect.apply(target, thisArg, args) as ts.DiagnosticRelatedInformation;
-			const { file } = diagnostic;
-			const sourceScript = file ? language.scripts.get(file.fileName) : undefined;
-
-			if (!sourceScript) {
-				return diagnostic;
-			}
-
-			return {
-				...diagnostic,
-				file: transformSourceFile(file!, sourceScript.snapshot.getText(0, sourceScript.snapshot.getLength())),
-			};
-		},
-	});
 }

--- a/packages/typescript/lib/node/proxyCreateProgram.ts
+++ b/packages/typescript/lib/node/proxyCreateProgram.ts
@@ -1,9 +1,7 @@
+import { LanguagePlugin, createLanguage } from '@volar/language-core';
 import type * as ts from 'typescript';
-import { decorateProgram } from './decorateProgram';
-import { Language, LanguagePlugin, createLanguage } from '@volar/language-core';
 import { createResolveModuleName } from '../resolveModuleName';
-
-let language: Language;
+import { decorateProgram } from './decorateProgram';
 
 export function proxyCreateProgram(
 	ts: typeof import('typescript'),
@@ -22,7 +20,7 @@ export function proxyCreateProgram(
 				.map(plugin => plugin.typescript?.extraFileExtensions.map(({ extension }) => `.${extension}`) ?? [])
 				.flat();
 			const sourceFileToSnapshotMap = new WeakMap<ts.SourceFile, ts.IScriptSnapshot>();
-			language = createLanguage(
+			const language = createLanguage(
 				languagePlugins,
 				ts.sys.useCaseSensitiveFileNames,
 				fileName => {

--- a/packages/typescript/lib/node/transform.ts
+++ b/packages/typescript/lib/node/transform.ts
@@ -3,7 +3,6 @@ import type * as ts from 'typescript';
 import { getServiceScript, notEmpty } from './utils';
 
 const transformedDiagnostics = new WeakMap<ts.Diagnostic, ts.Diagnostic | undefined>();
-const transformedSourceFiles = new WeakMap<ts.SourceFile, ts.SourceFile>();
 
 export function transformCallHierarchyItem(language: Language, item: ts.CallHierarchyItem, filter: (data: CodeInformation) => boolean): ts.CallHierarchyItem {
 	const span = transformSpan(language, item.file, item.span, filter);
@@ -39,7 +38,6 @@ export function transformDiagnostic<T extends ts.Diagnostic>(language: Language,
 						...diagnostic,
 						start: sourceSpan.start,
 						length: sourceSpan.length,
-						file: transformSourceFile(diagnostic.file, sourceScript.snapshot.getText(0, sourceScript.snapshot.getLength())),
 					});
 				}
 			}
@@ -52,16 +50,6 @@ export function transformDiagnostic<T extends ts.Diagnostic>(language: Language,
 		}
 	}
 	return transformedDiagnostics.get(diagnostic) as T | undefined;
-}
-
-export function transformSourceFile(sourceFile: ts.SourceFile, sourceText: string): ts.SourceFile {
-	if (!transformedSourceFiles.has(sourceFile)) {
-		transformedSourceFiles.set(sourceFile, {
-			...sourceFile,
-			text: sourceText,
-		});
-	}
-	return transformedSourceFiles.get(sourceFile)!;
 }
 
 export function transformFileTextChanges(language: Language, changes: ts.FileTextChanges, filter: (data: CodeInformation) => boolean): ts.FileTextChanges | undefined {

--- a/packages/typescript/lib/quickstart/runTsc.ts
+++ b/packages/typescript/lib/quickstart/runTsc.ts
@@ -42,15 +42,6 @@ export function runTsc(
 				+ s.replace('createProgram', '_createProgram')
 			);
 
-			// proxy convertToDiagnosticRelatedInformation for `--incremental`
-			try {
-				tsc = replace(tsc, /function convertToDiagnosticRelatedInformation\(.+\) {/, s =>
-					`var convertToDiagnosticRelatedInformation = require(${JSON.stringify(proxyApiPath)})`
-					+ `.proxyConvertToDiagnosticRelatedInformation(_convertToDiagnosticRelatedInformation);\n`
-					+ s.replace('convertToDiagnosticRelatedInformation', '_convertToDiagnosticRelatedInformation')
-				);
-			} catch { /*ignore*/ }
-
 			return tsc;
 		}
 		return (readFileSync as any)(...args);

--- a/packages/typescript/lib/quickstart/runTsc.ts
+++ b/packages/typescript/lib/quickstart/runTsc.ts
@@ -42,6 +42,15 @@ export function runTsc(
 				+ s.replace('createProgram', '_createProgram')
 			);
 
+			// proxy convertToDiagnosticRelatedInformation for `--incremental`
+			try {
+				tsc = replace(tsc, /function convertToDiagnosticRelatedInformation\(.+\) {/, s =>
+					`var convertToDiagnosticRelatedInformation = require(${JSON.stringify(proxyApiPath)})`
+					+ `.proxyConvertToDiagnosticRelatedInformation(_convertToDiagnosticRelatedInformation);\n`
+					+ s.replace('convertToDiagnosticRelatedInformation', '_convertToDiagnosticRelatedInformation')
+				);
+			} catch { /*ignore*/ }
+
 			return tsc;
 		}
 		return (readFileSync as any)(...args);


### PR DESCRIPTION
- I'm trying to fix the issue I raised: 
   https://github.com/vuejs/language-tools/issues/4194

- In the process of locating the problem, I found that when `tsc --incremental` is run repeatedly, the TS error message is converted by `tsc.js`'s `convertToDiagnosticRelatedInformation` method, which does not correctly get the text content corresponding to the error. So, I'm going to proxy this function to get `diagnostic.file.text` correctly.

- I don't think my solution is very elegant, and I'm worried about introducing new issues, but at least I hope to provide some clues. Since I'm not familiar with volar at the moment, I'm expecting a simpler fix as well.
