### PR TITLE
chore: specify packageManager in package.json

### DIFF
--- a/.github/workflows/auto-fix.yml
+++ b/.github/workflows/auto-fix.yml
@@ -12,8 +12,6 @@ jobs:
       - uses: actions/checkout@v4
 
       - uses: pnpm/action-setup@v2
-        with:
-          version: latest
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,8 +15,6 @@ jobs:
       - uses: actions/checkout@v2
 
       - uses: pnpm/action-setup@v2
-        with:
-          version: latest
 
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v1

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
 	"private": true,
+	"packageManager": "pnpm@9.1.0-0+sha256.c557b24d2298d9b5e3be7086ebf55a28253b008324d545f72645a6de89844102",
 	"scripts": {
 		"build": "tsc -b",
 		"watch": "tsc -b -w",


### PR DESCRIPTION
This makes corepack automatically pick the correct version of pnpm to use.

The pnpm GitHub action also supports this field.