### PR TITLE
feat(source-map): add API to support generated code with different length than original code

### DIFF
--- a/extensions/labs/src/common/showVirtualFile.ts
+++ b/extensions/labs/src/common/showVirtualFile.ts
@@ -234,7 +234,7 @@ export async function activate(extensions: vscode.Extension<LabsInfo>[]) {
 							map.mappings
 								.map(mapping => mapping.generatedOffsets.map((offset, i) => new vscode.Range(
 									getGeneratedPosition(virtualUri, offset),
-									getGeneratedPosition(virtualUri, offset + mapping.lengths[i]),
+									getGeneratedPosition(virtualUri, offset + (mapping.generatedLengths ?? mapping.lengths)[i]),
 								)))
 								.flat()
 						);
@@ -267,7 +267,7 @@ export async function activate(extensions: vscode.Extension<LabsInfo>[]) {
 									mappedStarts
 										.map(([_, mapping]) => mapping.generatedOffsets.map((offset, i) => new vscode.Range(
 											getGeneratedPosition(virtualUri, offset),
-											getGeneratedPosition(virtualUri, offset + mapping.lengths[i]),
+											getGeneratedPosition(virtualUri, offset + (mapping.generatedLengths ?? mapping.lengths)[i]),
 										)))
 										.flat()
 								);
@@ -305,7 +305,7 @@ export async function activate(extensions: vscode.Extension<LabsInfo>[]) {
 									mappedStarts
 										.map(([_, mapping]) => mapping.generatedOffsets.map((offset, i) => new vscode.Range(
 											getGeneratedPosition(virtualUri, offset),
-											getGeneratedPosition(virtualUri, offset + mapping.lengths[i]),
+											getGeneratedPosition(virtualUri, offset + (mapping.generatedLengths ?? mapping.lengths)[i]),
 										)))
 										.flat()
 								);

--- a/packages/language-service/lib/documents.ts
+++ b/packages/language-service/lib/documents.ts
@@ -114,14 +114,14 @@ export class SourceMapWithDocuments<Data = any> {
 	}
 
 	protected matchSourcePosition(position: vscode.Position, mapping: Mapping) {
-		let offset = translateOffset(this.embeddedDocument.offsetAt(position), mapping.generatedOffsets, mapping.sourceOffsets, mapping.lengths);
+		let offset = translateOffset(this.embeddedDocument.offsetAt(position), mapping.generatedOffsets, mapping.sourceOffsets, mapping.generatedLengths ?? mapping.lengths, mapping.lengths);
 		if (offset !== undefined) {
 			return this.sourceDocument.positionAt(offset);
 		}
 	}
 
 	protected matchGeneratedPosition(position: vscode.Position, mapping: Mapping) {
-		let offset = translateOffset(this.sourceDocument.offsetAt(position), mapping.sourceOffsets, mapping.generatedOffsets, mapping.lengths);
+		let offset = translateOffset(this.sourceDocument.offsetAt(position), mapping.sourceOffsets, mapping.generatedOffsets, mapping.lengths, mapping.generatedLengths ?? mapping.lengths);
 		if (offset !== undefined) {
 			return this.embeddedDocument.positionAt(offset);
 		}

--- a/packages/language-service/lib/features/provideDocumentFormattingEdits.ts
+++ b/packages/language-service/lib/features/provideDocumentFormattingEdits.ts
@@ -54,7 +54,7 @@ export function register(context: ServiceContext) {
 						embeddedRange.start = 0;
 					}
 					const lastMapping = map.mappings[map.mappings.length - 1];
-					if (embeddedRange.end === lastMapping.generatedOffsets[lastMapping.generatedOffsets.length - 1] + lastMapping.lengths[lastMapping.lengths.length - 1]) {
+					if (embeddedRange.end === lastMapping.generatedOffsets[lastMapping.generatedOffsets.length - 1] + (lastMapping.generatedLengths ?? lastMapping.lengths)[lastMapping.lengths.length - 1]) {
 						embeddedRange.end = code.snapshot.getLength();
 					}
 					embeddedRanges.set(code.id, embeddedRange);

--- a/packages/language-service/lib/utils/common.ts
+++ b/packages/language-service/lib/utils/common.ts
@@ -31,18 +31,16 @@ export function findOverlapCodeRange(
 				const mappingEnd = mapping.sourceOffsets[mapping.sourceOffsets.length - 1] + mapping.lengths[mapping.lengths.length - 1];
 				const overlap = getOverlapRange(start, end, mappingStart, mappingEnd);
 				if (overlap) {
-					if (mappedStart === undefined) {
-						mappedStart = overlap.start + mapping.generatedOffsets[0] - mappingStart;
-					}
-					else {
-						mappedStart = Math.min(mappedStart, overlap.start + mapping.generatedOffsets[0] - mappingStart);
-					}
-					if (mappedEnd === undefined) {
-						mappedEnd = overlap.end + mapping.generatedOffsets[0] - mappingStart;
-					}
-					else {
-						mappedEnd = Math.max(mappedEnd, overlap.end + mapping.generatedOffsets[0] - mappingStart);
-					}
+					const curMappedStart = (overlap.start - mappingStart) + mapping.generatedOffsets[0]
+
+					mappedStart = mappedStart === undefined ? curMappedStart : Math.min(mappedStart, curMappedStart);
+
+					const lastGeneratedLength = (mapping.generatedLengths ?? mapping.lengths)[mapping.generatedOffsets.length - 1];
+					const curMappedEndOffset = Math.min(overlap.end - mapping.sourceOffsets[mapping.sourceOffsets.length - 1], lastGeneratedLength)
+
+					const curMappedEnd = mapping.generatedOffsets[mapping.generatedOffsets.length - 1] + curMappedEndOffset
+
+					mappedEnd = mappedEnd === undefined ? curMappedEnd : Math.max(mappedEnd, curMappedEnd);
 				}
 			}
 		}

--- a/packages/language-service/tests/findOverlapCodeRange.spec.ts
+++ b/packages/language-service/tests/findOverlapCodeRange.spec.ts
@@ -53,6 +53,24 @@ describe(`Test findOverlapCodeRange()`, () => {
 		expect(findOverlapCodeRange(5, 30, map, () => true)).toEqual({ start: 7, end: 31 });
 	});
 
+	it('fallback to valid range (offset) - shorter generated range', () => {
+		const mappings: Mapping<CodeInformation>[] = [
+			{
+				sourceOffsets: [6],
+				generatedOffsets: [7],
+				lengths: [25],
+				generatedLengths: [23],
+				data: { verification: true, completion: true, semantic: true, navigation: true, structure: true, format: true },
+			},
+		];
+		const map = new SourceMap(mappings);
+
+		expect(findOverlapCodeRange(5, 32, map, () => true)).toEqual({ start: 7, end: 30 });
+		expect(findOverlapCodeRange(7, 32, map, () => true)).toEqual({ start: 8, end: 30 });
+		expect(findOverlapCodeRange(5, 30, map, () => true)).toEqual({ start: 7, end: 30 });
+		expect(findOverlapCodeRange(5, 26, map, () => true)).toEqual({ start: 7, end: 27 });
+	});
+
 	it('mutilple mappings', () => {
 		const mappings: Mapping<CodeInformation>[] = [
 			{
@@ -63,13 +81,13 @@ describe(`Test findOverlapCodeRange()`, () => {
 			},
 			{
 				sourceOffsets: [24],
-				generatedOffsets: [24],
+				generatedOffsets: [26],
 				lengths: [7],
 				data: { verification: true, completion: true, semantic: true, navigation: true, structure: true, format: true },
 			},
 		];
 		const map = new SourceMap(mappings);
 
-		expect(findOverlapCodeRange(0, 38, map, () => true)).toEqual({ start: 6, end: 31 });
+		expect(findOverlapCodeRange(0, 38, map, () => true)).toEqual({ start: 6, end: 33 });
 	});
 });

--- a/packages/source-map/lib/translateOffset.ts
+++ b/packages/source-map/lib/translateOffset.ts
@@ -1,10 +1,12 @@
-export function translateOffset(start: number, fromOffsets: number[], toOffsets: number[], lengths: number[]): number | undefined {
+export function translateOffset(start: number, fromOffsets: number[], toOffsets: number[], fromLengths: number[], toLengths: number[] = fromLengths): number | undefined {
 	for (let i = 0; i < fromOffsets.length; i++) {
 		const fromOffset = fromOffsets[i];
-		const toOffset = toOffsets[i];
-		const length = lengths[i];
-		if (start >= fromOffset && start <= fromOffset + length) {
-			return toOffset + start - fromOffset;
+		const fromLength = fromLengths[i];
+		if (start >= fromOffset && start <= fromOffset + fromLength) {
+			const toLength = toLengths[i];
+			const toOffset = toOffsets[i];
+			let rangeOffset = Math.min(start - fromOffset, toLength)
+			return toOffset + rangeOffset;
 		}
 	}
 }

--- a/packages/source-map/tests/translateOffset.spec.ts
+++ b/packages/source-map/tests/translateOffset.spec.ts
@@ -21,4 +21,7 @@ describe('translateOffset', () => {
 	test('start at end of fromRange', () => {
 		expect(translateOffset(10, [1], [11], [9])).toEqual(20);
 	});
+	test('start at the end of fromRange with shorter toLength', () => {
+		expect(translateOffset(10, [1], [11], [9], [7])).toEqual(18);
+	})
 });

--- a/packages/typescript/lib/node/decorateLanguageService.ts
+++ b/packages/typescript/lib/node/decorateLanguageService.ts
@@ -496,9 +496,9 @@ export function decorateLanguageService(
 				// TODO reuse the logic from language service
 				if (isSemanticTokensEnabled(mapping.data) && mapping.sourceOffsets[0] >= span.start && mapping.sourceOffsets[0] <= span.start + span.length) {
 					start ??= mapping.generatedOffsets[0];
-					end ??= mapping.generatedOffsets[mapping.generatedOffsets.length - 1] + mapping.lengths[mapping.lengths.length - 1];
+					end ??= mapping.generatedOffsets[mapping.generatedOffsets.length - 1] + (mapping.generatedLengths ?? mapping.lengths)[mapping.lengths.length - 1];
 					start = Math.min(start, mapping.generatedOffsets[0]);
-					end = Math.max(end, mapping.generatedOffsets[mapping.generatedOffsets.length - 1] + mapping.lengths[mapping.lengths.length - 1]);
+					end = Math.max(end, mapping.generatedOffsets[mapping.generatedOffsets.length - 1] + (mapping.generatedLengths ?? mapping.lengths)[mapping.lengths.length - 1]);
 				}
 			}
 			start ??= 0;


### PR DESCRIPTION
I am working on support for type checking of Angular templates in WebStorm using Volar in plug-in mode. In the Angular template transpilation logic some variables in expressions are renamed in the output, so the generated range length does not always match the source range length. This PR adds support for an optional `generatedLength` property on `Mapping` interface and adds support for it across the codebase.

There is also a fix for `findOverlapCodeRange` present. `mappedEnd` was incorrectly calculated.