### PR TITLE
refactor(typescript): reduce `decorateLanguageServiceHost` side effects

### DIFF
--- a/packages/typescript/lib/node/decorateLanguageServiceHost.ts
+++ b/packages/typescript/lib/node/decorateLanguageServiceHost.ts
@@ -6,24 +6,21 @@ export function decorateLanguageServiceHost(
 	ts: typeof import('typescript'),
 	language: Language,
 	languageServiceHost: ts.LanguageServiceHost,
-	getLanguageId: (fileName: string) => string,
 ) {
-
-	let extraProjectVersion = 0;
-
 	const extensions = language.plugins
 		.map(plugin => plugin.typescript?.extraFileExtensions.map(ext => '.' + ext.extension) ?? [])
 		.flat();
-	const scripts = new Map<string, [version: string, {
-		snapshot: ts.IScriptSnapshot;
-		kind: ts.ScriptKind;
-		extension: string;
-	}]>();
-
+	const scripts = new Map<string, [
+		version: string,
+		virtualScript?: {
+			snapshot: ts.IScriptSnapshot;
+			kind: ts.ScriptKind;
+			extension: string;
+		},
+	]>();
 	const readDirectory = languageServiceHost.readDirectory?.bind(languageServiceHost);
 	const resolveModuleNameLiterals = languageServiceHost.resolveModuleNameLiterals?.bind(languageServiceHost);
 	const resolveModuleNames = languageServiceHost.resolveModuleNames?.bind(languageServiceHost);
-	const getProjectVersion = languageServiceHost.getProjectVersion?.bind(languageServiceHost);
 	const getScriptSnapshot = languageServiceHost.getScriptSnapshot.bind(languageServiceHost);
 	const getScriptKind = languageServiceHost.getScriptKind?.bind(languageServiceHost);
 
@@ -84,12 +81,6 @@ export function decorateLanguageServiceHost(
 		}
 	}
 
-	if (getProjectVersion) {
-		languageServiceHost.getProjectVersion = () => {
-			return getProjectVersion() + ':' + extraProjectVersion;
-		};
-	}
-
 	languageServiceHost.getScriptSnapshot = fileName => {
 		const virtualScript = updateVirtualScript(fileName);
 		if (virtualScript) {
@@ -118,41 +109,32 @@ export function decorateLanguageServiceHost(
 			let snapshotSnapshot: ts.IScriptSnapshot | undefined;
 			let scriptKind = ts.ScriptKind.TS;
 
-			const snapshot = getScriptSnapshot(fileName);
-
-			if (snapshot) {
-				extraProjectVersion++;
-				const sourceScript = language.scripts.set(fileName, getLanguageId(fileName), snapshot);
-				if (sourceScript.generated) {
-					const text = snapshot.getText(0, snapshot.getLength());
-					let patchedText = text.split('\n').map(line => ' '.repeat(line.length)).join('\n');
-					const serviceScript = sourceScript.generated.languagePlugin.typescript?.getServiceScript(sourceScript.generated.root);
-					if (serviceScript) {
-						extension = serviceScript.extension;
-						scriptKind = serviceScript.scriptKind;
-						patchedText += serviceScript.code.snapshot.getText(0, serviceScript.code.snapshot.getLength());
-					}
-					snapshotSnapshot = ts.ScriptSnapshot.fromString(patchedText);
-					if (sourceScript.generated.languagePlugin.typescript?.getExtraServiceScripts) {
-						console.warn('getExtraScripts() is not available in this use case.');
-					}
+			const sourceScript = language.scripts.get(fileName);
+			if (sourceScript?.generated) {
+				const text = sourceScript.snapshot.getText(0, sourceScript.snapshot.getLength());
+				let patchedText = text.split('\n').map(line => ' '.repeat(line.length)).join('\n');
+				const serviceScript = sourceScript.generated.languagePlugin.typescript?.getServiceScript(sourceScript.generated.root);
+				if (serviceScript) {
+					extension = serviceScript.extension;
+					scriptKind = serviceScript.scriptKind;
+					patchedText += serviceScript.code.snapshot.getText(0, serviceScript.code.snapshot.getLength());
+				}
+				snapshotSnapshot = ts.ScriptSnapshot.fromString(patchedText);
+				if (sourceScript.generated.languagePlugin.typescript?.getExtraServiceScripts) {
+					console.warn('getExtraServiceScripts() is not available in TS plugin.');
 				}
 			}
-			else if (language.scripts.get(fileName)) {
-				extraProjectVersion++;
-				language.scripts.delete(fileName);
-			}
 
-			if (snapshotSnapshot) {
-				scripts.set(fileName, [
-					version,
-					{
+			scripts.set(fileName, [
+				version,
+				snapshotSnapshot
+					? {
 						extension,
 						snapshot: snapshotSnapshot,
 						kind: scriptKind,
 					}
-				]);
-			}
+					: undefined,
+			]);
 		}
 
 		return scripts.get(fileName)?.[1];

--- a/packages/typescript/lib/quickstart/createAsyncLanguageServicePlugin.ts
+++ b/packages/typescript/lib/quickstart/createAsyncLanguageServicePlugin.ts
@@ -84,7 +84,7 @@ export function createAsyncLanguageServicePlugin(
 						);
 
 						decorateLanguageService(language, info.languageService);
-						decorateLanguageServiceHost(ts, language, info.languageServiceHost, getLanguageId);
+						decorateLanguageServiceHost(ts, language, info.languageServiceHost);
 
 						info.project.markAsDirty();
 						initialized = true;

--- a/packages/typescript/lib/quickstart/createLanguageServicePlugin.ts
+++ b/packages/typescript/lib/quickstart/createLanguageServicePlugin.ts
@@ -47,7 +47,7 @@ export function createLanguageServicePlugin(
 					);
 
 					decorateLanguageService(language, info.languageService);
-					decorateLanguageServiceHost(ts, language, info.languageServiceHost, getLanguageId);
+					decorateLanguageServiceHost(ts, language, info.languageServiceHost);
 				}
 
 				return info.languageService;


### PR DESCRIPTION
As the architecture improves, `decorateLanguageServiceHost`'s modification of `getProjectVersion` seems to be no longer necessary, so it can be removed to reduce side effects.