### PR TITLE
feat(language-core): reimplement multi-source mapping

### DIFF
--- a/packages/eslint/index.ts
+++ b/packages/eslint/index.ts
@@ -31,7 +31,7 @@ export function createProcessor(
 	const documents = new FileMap<{
 		sourceDocument: TextDocument;
 		embeddedDocuments: TextDocument[];
-		codes: VirtualCode[];
+		codes: VirtualCode<string>[];
 	}>(caseSensitive);
 	return {
 		supportsAutofix,

--- a/packages/language-core/index.ts
+++ b/packages/language-core/index.ts
@@ -142,8 +142,8 @@ export function createLanguage<T>(
 				}
 				yield [sourceScript.id, sourceScript.snapshot, mapCache.get(sourceScript.snapshot)!];
 
-				if (virtualCode.relatedMappings) {
-					for (const [relatedScriptId, relatedMappings] of virtualCode.relatedMappings) {
+				if (virtualCode.associatedScriptMappings) {
+					for (const [relatedScriptId, relatedMappings] of virtualCode.associatedScriptMappings) {
 						const relatedSourceScript = scriptRegistry.get(relatedScriptId);
 						if (relatedSourceScript) {
 							if (!mapCache.has(relatedSourceScript.snapshot)) {
@@ -194,7 +194,7 @@ export function createLanguage<T>(
 		sourceScript.relateds.clear();
 		sourceScript.isRelatedDirty = false;
 		return {
-			getRelatedSourceScript(id) {
+			getAssociatedScript(id) {
 				sync(id);
 				const relatedSourceScript = scriptRegistry.get(id);
 				if (relatedSourceScript) {

--- a/packages/language-core/index.ts
+++ b/packages/language-core/index.ts
@@ -48,7 +48,7 @@ export function createLanguage<T>(
 						this.delete(id);
 						return this.set(id, snapshot, languageId);
 					}
-					else if (sourceScript.isRelatedDirty || sourceScript.snapshot !== snapshot) {
+					else if (sourceScript.isAssociationDirty || sourceScript.snapshot !== snapshot) {
 						// snapshot updated
 						sourceScript.snapshot = snapshot;
 						const codegenCtx = prepareCreateVirtualCode(sourceScript);
@@ -84,8 +84,8 @@ export function createLanguage<T>(
 						id: id,
 						languageId,
 						snapshot,
-						relateds: new Set(),
-						targets: new Set(),
+						associatedIds: new Set(),
+						targetIds: new Set(),
 					};
 					scriptRegistry.set(id, sourceScript);
 
@@ -179,27 +179,27 @@ export function createLanguage<T>(
 	};
 
 	function triggerTargetsDirty(sourceScript: SourceScript<T>) {
-		sourceScript.targets.forEach(id => {
+		sourceScript.targetIds.forEach(id => {
 			const sourceScript = scriptRegistry.get(id);
 			if (sourceScript) {
-				sourceScript.isRelatedDirty = true;
+				sourceScript.isAssociationDirty = true;
 			}
 		});
 	}
 
 	function prepareCreateVirtualCode(sourceScript: SourceScript<T>): CodegenContext<T> {
-		for (const id of sourceScript.relateds) {
-			scriptRegistry.get(id)?.targets.delete(sourceScript.id);
+		for (const id of sourceScript.associatedIds) {
+			scriptRegistry.get(id)?.targetIds.delete(sourceScript.id);
 		}
-		sourceScript.relateds.clear();
-		sourceScript.isRelatedDirty = false;
+		sourceScript.associatedIds.clear();
+		sourceScript.isAssociationDirty = false;
 		return {
 			getAssociatedScript(id) {
 				sync(id);
 				const relatedSourceScript = scriptRegistry.get(id);
 				if (relatedSourceScript) {
-					relatedSourceScript.targets.add(sourceScript.id);
-					sourceScript.relateds.add(relatedSourceScript.id);
+					relatedSourceScript.targetIds.add(sourceScript.id);
+					sourceScript.associatedIds.add(relatedSourceScript.id);
 				}
 				return relatedSourceScript;
 			},

--- a/packages/language-core/lib/linkedCodeMap.ts
+++ b/packages/language-core/lib/linkedCodeMap.ts
@@ -1,6 +1,6 @@
 import { SourceMap } from '@volar/source-map';
 
-export class LinkedCodeMap extends SourceMap {
+export class LinkedCodeMap extends SourceMap<any> {
 	*getLinkedOffsets(start: number) {
 		for (const mapped of this.getGeneratedOffsets(start)) {
 			yield mapped[0];

--- a/packages/language-core/lib/types.ts
+++ b/packages/language-core/lib/types.ts
@@ -2,7 +2,7 @@ import type { Mapping, SourceMap } from '@volar/source-map';
 import type * as ts from 'typescript';
 import type { LinkedCodeMap } from './linkedCodeMap';
 
-export interface Language<T> {
+export interface Language<T = unknown> {
 	plugins: LanguagePlugin<T>[];
 	scripts: {
 		get(id: T): SourceScript<T> | undefined;
@@ -30,7 +30,7 @@ export interface Language<T> {
 	};
 }
 
-export interface SourceScript<T> {
+export interface SourceScript<T = unknown> {
 	id: T;
 	languageId: string;
 	snapshot: ts.IScriptSnapshot;
@@ -90,11 +90,11 @@ export interface TypeScriptServiceScript<T = unknown> {
 	preventLeadingOffset?: boolean;
 }
 
-export interface TypeScriptExtraServiceScript<T> extends TypeScriptServiceScript<T> {
+export interface TypeScriptExtraServiceScript<T = unknown> extends TypeScriptServiceScript<T> {
 	fileName: string;
 }
 
-export interface LanguagePlugin<T, K extends VirtualCode<T> = VirtualCode<T>> {
+export interface LanguagePlugin<T = unknown, K extends VirtualCode<T> = VirtualCode<T>> {
 	/**
 	 * For files that are not opened in the IDE, the language ID will not be synchronized to the language server, so a hook is needed to parse the language ID of files that are known extension but not opened in the IDE.
 	 */
@@ -114,7 +114,7 @@ export interface LanguagePlugin<T, K extends VirtualCode<T> = VirtualCode<T>> {
 	typescript?: TypeScriptGenericOptions<T, K> & TypeScriptNonTSPluginOptions<T, K>;
 }
 
-export interface CodegenContext<T> {
+export interface CodegenContext<T = unknown> {
 	getAssociatedScript(scriptId: T): SourceScript<T> | undefined;
 }
 

--- a/packages/language-core/lib/types.ts
+++ b/packages/language-core/lib/types.ts
@@ -51,7 +51,7 @@ export interface VirtualCode<T = unknown> {
 	languageId: string;
 	snapshot: ts.IScriptSnapshot;
 	mappings: CodeMapping[];
-	relatedMappings?: Map<T, CodeMapping[]>;
+	associatedScriptMappings?: Map<T, CodeMapping[]>;
 	embeddedCodes?: VirtualCode<T>[];
 	linkedCodeMappings?: Mapping[];
 }
@@ -115,7 +115,7 @@ export interface LanguagePlugin<T, K extends VirtualCode<T> = VirtualCode<T>> {
 }
 
 export interface CodegenContext<T> {
-	getRelatedSourceScript(scriptId: T): SourceScript<T> | undefined;
+	getAssociatedScript(scriptId: T): SourceScript<T> | undefined;
 }
 
 /**

--- a/packages/language-core/lib/types.ts
+++ b/packages/language-core/lib/types.ts
@@ -34,9 +34,9 @@ export interface SourceScript<T> {
 	id: T;
 	languageId: string;
 	snapshot: ts.IScriptSnapshot;
-	relateds: Set<T>;
-	targets: Set<T>;
-	isRelatedDirty?: boolean;
+	targetIds: Set<T>;
+	associatedIds: Set<T>;
+	isAssociationDirty?: boolean;
 	generated?: {
 		root: VirtualCode<T>;
 		languagePlugin: LanguagePlugin<T>;

--- a/packages/language-server/lib/register/registerEditorFeatures.ts
+++ b/packages/language-server/lib/register/registerEditorFeatures.ts
@@ -92,8 +92,9 @@ export function registerEditorFeatures(server: LanguageServer) {
 		const virtualCode = sourceScript?.generated?.embeddedCodes.get(params.virtualCodeId);
 		if (virtualCode) {
 			const mappings: Record<string, CodeMapping[]> = {};
-			const map = languageService.context.documents.getSourceMap(virtualCode);
-			mappings[map.sourceDocument.uri] = map.map.mappings;
+			for (const map of languageService.context.documents.getMaps(virtualCode)) {
+				mappings[map.sourceDocument.uri] = map.map.mappings;
+			}
 			return {
 				content: virtualCode.snapshot.getText(0, virtualCode.snapshot.getLength()),
 				mappings,

--- a/packages/language-server/protocol.ts
+++ b/packages/language-server/protocol.ts
@@ -155,7 +155,6 @@ export namespace GetVirtualCodeRequest {
 	};
 	export type ResponseType = {
 		content: string;
-		// TODO: Simplify this, no map required
 		mappings: Record<string, CodeMapping[]>;
 	};
 	export type ErrorType = never;

--- a/packages/language-service/lib/features/provideCallHierarchyItems.ts
+++ b/packages/language-service/lib/features/provideCallHierarchyItems.ts
@@ -186,19 +186,22 @@ export function register(context: LanguageServiceContext) {
 			return [tsItem, tsRanges];
 		}
 
-		const map = context.documents.getSourceMap(virtualCode);
+		for (const map of context.documents.getMaps(virtualCode)) {
 
-		let range = map.getSourceRange(tsItem.range);
-		if (!range) {
-			// TODO: <script> range
-			range = {
-				start: map.sourceDocument.positionAt(0),
-				end: map.sourceDocument.positionAt(map.sourceDocument.getText().length),
-			};
-		}
+			let range = map.getSourceRange(tsItem.range);
+			if (!range) {
+				// TODO: <script> range
+				range = {
+					start: map.sourceDocument.positionAt(0),
+					end: map.sourceDocument.positionAt(map.sourceDocument.getText().length),
+				};
+			}
 
-		const selectionRange = map.getSourceRange(tsItem.selectionRange);
-		if (selectionRange) {
+			const selectionRange = map.getSourceRange(tsItem.selectionRange);
+			if (!selectionRange) {
+				continue;
+			}
+
 			const vueRanges = tsRanges.map(tsRange => map.getSourceRange(tsRange)).filter(notEmpty);
 			const vueItem: vscode.CallHierarchyItem = {
 				...tsItem,

--- a/packages/language-service/lib/features/provideDiagnostics.ts
+++ b/packages/language-service/lib/features/provideDiagnostics.ts
@@ -303,16 +303,17 @@ export function register(context: LanguageServiceContext) {
 					const virtualCode = decoded && sourceScript?.generated?.embeddedCodes.get(decoded[1]);
 
 					if (virtualCode) {
-						const map = context.documents.getSourceMap(virtualCode);
-						const range = map.getSourceRange(info.location.range, filter);
-						if (range) {
-							relatedInfos.push({
-								location: {
-									uri: map.sourceDocument.uri,
-									range,
-								},
-								message: info.message,
-							});
+						for (const map of context.documents.getMaps(virtualCode)) {
+							const range = map.getSourceRange(info.location.range, filter);
+							if (range) {
+								relatedInfos.push({
+									location: {
+										uri: map.sourceDocument.uri,
+										range,
+									},
+									message: info.message,
+								});
+							}
 						}
 					}
 					else {

--- a/packages/language-service/lib/features/provideDocumentFormattingEdits.ts
+++ b/packages/language-service/lib/features/provideDocumentFormattingEdits.ts
@@ -1,4 +1,4 @@
-import { CodeInformation, SourceMap, SourceScript, VirtualCode, forEachEmbeddedCode, isFormattingEnabled, updateVirtualCodeMapOfMap } from '@volar/language-core';
+import { SourceMap, SourceScript, VirtualCode, forEachEmbeddedCode, isFormattingEnabled } from '@volar/language-core';
 import type * as ts from 'typescript';
 import type * as vscode from 'vscode-languageserver-protocol';
 import { TextDocument } from 'vscode-languageserver-textdocument';
@@ -8,7 +8,6 @@ import type { EmbeddedCodeFormattingOptions, LanguageServiceContext } from '../t
 import { NoneCancellationToken } from '../utils/cancellation';
 import { findOverlapCodeRange, stringToSnapshot } from '../utils/common';
 import { getEmbeddedFilesByLevel as getEmbeddedCodesByLevel } from '../utils/featureWorkers';
-import { createUriMap } from '../utils/uriMap';
 
 export function register(context: LanguageServiceContext) {
 
@@ -253,32 +252,24 @@ export function register(context: LanguageServiceContext) {
 	};
 
 	function createDocMap(virtualCode: VirtualCode, documentUri: URI, sourceLanguageId: string, _sourceSnapshot: ts.IScriptSnapshot) {
-		const mapOfMap = createUriMap<[ts.IScriptSnapshot, SourceMap<CodeInformation>]>();
-		updateVirtualCodeMapOfMap(virtualCode, mapOfMap, sourceFileUri2 => {
-			if (!sourceFileUri2) {
-				return [documentUri, _sourceSnapshot];
-			}
-		});
-		if (mapOfMap.has(documentUri) && mapOfMap.get(documentUri)![0] === _sourceSnapshot) {
-			const map = mapOfMap.get(documentUri)!;
-			const version = fakeVersion++;
-			return new SourceMapWithDocuments(
-				TextDocument.create(
-					documentUri.toString(),
-					sourceLanguageId,
-					version,
-					_sourceSnapshot.getText(0, _sourceSnapshot.getLength())
-				),
-				TextDocument.create(
-					context.encodeEmbeddedDocumentUri(documentUri, virtualCode.id).toString(),
-					virtualCode.languageId,
-					version,
-					virtualCode.snapshot.getText(0, virtualCode.snapshot.getLength())
-				),
-				map[1],
-				virtualCode,
-			);
-		}
+		const map = new SourceMap(virtualCode.mappings);
+		const version = fakeVersion++;
+		return new SourceMapWithDocuments(
+			TextDocument.create(
+				documentUri.toString(),
+				sourceLanguageId,
+				version,
+				_sourceSnapshot.getText(0, _sourceSnapshot.getLength())
+			),
+			TextDocument.create(
+				context.encodeEmbeddedDocumentUri(documentUri, virtualCode.id).toString(),
+				virtualCode.languageId,
+				version,
+				virtualCode.snapshot.getText(0, virtualCode.snapshot.getLength())
+			),
+			map,
+			virtualCode,
+		);
 	}
 }
 

--- a/packages/language-service/lib/features/provideFileReferences.ts
+++ b/packages/language-service/lib/features/provideFileReferences.ts
@@ -32,12 +32,13 @@ export function register(context: LanguageServiceContext) {
 						return reference;
 					}
 
-					const map = context.documents.getSourceMap(virtualCode);
-					const range = map.getSourceRange(reference.range, isReferencesEnabled);
-					if (range) {
-						reference.uri = map.sourceDocument.uri;
-						reference.range = range;
-						return reference;
+					for (const map of context.documents.getMaps(virtualCode)) {
+						const range = map.getSourceRange(reference.range, isReferencesEnabled);
+						if (range) {
+							reference.uri = map.sourceDocument.uri;
+							reference.range = range;
+							return reference;
+						}
 					}
 				})
 				.filter(notEmpty),

--- a/packages/language-service/lib/features/provideReferences.ts
+++ b/packages/language-service/lib/features/provideReferences.ts
@@ -87,13 +87,14 @@ export function register(context: LanguageServiceContext) {
 					const virtualCode = decoded && sourceScript?.generated?.embeddedCodes.get(decoded[1]);
 
 					if (virtualCode) {
-						const map = context.documents.getSourceMap(virtualCode);
-						const range = map.getSourceRange(reference.range, isReferencesEnabled);
-						if (range) {
-							results.push({
-								uri: map.sourceDocument.uri,
-								range,
-							});
+						for (const map of context.documents.getMaps(virtualCode)) {
+							const range = map.getSourceRange(reference.range, isReferencesEnabled);
+							if (range) {
+								results.push({
+									uri: map.sourceDocument.uri,
+									range,
+								});
+							}
 						}
 					}
 					else {

--- a/packages/language-service/lib/features/provideWorkspaceSymbols.ts
+++ b/packages/language-service/lib/features/provideWorkspaceSymbols.ts
@@ -32,10 +32,11 @@ export function register(context: LanguageServiceContext) {
 				const virtualCode = decoded && sourceScript?.generated?.embeddedCodes.get(decoded[1]);
 
 				if (virtualCode) {
-					const map = context.documents.getSourceMap(virtualCode);
-					const range = map.getSourceRange(loc.range);
-					if (range) {
-						return { uri: map.sourceDocument.uri, range };
+					for (const map of context.documents.getMaps(virtualCode)) {
+						const range = map.getSourceRange(loc.range);
+						if (range) {
+							return { uri: map.sourceDocument.uri, range };
+						}
 					}
 				}
 				else {

--- a/packages/language-service/lib/features/resolveCompletionItem.ts
+++ b/packages/language-service/lib/features/resolveCompletionItem.ts
@@ -28,14 +28,17 @@ export function register(context: LanguageServiceContext) {
 				const virtualCode = decoded && sourceScript?.generated?.embeddedCodes.get(decoded[1]);
 
 				if (virtualCode) {
-					const map = context.documents.getSourceMap(virtualCode);
-					item = await plugin[1].resolveCompletionItem(item, token);
-					item = plugin[1].transformCompletionItem?.(item) ?? transformCompletionItem(
-						item,
-						embeddedRange => map.getSourceRange(embeddedRange),
-						map.embeddedDocument,
-						context
-					);
+
+					for (const map of context.documents.getMaps(virtualCode)) {
+
+						item = await plugin[1].resolveCompletionItem(item, token);
+						item = plugin[1].transformCompletionItem?.(item) ?? transformCompletionItem(
+							item,
+							embeddedRange => map.getSourceRange(embeddedRange),
+							map.embeddedDocument,
+							context
+						);
+					}
 				}
 			}
 			else {

--- a/packages/language-service/lib/languageService.ts
+++ b/packages/language-service/lib/languageService.ts
@@ -72,23 +72,19 @@ export function createLanguageService(
 				}
 				return map.get(uri)!;
 			},
-			getSourceMap(virtualCode) {
-				const map = context.language.maps.get(virtualCode);
-				let result = map2DocMap.get(map);
-				if (!result) {
-					const sourceScript = context.language.scripts.fromVirtualCode(virtualCode);
-					const embeddedUri = context.encodeEmbeddedDocumentUri(sourceScript.id, virtualCode.id);
-					map2DocMap.set(
-						map,
-						result = new SourceMapWithDocuments(
-							this.get(sourceScript.id, sourceScript.languageId, sourceScript.snapshot),
+			*getMaps(virtualCode) {
+				for (const [uri, [snapshot, map]] of context.language.maps.forEach(virtualCode)) {
+					if (!map2DocMap.has(map)) {
+						const embeddedUri = context.encodeEmbeddedDocumentUri(uri, virtualCode.id);
+						map2DocMap.set(map, new SourceMapWithDocuments(
+							this.get(uri, context.language.scripts.get(uri)!.languageId, snapshot),
 							this.get(embeddedUri, virtualCode.languageId, virtualCode.snapshot),
 							map,
 							virtualCode,
-						)
-					);
+						));
+					}
+					yield map2DocMap.get(map)!;
 				}
-				return result;
 			},
 			getLinkedCodeMap(virtualCode, documentUri) {
 				const map = context.language.linkedCodeMaps.get(virtualCode);

--- a/packages/language-service/lib/languageService.ts
+++ b/packages/language-service/lib/languageService.ts
@@ -73,7 +73,7 @@ export function createLanguageService(
 				return map.get(uri)!;
 			},
 			*getMaps(virtualCode) {
-				for (const [uri, [snapshot, map]] of context.language.maps.forEach(virtualCode)) {
+				for (const [uri, snapshot, map] of context.language.maps.forEach(virtualCode)) {
 					if (!map2DocMap.has(map)) {
 						const embeddedUri = context.encodeEmbeddedDocumentUri(uri, virtualCode.id);
 						map2DocMap.set(map, new SourceMapWithDocuments(

--- a/packages/language-service/lib/types.ts
+++ b/packages/language-service/lib/types.ts
@@ -59,8 +59,8 @@ export interface LanguageServiceContext {
 	};
 	documents: {
 		get(uri: URI, languageId: string, snapshot: ts.IScriptSnapshot): TextDocument;
-		getMaps(virtualCode: VirtualCode): Generator<SourceMapWithDocuments>;
-		getLinkedCodeMap(virtualCode: VirtualCode, documentUri: URI): LinkedCodeMapWithDocument | undefined;
+		getMaps(virtualCode: VirtualCode<URI>): Generator<SourceMapWithDocuments>;
+		getLinkedCodeMap(virtualCode: VirtualCode<URI>, documentUri: URI): LinkedCodeMapWithDocument | undefined;
 	};
 	plugins: [LanguageServicePlugin, LanguageServicePluginInstance][];
 	disabledEmbeddedDocumentUris: UriMap<boolean>;

--- a/packages/language-service/lib/types.ts
+++ b/packages/language-service/lib/types.ts
@@ -59,7 +59,7 @@ export interface LanguageServiceContext {
 	};
 	documents: {
 		get(uri: URI, languageId: string, snapshot: ts.IScriptSnapshot): TextDocument;
-		getSourceMap(virtualCode: VirtualCode): SourceMapWithDocuments;
+		getMaps(virtualCode: VirtualCode): Generator<SourceMapWithDocuments>;
 		getLinkedCodeMap(virtualCode: VirtualCode, documentUri: URI): LinkedCodeMapWithDocument | undefined;
 	};
 	plugins: [LanguageServicePlugin, LanguageServicePluginInstance][];

--- a/packages/language-service/lib/utils/common.ts
+++ b/packages/language-service/lib/utils/common.ts
@@ -31,14 +31,14 @@ export function findOverlapCodeRange(
 				const mappingEnd = mapping.sourceOffsets[mapping.sourceOffsets.length - 1] + mapping.lengths[mapping.lengths.length - 1];
 				const overlap = getOverlapRange(start, end, mappingStart, mappingEnd);
 				if (overlap) {
-					const curMappedStart = (overlap.start - mappingStart) + mapping.generatedOffsets[0]
+					const curMappedStart = (overlap.start - mappingStart) + mapping.generatedOffsets[0];
 
 					mappedStart = mappedStart === undefined ? curMappedStart : Math.min(mappedStart, curMappedStart);
 
 					const lastGeneratedLength = (mapping.generatedLengths ?? mapping.lengths)[mapping.generatedOffsets.length - 1];
-					const curMappedEndOffset = Math.min(overlap.end - mapping.sourceOffsets[mapping.sourceOffsets.length - 1], lastGeneratedLength)
+					const curMappedEndOffset = Math.min(overlap.end - mapping.sourceOffsets[mapping.sourceOffsets.length - 1], lastGeneratedLength);
 
-					const curMappedEnd = mapping.generatedOffsets[mapping.generatedOffsets.length - 1] + curMappedEndOffset
+					const curMappedEnd = mapping.generatedOffsets[mapping.generatedOffsets.length - 1] + curMappedEndOffset;
 
 					mappedEnd = mappedEnd === undefined ? curMappedEnd : Math.max(mappedEnd, curMappedEnd);
 				}

--- a/packages/language-service/lib/utils/featureWorkers.ts
+++ b/packages/language-service/lib/utils/featureWorkers.ts
@@ -135,7 +135,7 @@ export async function safeCall<T>(cb: () => Thenable<T> | T, errorMsg?: string) 
 export function* forEachEmbeddedDocument(
 	context: LanguageServiceContext,
 	sourceScriptId: URI,
-	current: VirtualCode
+	current: VirtualCode<URI>
 ): Generator<SourceMapWithDocuments> {
 
 	if (current.embeddedCodes) {

--- a/packages/language-service/lib/utils/featureWorkers.ts
+++ b/packages/language-service/lib/utils/featureWorkers.ts
@@ -144,9 +144,13 @@ export function* forEachEmbeddedDocument(
 		}
 	}
 
-	const map = context.documents.getSourceMap(current);
-	if (!context.disabledEmbeddedDocumentUris.get(context.encodeEmbeddedDocumentUri(sourceScriptId, current.id))) {
-		yield map;
+	for (const map of context.documents.getMaps(current)) {
+		if (
+			sourceScriptId.toString() === map.sourceDocument.uri
+			&& !context.disabledEmbeddedDocumentUris.get(context.encodeEmbeddedDocumentUri(sourceScriptId, current.id))
+		) {
+			yield map;
+		}
 	}
 }
 

--- a/packages/language-service/lib/utils/transform.ts
+++ b/packages/language-service/lib/utils/transform.ts
@@ -19,8 +19,11 @@ export function transformDocumentLinkTarget(_target: string, context: LanguageSe
 	target = decoded[0];
 
 	if (embeddedRange && virtualCode) {
-		const map = context.documents.getSourceMap(virtualCode);
-		if (map.map.mappings.some(mapping => isDocumentLinkEnabled(mapping.data))) {
+		for (const map of context.documents.getMaps(virtualCode)) {
+			if (!map.map.mappings.some(mapping => isDocumentLinkEnabled(mapping.data))) {
+				continue;
+			}
+
 			const startLine = Number(embeddedRange[1]) - 1;
 			const startCharacter = Number(embeddedRange[3] ?? 1) - 1;
 			if (embeddedRange[5] !== undefined) {
@@ -35,6 +38,7 @@ export function transformDocumentLinkTarget(_target: string, context: LanguageSe
 						fragment: 'L' + (sourceRange.start.line + 1) + ',' + (sourceRange.start.character + 1)
 							+ '-L' + (sourceRange.end.line + 1) + ',' + (sourceRange.end.character + 1),
 					});
+					break;
 				}
 			}
 			else {
@@ -43,6 +47,7 @@ export function transformDocumentLinkTarget(_target: string, context: LanguageSe
 					target = target.with({
 						fragment: 'L' + (sourcePos.line + 1) + ',' + (sourcePos.character + 1),
 					});
+					break;
 				}
 			}
 		}
@@ -324,10 +329,11 @@ export function transformWorkspaceEdit(
 		const virtualCode = decoded && sourceScript?.generated?.embeddedCodes.get(decoded[1]);
 
 		if (virtualCode) {
-			const map = context.documents.getSourceMap(virtualCode);
-			// TODO: check capability?
-			const uri = map.sourceDocument.uri;
-			sourceResult.changeAnnotations[uri] = tsAnno;
+			for (const map of context.documents.getMaps(virtualCode)) {
+				// TODO: check capability?
+				const uri = map.sourceDocument.uri;
+				sourceResult.changeAnnotations[uri] = tsAnno;
+			}
 		}
 		else {
 			sourceResult.changeAnnotations[tsUri] = tsAnno;
@@ -342,33 +348,34 @@ export function transformWorkspaceEdit(
 		const virtualCode = decoded && sourceScript?.generated?.embeddedCodes.get(decoded[1]);
 
 		if (virtualCode) {
-			const map = context.documents.getSourceMap(virtualCode);
-			const tsEdits = edit.changes[tsUri];
-			for (const tsEdit of tsEdits) {
-				if (mode === 'rename' || mode === 'fileName' || mode === 'codeAction') {
+			for (const map of context.documents.getMaps(virtualCode)) {
+				const tsEdits = edit.changes[tsUri];
+				for (const tsEdit of tsEdits) {
+					if (mode === 'rename' || mode === 'fileName' || mode === 'codeAction') {
 
-					let _data!: CodeInformation;
+						let _data!: CodeInformation;
 
-					const range = map.getSourceRange(tsEdit.range, data => {
-						_data = data;
-						return isRenameEnabled(data);
-					});
-
-					if (range) {
-						sourceResult.changes[map.sourceDocument.uri] ??= [];
-						sourceResult.changes[map.sourceDocument.uri].push({
-							newText: resolveRenameEditText(tsEdit.newText, _data),
-							range,
+						const range = map.getSourceRange(tsEdit.range, data => {
+							_data = data;
+							return isRenameEnabled(data);
 						});
-						hasResult = true;
+
+						if (range) {
+							sourceResult.changes[map.sourceDocument.uri] ??= [];
+							sourceResult.changes[map.sourceDocument.uri].push({
+								newText: resolveRenameEditText(tsEdit.newText, _data),
+								range,
+							});
+							hasResult = true;
+						}
 					}
-				}
-				else {
-					const range = map.getSourceRange(tsEdit.range);
-					if (range) {
-						sourceResult.changes[map.sourceDocument.uri] ??= [];
-						sourceResult.changes[map.sourceDocument.uri].push({ newText: tsEdit.newText, range });
-						hasResult = true;
+					else {
+						const range = map.getSourceRange(tsEdit.range);
+						if (range) {
+							sourceResult.changes[map.sourceDocument.uri] ??= [];
+							sourceResult.changes[map.sourceDocument.uri].push({ newText: tsEdit.newText, range });
+							hasResult = true;
+						}
 					}
 				}
 			}
@@ -391,43 +398,44 @@ export function transformWorkspaceEdit(
 				const virtualCode = decoded && sourceScript?.generated?.embeddedCodes.get(decoded[1]);
 
 				if (virtualCode) {
-					const map = context.documents.getSourceMap(virtualCode);
-					sourceEdit = {
-						textDocument: {
-							uri: map.sourceDocument.uri,
-							version: versions[map.sourceDocument.uri] ?? null,
-						},
-						edits: [],
-					} satisfies vscode.TextDocumentEdit;
-					for (const tsEdit of tsDocEdit.edits) {
-						if (mode === 'rename' || mode === 'fileName' || mode === 'codeAction') {
-							let _data!: CodeInformation;
-							const range = map.getSourceRange(tsEdit.range, data => {
-								_data = data;
-								// fix https://github.com/johnsoncodehk/volar/issues/1091
-								return isRenameEnabled(data);
-							});
-							if (range) {
-								sourceEdit.edits.push({
-									annotationId: 'annotationId' in tsEdit ? tsEdit.annotationId : undefined,
-									newText: resolveRenameEditText(tsEdit.newText, _data),
-									range,
+					for (const map of context.documents.getMaps(virtualCode)) {
+						sourceEdit = {
+							textDocument: {
+								uri: map.sourceDocument.uri,
+								version: versions[map.sourceDocument.uri] ?? null,
+							},
+							edits: [],
+						} satisfies vscode.TextDocumentEdit;
+						for (const tsEdit of tsDocEdit.edits) {
+							if (mode === 'rename' || mode === 'fileName' || mode === 'codeAction') {
+								let _data!: CodeInformation;
+								const range = map.getSourceRange(tsEdit.range, data => {
+									_data = data;
+									// fix https://github.com/johnsoncodehk/volar/issues/1091
+									return isRenameEnabled(data);
 								});
+								if (range) {
+									sourceEdit.edits.push({
+										annotationId: 'annotationId' in tsEdit ? tsEdit.annotationId : undefined,
+										newText: resolveRenameEditText(tsEdit.newText, _data),
+										range,
+									});
+								}
+							}
+							else {
+								const range = map.getSourceRange(tsEdit.range);
+								if (range) {
+									sourceEdit.edits.push({
+										annotationId: 'annotationId' in tsEdit ? tsEdit.annotationId : undefined,
+										newText: tsEdit.newText,
+										range,
+									});
+								}
 							}
 						}
-						else {
-							const range = map.getSourceRange(tsEdit.range);
-							if (range) {
-								sourceEdit.edits.push({
-									annotationId: 'annotationId' in tsEdit ? tsEdit.annotationId : undefined,
-									newText: tsEdit.newText,
-									range,
-								});
-							}
+						if (!sourceEdit.edits.length) {
+							sourceEdit = undefined;
 						}
-					}
-					if (!sourceEdit.edits.length) {
-						sourceEdit = undefined;
 					}
 				}
 				else {
@@ -444,15 +452,16 @@ export function transformWorkspaceEdit(
 				const virtualCode = decoded && sourceScript?.generated?.embeddedCodes.get(decoded[1]);
 
 				if (virtualCode) {
-					const map = context.documents.getSourceMap(virtualCode);
-					// TODO: check capability?
-					sourceEdit = {
-						kind: 'rename',
-						oldUri: map.sourceDocument.uri,
-						newUri: tsDocEdit.newUri /* TODO: remove .ts? */,
-						options: tsDocEdit.options,
-						annotationId: tsDocEdit.annotationId,
-					} satisfies vscode.RenameFile;
+					for (const map of context.documents.getMaps(virtualCode)) {
+						// TODO: check capability?
+						sourceEdit = {
+							kind: 'rename',
+							oldUri: map.sourceDocument.uri,
+							newUri: tsDocEdit.newUri /* TODO: remove .ts? */,
+							options: tsDocEdit.options,
+							annotationId: tsDocEdit.annotationId,
+						} satisfies vscode.RenameFile;
+					}
 				}
 				else {
 					sourceEdit = tsDocEdit;
@@ -465,14 +474,15 @@ export function transformWorkspaceEdit(
 				const virtualCode = decoded && sourceScript?.generated?.embeddedCodes.get(decoded[1]);
 
 				if (virtualCode) {
-					const map = context.documents.getSourceMap(virtualCode);
-					// TODO: check capability?
-					sourceEdit = {
-						kind: 'delete',
-						uri: map.sourceDocument.uri,
-						options: tsDocEdit.options,
-						annotationId: tsDocEdit.annotationId,
-					} satisfies vscode.DeleteFile;
+					for (const map of context.documents.getMaps(virtualCode)) {
+						// TODO: check capability?
+						sourceEdit = {
+							kind: 'delete',
+							uri: map.sourceDocument.uri,
+							options: tsDocEdit.options,
+							annotationId: tsDocEdit.annotationId,
+						} satisfies vscode.DeleteFile;
+					}
 				}
 				else {
 					sourceEdit = tsDocEdit;

--- a/packages/source-map/lib/buildMappings.ts
+++ b/packages/source-map/lib/buildMappings.ts
@@ -10,7 +10,6 @@ export function buildMappings<T>(chunks: Segment<T>[]) {
 		}
 		else {
 			mappings.push({
-				source: segment[1],
 				sourceOffsets: [segment[2]],
 				generatedOffsets: [length],
 				lengths: [segment[0].length],

--- a/packages/test-utils/index.ts
+++ b/packages/test-utils/index.ts
@@ -500,8 +500,7 @@ export function* printSnapshot(
 					' '.repeat(log.lineOffset),
 					sourceLineHead,
 					'(exact match)',
-					`(${log.mapping.source
-					+ ':' + (sourcePosition.line + 1)
+					`(${':' + (sourcePosition.line + 1)
 					+ ':' + (sourcePosition.character + 1)
 					})`,
 				].join(' ');
@@ -512,8 +511,7 @@ export function* printSnapshot(
 					' '.repeat(log.lineOffset),
 					sourceLineHead,
 					normalizeLogText(sourceLine),
-					`(${log.mapping.source
-					+ ':' + (sourcePosition.line + 1)
+					`(${':' + (sourcePosition.line + 1)
 					+ ':' + (sourcePosition.character + 1)})`,
 				].join(' ');
 				yield [

--- a/packages/typescript/lib/node/transform.ts
+++ b/packages/typescript/lib/node/transform.ts
@@ -184,7 +184,7 @@ export function transformTextSpan(
 export function toSourceOffset(
 	serviceScript: TypeScriptServiceScript,
 	sourceScript: SourceScript<string>,
-	map: SourceMap,
+	map: SourceMap<CodeInformation>,
 	position: number,
 	filter: (data: CodeInformation) => boolean
 ) {
@@ -198,7 +198,7 @@ export function toSourceOffset(
 export function toGeneratedOffset(
 	serviceScript: TypeScriptServiceScript,
 	sourceScript: SourceScript<string>,
-	map: SourceMap,
+	map: SourceMap<CodeInformation>,
 	position: number,
 	filter: (data: CodeInformation) => boolean
 ) {

--- a/packages/typescript/lib/node/utils.ts
+++ b/packages/typescript/lib/node/utils.ts
@@ -9,7 +9,7 @@ export function getServiceScript(language: Language<string>, fileName: string) {
 	if (sourceScript?.generated) {
 		const serviceScript = sourceScript.generated.languagePlugin.typescript?.getServiceScript(sourceScript.generated.root);
 		if (serviceScript) {
-			const map = language.maps.get(serviceScript.code);
+			const map = language.maps.get(serviceScript.code, sourceScript.id);
 			if (map) {
 				return [serviceScript, sourceScript, map] as const;
 			}

--- a/packages/typescript/lib/node/utils.ts
+++ b/packages/typescript/lib/node/utils.ts
@@ -9,7 +9,7 @@ export function getServiceScript(language: Language<string>, fileName: string) {
 	if (sourceScript?.generated) {
 		const serviceScript = sourceScript.generated.languagePlugin.typescript?.getServiceScript(sourceScript.generated.root);
 		if (serviceScript) {
-			const map = language.maps.get(serviceScript.code, sourceScript.id);
+			const map = language.maps.get(serviceScript.code);
 			if (map) {
 				return [serviceScript, sourceScript, map] as const;
 			}

--- a/packages/typescript/lib/protocol/createProject.ts
+++ b/packages/typescript/lib/protocol/createProject.ts
@@ -1,4 +1,4 @@
-import { FileMap, Language, TypeScriptExtraServiceScript, forEachEmbeddedCode } from '@volar/language-core';
+import { FileMap, Language, SourceScript, TypeScriptExtraServiceScript, forEachEmbeddedCode } from '@volar/language-core';
 import * as path from 'path-browserify';
 import type * as ts from 'typescript';
 import { createResolveModuleName } from '../resolveModuleName';
@@ -27,7 +27,7 @@ export function createLanguageServiceHost<T>(
 	let lastProjectVersion: number | string | undefined;
 	let tsProjectVersion = 0;
 	let tsFileRegistry = new FileMap<boolean>(sys.useCaseSensitiveFileNames);
-	let extraScriptRegistry = new FileMap<TypeScriptExtraServiceScript>(sys.useCaseSensitiveFileNames);
+	let extraScriptRegistry = new FileMap<[SourceScript<T>, TypeScriptExtraServiceScript]>(sys.useCaseSensitiveFileNames);
 	let lastTsVirtualFileSnapshots = new Set<ts.IScriptSnapshot>();
 	let lastOtherVirtualFileSnapshots = new Set<ts.IScriptSnapshot>();
 	let languageServiceHost: ts.LanguageServiceHost = {
@@ -99,7 +99,7 @@ export function createLanguageServiceHost<T>(
 			sync();
 
 			if (extraScriptRegistry.has(fileName)) {
-				return extraScriptRegistry.get(fileName)!.scriptKind;
+				return extraScriptRegistry.get(fileName)![1].scriptKind;
 			}
 
 			const sourceScript = language.scripts.get(asScrpitId(fileName));
@@ -218,7 +218,7 @@ export function createLanguageServiceHost<T>(
 				for (const extraServiceScript of sourceScript.generated.languagePlugin.typescript?.getExtraServiceScripts?.(fileName, sourceScript.generated.root) ?? []) {
 					newTsVirtualFileSnapshots.add(extraServiceScript.code.snapshot);
 					tsFileNamesSet.add(extraServiceScript.fileName);
-					extraScriptRegistry.set(extraServiceScript.fileName, extraServiceScript);
+					extraScriptRegistry.set(extraServiceScript.fileName, [sourceScript, extraServiceScript]);
 				}
 				for (const code of forEachEmbeddedCode(sourceScript.generated.root)) {
 					newOtherVirtualFileSnapshots.add(code.snapshot);
@@ -251,7 +251,7 @@ export function createLanguageServiceHost<T>(
 		sync();
 
 		if (extraScriptRegistry.has(fileName)) {
-			return extraScriptRegistry.get(fileName)!.code.snapshot;
+			return extraScriptRegistry.get(fileName)![1].code.snapshot;
 		}
 
 		const sourceScript = language.scripts.get(asScrpitId(fileName));
@@ -278,7 +278,7 @@ export function createLanguageServiceHost<T>(
 		const version = scriptVersions.get(fileName)!;
 
 		if (extraScriptRegistry.has(fileName)) {
-			const snapshot = extraScriptRegistry.get(fileName)!.code.snapshot;
+			const snapshot = extraScriptRegistry.get(fileName)![1].code.snapshot;
 			if (!version.map.has(snapshot)) {
 				version.map.set(snapshot, version.lastVersion++);
 			}

--- a/packages/typescript/lib/protocol/createProject.ts
+++ b/packages/typescript/lib/protocol/createProject.ts
@@ -1,4 +1,4 @@
-import { FileMap, Language, SourceScript, TypeScriptExtraServiceScript, forEachEmbeddedCode } from '@volar/language-core';
+import { FileMap, Language, TypeScriptExtraServiceScript, forEachEmbeddedCode } from '@volar/language-core';
 import * as path from 'path-browserify';
 import type * as ts from 'typescript';
 import { createResolveModuleName } from '../resolveModuleName';
@@ -27,7 +27,7 @@ export function createLanguageServiceHost<T>(
 	let lastProjectVersion: number | string | undefined;
 	let tsProjectVersion = 0;
 	let tsFileRegistry = new FileMap<boolean>(sys.useCaseSensitiveFileNames);
-	let extraScriptRegistry = new FileMap<[SourceScript<T>, TypeScriptExtraServiceScript]>(sys.useCaseSensitiveFileNames);
+	let extraScriptRegistry = new FileMap<TypeScriptExtraServiceScript<T>>(sys.useCaseSensitiveFileNames);
 	let lastTsVirtualFileSnapshots = new Set<ts.IScriptSnapshot>();
 	let lastOtherVirtualFileSnapshots = new Set<ts.IScriptSnapshot>();
 	let languageServiceHost: ts.LanguageServiceHost = {
@@ -99,7 +99,7 @@ export function createLanguageServiceHost<T>(
 			sync();
 
 			if (extraScriptRegistry.has(fileName)) {
-				return extraScriptRegistry.get(fileName)![1].scriptKind;
+				return extraScriptRegistry.get(fileName)!.scriptKind;
 			}
 
 			const sourceScript = language.scripts.get(asScrpitId(fileName));
@@ -218,7 +218,7 @@ export function createLanguageServiceHost<T>(
 				for (const extraServiceScript of sourceScript.generated.languagePlugin.typescript?.getExtraServiceScripts?.(fileName, sourceScript.generated.root) ?? []) {
 					newTsVirtualFileSnapshots.add(extraServiceScript.code.snapshot);
 					tsFileNamesSet.add(extraServiceScript.fileName);
-					extraScriptRegistry.set(extraServiceScript.fileName, [sourceScript, extraServiceScript]);
+					extraScriptRegistry.set(extraServiceScript.fileName, extraServiceScript);
 				}
 				for (const code of forEachEmbeddedCode(sourceScript.generated.root)) {
 					newOtherVirtualFileSnapshots.add(code.snapshot);
@@ -251,7 +251,7 @@ export function createLanguageServiceHost<T>(
 		sync();
 
 		if (extraScriptRegistry.has(fileName)) {
-			return extraScriptRegistry.get(fileName)![1].code.snapshot;
+			return extraScriptRegistry.get(fileName)!.code.snapshot;
 		}
 
 		const sourceScript = language.scripts.get(asScrpitId(fileName));
@@ -278,7 +278,7 @@ export function createLanguageServiceHost<T>(
 		const version = scriptVersions.get(fileName)!;
 
 		if (extraScriptRegistry.has(fileName)) {
-			const snapshot = extraScriptRegistry.get(fileName)![1].code.snapshot;
+			const snapshot = extraScriptRegistry.get(fileName)!.code.snapshot;
 			if (!version.map.has(snapshot)) {
 				version.map.set(snapshot, version.lastVersion++);
 			}


### PR DESCRIPTION
https://github.com/volarjs/volar.js/commit/c4b297b2426ec8b032eec16c5396263bc03e2163 removed multi-source support, but to support Angular use cases, this PR re-implements it.

### Changes

- `getAssociatedScript` needs to be called to explicitly register dependencies on additional sources.
- Mappings with additional source scripts should be added to `associatedScriptMappings` instead of using the `Mapping#source` field.
- The `Mapping#source` field has beed removed.

Example:

```ts
export const angularLanguagePlugin: LanguagePlugin<string> = {
	createVirtualCode(fileName, languageId, snapshot, { getAssociatedScript }) {
		if (fileName.endsWith('app.component.ts')) {

			// Register dependencies
			const templateScript = getAssociatedScript('.../template.html');

			if (templateScript) {
				return {
					mappings: [
						// Mappings for app.component.ts
					],
					associatedScriptMappings: new Map([
						[templateScript.id, [
							// Mappings for template.html
						]],
					])
				}
			}
		}
	},
};
```