### PR TITLE
refactor(language-core): resolved language ID by LangaugePlugin

### DIFF
--- a/packages/kit/lib/createChecker.ts
+++ b/packages/kit/lib/createChecker.ts
@@ -1,4 +1,4 @@
-import { CodeActionTriggerKind, Diagnostic, DiagnosticSeverity, DidChangeWatchedFilesParams, FileChangeType, LanguagePlugin, NotificationHandler, LanguageServicePlugin, ServiceEnvironment, createLanguageService, mergeWorkspaceEdits, resolveCommonLanguageId, TypeScriptProjectHost } from '@volar/language-service';
+import { CodeActionTriggerKind, Diagnostic, DiagnosticSeverity, DidChangeWatchedFilesParams, FileChangeType, LanguagePlugin, NotificationHandler, LanguageServicePlugin, ServiceEnvironment, createLanguageService, mergeWorkspaceEdits, TypeScriptProjectHost } from '@volar/language-service';
 import * as path from 'typesafe-path/posix';
 import * as ts from 'typescript';
 import { TextDocument } from 'vscode-languageserver-textdocument';
@@ -10,7 +10,6 @@ export function createTypeScriptChecker(
 	languagePlugins: LanguagePlugin[],
 	languageServicePlugins: LanguageServicePlugin[],
 	tsconfig: string,
-	getLanguageId = resolveCommonLanguageId,
 ) {
 	const tsconfigPath = asPosix(tsconfig);
 	return createTypeScriptCheckerWorker(languagePlugins, languageServicePlugins, env => {
@@ -30,7 +29,6 @@ export function createTypeScriptChecker(
 				parsed.fileNames = parsed.fileNames.map(asPosix);
 				return parsed;
 			},
-			getLanguageId,
 		);
 	});
 }
@@ -39,7 +37,6 @@ export function createTypeScriptInferredChecker(
 	languagePlugins: LanguagePlugin[],
 	languageServicePlugins: LanguageServicePlugin[],
 	getScriptFileNames: () => string[],
-	getLanguageId = resolveCommonLanguageId,
 	compilerOptions = defaultCompilerOptions
 ) {
 	return createTypeScriptCheckerWorker(languagePlugins, languageServicePlugins, env => {
@@ -50,7 +47,6 @@ export function createTypeScriptInferredChecker(
 				options: compilerOptions,
 				fileNames: getScriptFileNames().map(asPosix),
 			}),
-			getLanguageId,
 		);
 	});
 }
@@ -203,7 +199,6 @@ function createTypeScriptProjectHost(
 	configFileName: string | undefined,
 	env: ServiceEnvironment,
 	createParsedCommandLine: () => Pick<ts.ParsedCommandLine, 'options' | 'fileNames'>,
-	getLanguageId: (fileName: string) => string,
 ) {
 
 	let scriptSnapshotsCache: Map<string, ts.IScriptSnapshot | undefined> = new Map();
@@ -240,7 +235,6 @@ function createTypeScriptProjectHost(
 			}
 			return scriptSnapshotsCache.get(fileName);
 		},
-		getLanguageId,
 		fileNameToScriptId: env.typescript!.fileNameToUri,
 		scriptIdToFileName: env.typescript!.uriToFileName,
 	};

--- a/packages/kit/lib/createFormatter.ts
+++ b/packages/kit/lib/createFormatter.ts
@@ -33,7 +33,7 @@ export function createFormatter(
 	async function format(content: string, languageId: string, options: FormattingOptions): Promise<string> {
 
 		const snapshot = ts.ScriptSnapshot.fromString(content);
-		language.scripts.set(fakeUri, languageId, snapshot);
+		language.scripts.set(fakeUri, snapshot, languageId);
 
 		const document = service.context.documents.get(fakeUri, languageId, snapshot);
 		const edits = await service.format(fakeUri, options, undefined, undefined);

--- a/packages/language-core/lib/types.ts
+++ b/packages/language-core/lib/types.ts
@@ -6,7 +6,7 @@ export interface Language {
 	plugins: LanguagePlugin[];
 	scripts: {
 		get(id: string): SourceScript | undefined;
-		set(id: string, languageId: string, snapshot: ts.IScriptSnapshot, plugins?: LanguagePlugin[]): SourceScript;
+		set(id: string, snapshot: ts.IScriptSnapshot, languageId?: string, plugins?: LanguagePlugin[]): SourceScript | undefined;
 		delete(id: string): void;
 	};
 	maps: {
@@ -86,8 +86,9 @@ export interface ExtraServiceScript extends ServiceScript {
 }
 
 export interface LanguagePlugin<T extends VirtualCode = VirtualCode> {
-	createVirtualCode(scriptId: string, languageId: string, snapshot: ts.IScriptSnapshot): T | undefined;
-	updateVirtualCode(scriptId: string, virtualCode: T, newSnapshot: ts.IScriptSnapshot): T;
+	getLanguageId(scriptId: string): string | undefined;
+	createVirtualCode?(scriptId: string, languageId: string, snapshot: ts.IScriptSnapshot): T | undefined;
+	updateVirtualCode?(scriptId: string, virtualCode: T, newSnapshot: ts.IScriptSnapshot): T | undefined;
 	disposeVirtualCode?(scriptId: string, virtualCode: T): void;
 	typescript?: {
 		/**
@@ -120,7 +121,6 @@ export interface TypeScriptProjectHost extends ts.System, Pick<
 	| 'getScriptSnapshot'
 > {
 	configFileName: string | undefined;
-	getLanguageId(scriptId: string): string;
 	getSystemVersion?(): number;
 	syncSystem?(): Promise<number>;
 	scriptIdToFileName(scriptId: string): string;

--- a/packages/language-server/lib/project/simpleProject.ts
+++ b/packages/language-server/lib/project/simpleProject.ts
@@ -19,9 +19,9 @@ export async function createSimpleServerProject(
 	function getLanguageService() {
 		if (!languageService) {
 			const language = createLanguage(languagePlugins, false, uri => {
-				const script = server.documents.get(uri);
-				if (script) {
-					language.scripts.set(uri, script.languageId, script.getSnapshot());
+				const document = server.documents.get(uri);
+				if (document) {
+					language.scripts.set(uri, document.getSnapshot(), document.uri);
 				}
 				else {
 					language.scripts.delete(uri);

--- a/packages/language-server/lib/project/typescriptProject.ts
+++ b/packages/language-server/lib/project/typescriptProject.ts
@@ -1,4 +1,4 @@
-import { LanguagePlugin, LanguageService, ProviderResult, ServiceEnvironment, TypeScriptProjectHost, createLanguageService, resolveCommonLanguageId } from '@volar/language-service';
+import { LanguagePlugin, LanguageService, ProviderResult, ServiceEnvironment, TypeScriptProjectHost, createLanguageService } from '@volar/language-service';
 import { createSys, createTypeScriptLanguage } from '@volar/typescript';
 import * as path from 'path-browserify';
 import type * as ts from 'typescript';
@@ -63,9 +63,6 @@ export async function createTypeScriptServerProject(
 		getProjectReferences() {
 			return parsedCommandLine.projectReferences;
 		},
-		getLanguageId(uri) {
-			return server.documents.get(uri)?.languageId ?? resolveCommonLanguageId(uri);
-		},
 		fileNameToScriptId: serviceEnv.typescript!.fileNameToUri,
 		scriptIdToFileName: serviceEnv.typescript!.uriToFileName,
 	};
@@ -112,7 +109,14 @@ export async function createTypeScriptServerProject(
 		if (!languageService) {
 			const language = createTypeScriptLanguage(
 				ts,
-				languagePlugins,
+				[
+					{
+						getLanguageId(uri) {
+							return server.documents.get(uri)?.languageId;
+						},
+					},
+					...languagePlugins,
+				],
 				host,
 			);
 			languageService = createLanguageService(

--- a/packages/language-server/lib/server.ts
+++ b/packages/language-server/lib/server.ts
@@ -4,12 +4,12 @@ import * as l10n from '@vscode/l10n';
 import { configure as configureHttpRequests } from 'request-light';
 import * as vscode from 'vscode-languageserver';
 import { URI } from 'vscode-uri';
-import { getServerCapabilities } from './serverCapabilities.js';
-import type { VolarInitializeParams, ServerProjectProvider } from './types.js';
-import { fileNameToUri } from './uri.js';
-import { createUriMap } from './utils/uriMap.js';
 import { registerEditorFeatures } from './register/registerEditorFeatures.js';
 import { registerLanguageFeatures } from './register/registerLanguageFeatures.js';
+import { getServerCapabilities } from './serverCapabilities.js';
+import type { ServerProjectProvider, VolarInitializeParams } from './types.js';
+import { fileNameToUri } from './uri.js';
+import { createUriMap } from './utils/uriMap.js';
 
 export * from '@volar/snapshot-document';
 

--- a/packages/language-service/lib/features/provideDocumentFormattingEdits.ts
+++ b/packages/language-service/lib/features/provideDocumentFormattingEdits.ts
@@ -66,7 +66,7 @@ export function register(context: ServiceContext) {
 			const originalDocument = document;
 
 			let tempSourceSnapshot = sourceScript.snapshot;
-			let tempVirtualFile = context.language.scripts.set(sourceScript.id + '.tmp', sourceScript.languageId, sourceScript.snapshot, [sourceScript.generated.languagePlugin]).generated?.root;
+			let tempVirtualFile = context.language.scripts.set(sourceScript.id + '.tmp', sourceScript.snapshot, sourceScript.languageId, [sourceScript.generated.languagePlugin])?.generated?.root;
 			if (!tempVirtualFile) {
 				return;
 			}
@@ -145,7 +145,7 @@ export function register(context: ServiceContext) {
 					const newText = TextDocument.applyEdits(document, edits);
 					document = TextDocument.create(document.uri, document.languageId, document.version + 1, newText);
 					tempSourceSnapshot = stringToSnapshot(newText);
-					tempVirtualFile = context.language.scripts.set(sourceScript.id + '.tmp', sourceScript.languageId, tempSourceSnapshot, [sourceScript.generated.languagePlugin]).generated?.root;
+					tempVirtualFile = context.language.scripts.set(sourceScript.id + '.tmp', tempSourceSnapshot, sourceScript.languageId, [sourceScript.generated.languagePlugin])?.generated?.root;
 					if (!tempVirtualFile) {
 						break;
 					}

--- a/packages/monaco/worker.ts
+++ b/packages/monaco/worker.ts
@@ -4,7 +4,6 @@ import {
 	LanguageServicePlugin,
 	createLanguageService as _createLanguageService,
 	createLanguage,
-	resolveCommonLanguageId,
 	type LanguageService,
 	type ServiceEnvironment,
 	TypeScriptProjectHost,
@@ -22,14 +21,12 @@ export function createSimpleWorkerService<T = {}>({
 	languagePlugins = [],
 	servicePlugins = [],
 	extraApis = {} as T,
-	getLanguageId = resolveCommonLanguageId,
 }: {
 	env: ServiceEnvironment;
 	workerContext: monaco.worker.IWorkerContext<any>;
 	languagePlugins?: LanguagePlugin[];
 	servicePlugins?: LanguageServicePlugin[];
 	extraApis?: T;
-	getLanguageId?: (uri: string) => string;
 }) {
 	const snapshots = new Map<monaco.worker.IMirrorModel, readonly [number, ts.IScriptSnapshot]>();
 	const language = createLanguage(
@@ -49,7 +46,7 @@ export function createSimpleWorkerService<T = {}>({
 					getChangeRange: () => undefined,
 				};
 				snapshots.set(model, [model.version, snapshot]);
-				language.scripts.set(uri, getLanguageId(uri), snapshot);
+				language.scripts.set(uri, snapshot);
 			}
 			else {
 				language.scripts.delete(uri);
@@ -68,7 +65,6 @@ export function createTypeScriptWorkerService<T = {}>({
 	languagePlugins = [],
 	servicePlugins = [],
 	extraApis = {} as T,
-	getLanguageId = resolveCommonLanguageId,
 }: {
 	typescript: typeof import('typescript'),
 	compilerOptions: ts.CompilerOptions,
@@ -77,7 +73,6 @@ export function createTypeScriptWorkerService<T = {}>({
 	languagePlugins?: LanguagePlugin[];
 	servicePlugins?: LanguageServicePlugin[];
 	extraApis?: T;
-	getLanguageId?: (uri: string) => string;
 }) {
 
 	let projectVersion = 0;
@@ -134,7 +129,6 @@ export function createTypeScriptWorkerService<T = {}>({
 		getCompilationSettings() {
 			return compilerOptions;
 		},
-		getLanguageId: id => getLanguageId(id),
 		fileNameToScriptId: env.typescript!.fileNameToUri,
 		scriptIdToFileName: env.typescript!.uriToFileName,
 	};

--- a/packages/typescript/lib/common.ts
+++ b/packages/typescript/lib/common.ts
@@ -1,0 +1,17 @@
+import type { LanguagePlugin } from "@volar/language-core";
+
+export const fileLanguageIdProviderPlugin: LanguagePlugin = {
+	getLanguageId(scriptId) {
+		const ext = scriptId.split('.').pop()!;
+		switch (ext) {
+			case 'js': return 'javascript';
+			case 'cjs': return 'javascript';
+			case 'mjs': return 'javascript';
+			case 'ts': return 'typescript';
+			case 'cts': return 'typescript';
+			case 'mts': return 'typescript';
+			case 'jsx': return 'javascriptreact';
+			case 'tsx': return 'typescriptreact';
+		}
+	},
+};

--- a/packages/typescript/lib/protocol/createProject.ts
+++ b/packages/typescript/lib/protocol/createProject.ts
@@ -3,6 +3,7 @@ import type * as ts from 'typescript';
 import { forEachEmbeddedCode } from '@volar/language-core';
 import * as path from 'path-browserify';
 import { createResolveModuleName } from '../resolveModuleName';
+import { fileLanguageIdProviderPlugin } from '../common';
 
 const scriptVersions = new Map<string, { lastVersion: number; map: WeakMap<ts.IScriptSnapshot, number>; }>();
 const fsFileSnapshots = new Map<string, [number | undefined, ts.IScriptSnapshot | undefined]>();
@@ -14,7 +15,10 @@ export function createTypeScriptLanguage(
 ): Language {
 
 	const language = createLanguage(
-		languagePlugins,
+		[
+			...languagePlugins,
+			fileLanguageIdProviderPlugin,
+		],
 		projectHost.useCaseSensitiveFileNames,
 		scriptId => {
 			const fileName = projectHost.scriptIdToFileName(scriptId);
@@ -39,7 +43,7 @@ export function createTypeScriptLanguage(
 			}
 
 			if (snapshot) {
-				language.scripts.set(scriptId, projectHost.getLanguageId(scriptId), snapshot);
+				language.scripts.set(scriptId, snapshot);
 			}
 			else {
 				language.scripts.delete(scriptId);


### PR DESCRIPTION
Endpoints is no longer required to provide `getLanguageId`, but require provided by the `LanguagePlugin`. Because `LanguagePlugin` has the complete context to calculate `languageId` of a file path. For Vue, it depends on `extensions`, `vitePressExtensions`, `petiteVueExtensions` options.