### PR TITLE
fix(language-core): handle empty mappings in updateVirtualCodeMapOfMap

### DIFF
--- a/packages/language-core/index.ts
+++ b/packages/language-core/index.ts
@@ -138,6 +138,12 @@ export function updateVirtualCodeMapOfMap(
 	getSourceSnapshot: (id: string | undefined) => [string, ts.IScriptSnapshot] | undefined,
 ) {
 	const sources = new Set<string | undefined>();
+	if (!virtualCode.mappings.length) {
+		const source = getSourceSnapshot(undefined);
+		if (source) {
+			mapOfMap.set(source[0], [source[1], new SourceMap([])]);
+		}
+	}
 	for (const mapping of virtualCode.mappings) {
 		if (sources.has(mapping.source)) {
 			continue;


### PR DESCRIPTION
If virtual code has no mappings, we still need to update virtual code maps based on a source of undefined. Without this, the TypeScript plugin isn’t able to find virtual code without mappings. For completions this means it falls back to TypeScript’s own `getCompletsionsAtPosition` implementation, which returns a list of everything in scope.

Refs https://github.com/mdx-js/mdx-analyzer/issues/427