### PR TITLE
fix(language-server): pass correct languageId when creating virtual code

### DIFF
--- a/packages/language-server/lib/project/simpleProject.ts
+++ b/packages/language-server/lib/project/simpleProject.ts
@@ -21,7 +21,7 @@ export async function createSimpleServerProject(
 			const language = createLanguage(languagePlugins, false, uri => {
 				const document = server.documents.get(uri);
 				if (document) {
-					language.scripts.set(uri, document.getSnapshot(), document.uri);
+					language.scripts.set(uri, document.getSnapshot(), document.languageId);
 				}
 				else {
 					language.scripts.delete(uri);


### PR DESCRIPTION
When virtual code was created, the URI was passed as the language ID. Within MDX this means sometimes no virtual code was created at all, breaking semantic diagnostics and syntax toggles. The effects may be different for other implementations.