### PR TITLE
refactor: remove "Codegen Stacks" debug feature

### DIFF
--- a/extensions/labs/src/common/showVirtualFile.ts
+++ b/extensions/labs/src/common/showVirtualFile.ts
@@ -1,5 +1,5 @@
 import type { CodeInformation } from '@volar/language-server';
-import { SourceMap, Stack } from '@volar/source-map';
+import { SourceMap } from '@volar/source-map';
 import { LabsInfo, TextDocument } from '@volar/vscode';
 import * as vscode from 'vscode';
 import { VOLAR_VIRTUAL_CODE_SCHEME } from '../views/virtualFilesView';
@@ -29,7 +29,6 @@ export async function activate(extensions: vscode.Extension<LabsInfo>[]) {
 	const subscriptions: vscode.Disposable[] = [];
 	const docChangeEvent = new vscode.EventEmitter<vscode.Uri>();
 	const virtualUriToSourceMap = new Map<string, [string, number, SourceMap<CodeInformation>][]>();
-	const virtualUriToStacks = new Map<string, Stack[]>();
 	const virtualDocuments = new Map<string, TextDocument>();
 
 	let updateVirtualDocument: ReturnType<typeof setTimeout> | undefined;
@@ -87,61 +86,6 @@ export async function activate(extensions: vscode.Extension<LabsInfo>[]) {
 				].join('\n')));
 			}
 		}),
-		vscode.languages.registerDefinitionProvider({ scheme: VOLAR_VIRTUAL_CODE_SCHEME.toLowerCase() }, {
-			async provideDefinition(document: vscode.TextDocument, position: vscode.Position, _token: vscode.CancellationToken) {
-
-				const stacks = virtualUriToStacks.get(document.uri.toString());
-				if (!stacks) {
-					return;
-				}
-
-				const offset = document.offsetAt(position);
-				const stack = stacks.find(stack => stack.range[0] <= offset && offset <= stack.range[1]);
-				if (!stack) {
-					return;
-				}
-
-				const line = Number(stack.source.split(':').at(-2));
-				const character = Number(stack.source.split(':').at(-1));
-				const fileName = stack.source.split(':').slice(0, -2).join(':');
-				const link: vscode.DefinitionLink = {
-					originSelectionRange: new vscode.Range(document.positionAt(stack.range[0]), document.positionAt(stack.range[1])),
-					targetUri: vscode.Uri.file(fileName),
-					targetRange: new vscode.Range(line - 1, character - 1, line - 1, character - 1),
-				};
-				return [link];
-			}
-		}),
-		vscode.languages.registerInlayHintsProvider({ scheme: VOLAR_VIRTUAL_CODE_SCHEME.toLowerCase() }, {
-			provideInlayHints(document, range) {
-				const stacks = virtualUriToStacks.get(document.uri.toString());
-				const result: vscode.InlayHint[] = [];
-				const range2 = [document.offsetAt(range.start), document.offsetAt(range.end)];
-				const text = document.getText();
-				for (const stack of stacks ?? []) {
-					let [start, end] = stack.range;
-					let startText = '[';
-					let endText = ']';
-					while (end > start && text[end - 1] === '\n') {
-						end--;
-						endText = '\n' + endText;
-					}
-					while (start < end && text[start] === '\n') {
-						start++;
-						startText = '\n' + startText;
-					}
-					if (start >= range2[0] && start <= range2[1]) {
-						result.push(new vscode.InlayHint(document.positionAt(start), startText));
-						result[result.length - 1].paddingLeft = true;
-					}
-					if (end >= range2[0] && end <= range2[1]) {
-						result.push(new vscode.InlayHint(document.positionAt(end), endText));
-						result[result.length - 1].paddingRight = true;
-					}
-				}
-				return result;
-			},
-		}),
 		vscode.workspace.registerTextDocumentContentProvider(
 			VOLAR_VIRTUAL_CODE_SCHEME,
 			{
@@ -188,7 +132,6 @@ export async function activate(extensions: vscode.Extension<LabsInfo>[]) {
 						}
 					});
 					virtualDocuments.set(uri.toString(), TextDocument.create('', '', 0, virtualCode.content));
-					virtualUriToStacks.set(uri.toString(), virtualCode.codegenStacks);
 
 					clearTimeout(updateDecorationsTimeout);
 					updateDecorationsTimeout = setTimeout(updateDecorations, 100);

--- a/extensions/labs/src/views/serversView.ts
+++ b/extensions/labs/src/views/serversView.ts
@@ -18,7 +18,7 @@ interface InvalidLanguageClientItem {
 }
 
 interface LanguageClientFieldItem extends LanguageClientItem {
-	field: 'start' | 'stop' | 'restart' | 'enableCodegenStack' | 'disableCodegenStack' | 'initializationOptions' | 'initializeResult' | 'memory';
+	field: 'start' | 'stop' | 'restart' | 'initializationOptions' | 'initializeResult' | 'memory';
 }
 
 export function activate(context: vscode.ExtensionContext) {
@@ -55,15 +55,6 @@ export function activate(context: vscode.ExtensionContext) {
 				if (element.client.state === lsp.State.Running) {
 					stats.push({ ...element, field: 'stop' });
 					stats.push({ ...element, field: 'restart' });
-					if (element.extension.exports.volarLabs.codegenStackSupport) {
-						element.client.clientOptions.initializationOptions ??= {};
-						if (element.client.clientOptions.initializationOptions.codegenStack) {
-							stats.push({ ...element, field: 'disableCodegenStack' });
-						}
-						else {
-							stats.push({ ...element, field: 'enableCodegenStack' });
-						}
-					}
 					stats.push({ ...element, field: 'initializationOptions' });
 					stats.push({ ...element, field: 'initializeResult' });
 					stats.push({ ...element, field: 'memory' });
@@ -122,30 +113,6 @@ export function activate(context: vscode.ExtensionContext) {
 						collapsibleState: vscode.TreeItemCollapsibleState.None,
 						command: {
 							command: '_volar.action.tsMemoryTreemap',
-							title: '',
-							arguments: [element.client],
-						},
-					};
-				}
-				else if (element.field === 'enableCodegenStack') {
-					return {
-						iconPath: new vscode.ThemeIcon('primitive-dot'),
-						label: 'Enable Codegen Stack',
-						collapsibleState: vscode.TreeItemCollapsibleState.None,
-						command: {
-							command: '_volar.action.enableCodegenStack',
-							title: '',
-							arguments: [element.client],
-						},
-					};
-				}
-				else if (element.field === 'disableCodegenStack') {
-					return {
-						iconPath: new vscode.ThemeIcon('debug-breakpoint'),
-						label: 'Disable Codegen Stack',
-						collapsibleState: vscode.TreeItemCollapsibleState.None,
-						command: {
-							command: '_volar.action.disableCodegenStack',
 							title: '',
 							arguments: [element.client],
 						},
@@ -274,16 +241,6 @@ export function activate(context: vscode.ExtensionContext) {
 
 				progress.report({ increment: 100 });
 			});
-		}),
-		vscode.commands.registerCommand('_volar.action.enableCodegenStack', async (client: lsp.BaseLanguageClient) => {
-			client.clientOptions.initializationOptions.codegenStack = true;
-			await client.stop();
-			await client.start();
-		}),
-		vscode.commands.registerCommand('_volar.action.disableCodegenStack', async (client: lsp.BaseLanguageClient) => {
-			client.clientOptions.initializationOptions.codegenStack = false;
-			await client.stop();
-			await client.start();
 		}),
 		vscode.commands.registerCommand('volar.action.serverStat.initializationOptions', async (client: lsp.BaseLanguageClient) => {
 			const doc = await vscode.workspace.openTextDocument({ content: JSON.stringify(client.clientOptions.initializationOptions, undefined, '\t'), language: 'json' });

--- a/extensions/labs/src/views/virtualFilesView.ts
+++ b/extensions/labs/src/views/virtualFilesView.ts
@@ -104,7 +104,7 @@ export async function activate(context: vscode.ExtensionContext) {
 			}
 			return {
 				checkboxState: element.generated.disabled ? vscode.TreeItemCheckboxState.Unchecked : vscode.TreeItemCheckboxState.Checked,
-				iconPath: element.client.clientOptions.initializationOptions.codegenStack ? new vscode.ThemeIcon('debug-breakpoint') : new vscode.ThemeIcon('file'),
+				iconPath: new vscode.ThemeIcon('file'),
 				label: element.generated.virtualCodeId,
 				description,
 				collapsibleState: element.generated.embeddedCodes.length ? vscode.TreeItemCollapsibleState.Expanded : vscode.TreeItemCollapsibleState.None,

--- a/packages/language-core/lib/types.ts
+++ b/packages/language-core/lib/types.ts
@@ -1,4 +1,4 @@
-import type { Mapping, SourceMap, Stack } from '@volar/source-map';
+import type { Mapping, SourceMap } from '@volar/source-map';
 import type * as ts from 'typescript';
 import type { LinkedCodeMap } from './linkedCodeMap';
 
@@ -44,7 +44,6 @@ export interface VirtualCode {
 	snapshot: ts.IScriptSnapshot;
 	mappings: CodeMapping[];
 	embeddedCodes?: VirtualCode[];
-	codegenStacks?: Stack[];
 	linkedCodeMappings?: Mapping[];
 }
 

--- a/packages/language-server/lib/register/registerEditorFeatures.ts
+++ b/packages/language-server/lib/register/registerEditorFeatures.ts
@@ -97,7 +97,6 @@ export function registerEditorFeatures(server: ServerBase) {
 			}
 			return {
 				content: virtualCode.snapshot.getText(0, virtualCode.snapshot.getLength()),
-				codegenStacks: virtualCode.codegenStacks ?? [],
 				mappings,
 			};
 		}

--- a/packages/language-server/lib/types.ts
+++ b/packages/language-server/lib/types.ts
@@ -5,7 +5,6 @@ import type { createServerBase } from './server';
 
 export interface InitializationOptions {
 	maxFileSize?: number;
-	codegenStack?: boolean;
 }
 
 export type VolarInitializeParams = Omit<vscode.InitializeParams, 'initializationOptions'> & { initializationOptions?: InitializationOptions; };;

--- a/packages/language-server/protocol.ts
+++ b/packages/language-server/protocol.ts
@@ -1,4 +1,4 @@
-import type { CodeMapping, Stack } from '@volar/language-core';
+import type { CodeMapping } from '@volar/language-core';
 import type { FileStat, FileType, DocumentDropEdit } from '@volar/language-service';
 import * as vscode from 'vscode-languageserver-protocol';
 
@@ -156,7 +156,6 @@ export namespace GetVirtualCodeRequest {
 	export type ResponseType = {
 		content: string;
 		mappings: Record<string, CodeMapping[]>;
-		codegenStacks: Stack[];
 	};
 	export type ErrorType = never;
 	export const type = new vscode.RequestType<ParamsType, ResponseType, ErrorType>('volar/client/virtualFile');

--- a/packages/vscode/index.ts
+++ b/packages/vscode/index.ts
@@ -106,6 +106,5 @@ export interface LabsInfo {
 		languageClients: BaseLanguageClient[];
 		onDidAddLanguageClient: vscode.Event<BaseLanguageClient>;
 		languageServerProtocol: typeof import('@volar/language-server/protocol');
-		codegenStackSupport?: boolean;
 	};
 }


### PR DESCRIPTION
Vue language tools used to be the only extension that integrated Codegen Stacks. Since the latest version of Vue language tools has removed the debug feature, this feature is no longer used by any framework, so we can remove it.