### PR TITLE
feat(language-core): add option to resolve hidden extensions

### DIFF
--- a/packages/language-core/lib/types.ts
+++ b/packages/language-core/lib/types.ts
@@ -100,6 +100,10 @@ export interface LanguagePlugin<T, K extends VirtualCode = VirtualCode> {
 		/**
 		 * LSP + TS Plugin
 		 */
+		resolveHiddenExtensions?: boolean;
+		/**
+		 * LSP + TS Plugin
+		 */
 		getServiceScript(rootVirtualCode: K): TypeScriptServiceScript | undefined;
 		/**
 		 * LSP only

--- a/packages/typescript/lib/resolveModuleName.ts
+++ b/packages/typescript/lib/resolveModuleName.ts
@@ -52,6 +52,24 @@ export function createResolveModuleName<T>(
 						}
 					}
 				}
+				if (typescript.resolveHiddenExtensions && fileName.endsWith(`.d.ts`)) {
+					for (const { extension } of typescript.extraFileExtensions) {
+						const sourceFileName = fileName.slice(0, -`.d.ts`.length) + `.${extension}`;
+						if (fileExists(sourceFileName)) {
+							const sourceScript = getSourceScript(sourceFileName);
+							if (sourceScript?.generated) {
+								const serviceScript = sourceScript.generated.languagePlugin.typescript?.getServiceScript(sourceScript.generated.root);
+								if (serviceScript) {
+									toSourceFileInfo.set(fileName, {
+										sourceFileName,
+										extension: serviceScript.extension,
+									});
+									return true;
+								}
+							}
+						}
+					}
+				}
 			}
 			return host.fileExists(fileName);
 		},


### PR DESCRIPTION
Add `resolveHiddenExtensions` option to `LanguagePlugin#typescript`. When enabled, `resolveModeName` will attempt to add extra extensions to resolve's module name.