### PR TITLE
fix(test-utils): use stdio transport for test server

### DIFF
--- a/packages/test-utils/index.ts
+++ b/packages/test-utils/index.ts
@@ -34,6 +34,13 @@ export function startLanguageServer(serverModule: string, cwd?: string | URL) {
 	connection.onClose(e => console.log(e));
 	connection.onUnhandledNotification(e => console.log(e));
 	connection.onError(e => console.log(e));
+	connection.onNotification(_.LogMessageNotification.type, e => {
+		if (e.type === _.MessageType.Error || e.type === _.MessageType.Warning) {
+			console.error(e.message);
+		} else {
+			console.log(e.message);
+		}
+	});
 	connection.onDispose(() => {
 		connection.end();
 	});


### PR DESCRIPTION
Using the IPC transport, breaks code coverage. This is related to https://github.com/bcoe/c8/issues/189.