### PR TITLE
fix(typescript): transform source file for tsc without `incremental`

### DIFF
--- a/packages/typescript/lib/node/decorateProgram.ts
+++ b/packages/typescript/lib/node/decorateProgram.ts
@@ -1,7 +1,7 @@
 import type { Language } from '@volar/language-core';
 import type * as ts from 'typescript';
-import { getServiceScript, notEmpty } from './utils';
-import { transformDiagnostic } from './transform';
+import { notEmpty } from './utils';
+import { transformDiagnostic, transformSourceFile } from './transform';
 
 export function decorateProgram(language: Language, program: ts.Program) {
 
@@ -48,16 +48,9 @@ export function decorateProgram(language: Language, program: ts.Program) {
 			.filter(notEmpty);
 	};
 
-	// fix https://github.com/vuejs/language-tools/issues/4099
+	// fix https://github.com/vuejs/language-tools/issues/4099 with `incremental`
 	program.getSourceFileByPath = path => {
 		const sourceFile = getSourceFileByPath(path);
-		if (sourceFile) {
-			const [serviceScript, sourceScript] = getServiceScript(language, sourceFile.fileName);
-			if (serviceScript) {
-				sourceFile.text = sourceScript.snapshot.getText(0, sourceScript.snapshot.getLength())
-					+ sourceFile.text.substring(sourceScript.snapshot.getLength());
-			}
-		}
-		return sourceFile;
+		return sourceFile && transformSourceFile(language, sourceFile);
 	};
 }

--- a/packages/typescript/lib/node/decorateProgram.ts
+++ b/packages/typescript/lib/node/decorateProgram.ts
@@ -1,7 +1,7 @@
 import type { Language } from '@volar/language-core';
 import type * as ts from 'typescript';
 import { notEmpty } from './utils';
-import { transformDiagnostic, transformSourceFile } from './transform';
+import { transformDiagnostic, fillSourceFileText } from './transform';
 
 export function decorateProgram(language: Language, program: ts.Program) {
 
@@ -51,6 +51,9 @@ export function decorateProgram(language: Language, program: ts.Program) {
 	// fix https://github.com/vuejs/language-tools/issues/4099 with `incremental`
 	program.getSourceFileByPath = path => {
 		const sourceFile = getSourceFileByPath(path);
-		return sourceFile && transformSourceFile(language, sourceFile);
+		if (sourceFile) {
+			fillSourceFileText(language, sourceFile);
+		}
+		return sourceFile;
 	};
 }

--- a/packages/typescript/lib/node/transform.ts
+++ b/packages/typescript/lib/node/transform.ts
@@ -35,11 +35,12 @@ export function transformDiagnostic<T extends ts.Diagnostic>(language: Language,
 			if (serviceScript) {
 				const sourceSpan = transformTextSpan(sourceScript, map, { start: diagnostic.start, length: diagnostic.length }, shouldReportDiagnostics);
 				if (sourceSpan) {
+					fillSourceFileText(language, diagnostic.file);
 					transformedDiagnostics.set(diagnostic, {
 						...diagnostic,
 						start: sourceSpan.start,
 						length: sourceSpan.length,
-						file: transformSourceFile(language, diagnostic.file),
+						file: diagnostic.file,
 					});
 				}
 			}
@@ -55,9 +56,9 @@ export function transformDiagnostic<T extends ts.Diagnostic>(language: Language,
 }
 
 // fix https://github.com/vuejs/language-tools/issues/4099 without `incremental`
-export function transformSourceFile(language: Language, sourceFile: ts.SourceFile): ts.SourceFile {
+export function fillSourceFileText(language: Language, sourceFile: ts.SourceFile) {
 	if (transformedSourceFile.has(sourceFile)) {
-		return sourceFile;
+		return;
 	}
 	transformedSourceFile.add(sourceFile);
 	const [serviceScript, sourceScript] = getServiceScript(language, sourceFile.fileName);
@@ -65,7 +66,7 @@ export function transformSourceFile(language: Language, sourceFile: ts.SourceFil
 		sourceFile.text = sourceScript.snapshot.getText(0, sourceScript.snapshot.getLength())
 			+ sourceFile.text.substring(sourceScript.snapshot.getLength());
 	}
-	return sourceFile;
+	return;
 }
 
 export function transformFileTextChanges(language: Language, changes: ts.FileTextChanges, filter: (data: CodeInformation) => boolean): ts.FileTextChanges | undefined {

--- a/packages/typescript/lib/node/transform.ts
+++ b/packages/typescript/lib/node/transform.ts
@@ -3,6 +3,7 @@ import type * as ts from 'typescript';
 import { getServiceScript, notEmpty } from './utils';
 
 const transformedDiagnostics = new WeakMap<ts.Diagnostic, ts.Diagnostic | undefined>();
+const transformedSourceFile = new WeakSet<ts.SourceFile>();
 
 export function transformCallHierarchyItem(language: Language, item: ts.CallHierarchyItem, filter: (data: CodeInformation) => boolean): ts.CallHierarchyItem {
 	const span = transformSpan(language, item.file, item.span, filter);
@@ -55,6 +56,10 @@ export function transformDiagnostic<T extends ts.Diagnostic>(language: Language,
 
 // fix https://github.com/vuejs/language-tools/issues/4099 without `incremental`
 export function transformSourceFile(language: Language, sourceFile: ts.SourceFile): ts.SourceFile {
+	if (transformedSourceFile.has(sourceFile)) {
+		return sourceFile;
+	}
+	transformedSourceFile.add(sourceFile);
 	const [serviceScript, sourceScript] = getServiceScript(language, sourceFile.fileName);
 	if (serviceScript) {
 		sourceFile.text = sourceScript.snapshot.getText(0, sourceScript.snapshot.getLength())

--- a/packages/typescript/lib/node/transform.ts
+++ b/packages/typescript/lib/node/transform.ts
@@ -40,7 +40,6 @@ export function transformDiagnostic<T extends ts.Diagnostic>(language: Language,
 						...diagnostic,
 						start: sourceSpan.start,
 						length: sourceSpan.length,
-						file: diagnostic.file,
 					});
 				}
 			}


### PR DESCRIPTION
- refs
  https://github.com/vuejs/language-tools/issues/4099
  https://github.com/vuejs/language-tools/issues/4194

- I've found that `program.getSourceFileByPath` is only used when enabled with the `incremental` option, and when **without** `incremental`, tsc diagnostics don't go through the `program.getSourceFileByPath`.

- So we still need the `transformSourceFile` function that was removed from the previous [**fix PR**](https://github.com/volarjs/volar.js/pull/158/files#diff-9b81391499358e6a051b86a6026a74f7dfdda8d53e856f7b11f696e703a93996L57). Sorry I didn't test this issue in time before.