### PR TITLE
Fix Monaco selection ranges conversion

### DIFF
--- a/packages/monaco/lib/provider.ts
+++ b/packages/monaco/lib/provider.ts
@@ -29,7 +29,7 @@ import {
 	toLinkedEditingRanges,
 	toLocation,
 	toLocationLink,
-	toSelectionRange,
+	toSelectionRanges,
 	toSemanticTokens,
 	toSignatureHelp,
 	toTextEdit,
@@ -374,17 +374,11 @@ export async function createLanguageFeaturesProvider(
 		},
 		async provideSelectionRanges(model, positions) {
 			const languageService = await worker.withSyncedResources(getSyncUris());
-			const codeResults = await Promise.all(
-				positions.map(position =>
-					languageService.getSelectionRanges(
-						model.uri as URI,
-						[fromPosition(position)]
-					)
-				)
+			const codeResults = await languageService.getSelectionRanges(
+				model.uri as URI,
+				positions.map(fromPosition)
 			);
-			return codeResults.map(
-				codeResult => codeResult?.map(toSelectionRange) ?? []
-			);
+			return codeResults?.map(toSelectionRanges);
 		},
 		async provideSignatureHelp(model, position, _token, context) {
 			const languageService = await worker.withSyncedResources(getSyncUris());

--- a/packages/monaco/package.json
+++ b/packages/monaco/package.json
@@ -15,7 +15,7 @@
 	"dependencies": {
 		"@volar/language-service": "2.3.0-alpha.13",
 		"@volar/typescript": "2.3.0-alpha.13",
-		"monaco-languageserver-types": "^0.3.3",
+		"monaco-languageserver-types": "^0.3.4",
 		"monaco-types": "^0.1.0",
 		"vscode-uri": "^3.0.8"
 	},

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -167,8 +167,8 @@ importers:
         specifier: 2.3.0-alpha.13
         version: link:../typescript
       monaco-languageserver-types:
-        specifier: ^0.3.3
-        version: 0.3.3
+        specifier: ^0.3.4
+        version: 0.3.4
       monaco-types:
         specifier: ^0.1.0
         version: 0.1.0
@@ -2122,8 +2122,8 @@ packages:
   monaco-editor-core@0.49.0:
     resolution: {integrity: sha512-MANZcpLnpcM5qceEMsdwndvyB9rlGu+Sd8mVLd6y4VpSZCQenpoUAYk0K+UAPtcnCOYhgIsR/ZS9PxzMnCFkYw==}
 
-  monaco-languageserver-types@0.3.3:
-    resolution: {integrity: sha512-4uJ6XaVwVamOQ1SXfBGusAqL4fTn7ZJzaybEinr2U5ZX7AKSjsbXWlu0X3Ah+hyefn+85+Ca7GZwbI87g55C8Q==}
+  monaco-languageserver-types@0.3.4:
+    resolution: {integrity: sha512-d58sP5yNhjs8uG1ESXs0hFnuX2YfdMhiGeWhdgTUZyG9aaWgyI4dDwrK1khf1mPF2u9Sljv42sfYqPFZnqYMYg==}
 
   monaco-types@0.1.0:
     resolution: {integrity: sha512-aWK7SN9hAqNYi0WosPoMjenMeXJjwCxDibOqWffyQ/qXdzB/86xshGQobRferfmNz7BSNQ8GB0MD0oby9/5fTQ==}
@@ -4921,7 +4921,7 @@ snapshots:
 
   monaco-editor-core@0.49.0: {}
 
-  monaco-languageserver-types@0.3.3:
+  monaco-languageserver-types@0.3.4:
     dependencies:
       monaco-types: 0.1.0
       vscode-languageserver-protocol: 3.17.5


### PR DESCRIPTION
LSP represents an ancestry of selection ranges using the `parent` property. Monaco editor represents this using an array of selection ranges. This is why one LSP selection range represents an array of Monaco editor selection ranges. It’s not needed to call `getSelectionRanges` multiple times.