### PR TITLE
feat(language-server): add support for Workspace Diagnostics

### DIFF
--- a/packages/language-server/lib/register/registerLanguageFeatures.ts
+++ b/packages/language-server/lib/register/registerLanguageFeatures.ts
@@ -277,7 +277,7 @@ export function registerLanguageFeatures(server: LanguageServer) {
 				break;
 			}
 			const result = await languageService.getWorkspaceDiagnostics(token);
-			items.push(...result.items);
+			items.push(...result);
 		}
 		return { items };
 	});

--- a/packages/language-server/lib/server.ts
+++ b/packages/language-server/lib/server.ts
@@ -174,7 +174,7 @@ export function createServerBase(
 			diagnosticProvider: capabilitiesArr.some(data => data.diagnosticProvider)
 				? {
 					interFileDependencies: true,
-					workspaceDiagnostics: false,
+					workspaceDiagnostics: capabilitiesArr.some(data => data.diagnosticProvider?.workspaceDiagnostics),
 				}
 				: undefined,
 			documentOnTypeFormattingProvider: capabilitiesArr.some(data => data.documentOnTypeFormattingProvider)

--- a/packages/language-service/lib/features/provideWorkspaceDiagnostics.ts
+++ b/packages/language-service/lib/features/provideWorkspaceDiagnostics.ts
@@ -8,7 +8,7 @@ import { shouldReportDiagnostics } from '@volar/language-core';
 
 export function register(context: LanguageServiceContext) {
 
-	return async (token = NoneCancellationToken): Promise<vscode.WorkspaceDiagnosticReport> => {
+	return async (token = NoneCancellationToken) => {
 
 		const allItems: vscode.WorkspaceDocumentDiagnosticReport[] = [];
 
@@ -26,7 +26,7 @@ export function register(context: LanguageServiceContext) {
 			if (!report) {
 				continue;
 			}
-			const items = report.items
+			const items = report
 				.map<vscode.WorkspaceDocumentDiagnosticReport>(item => {
 					const decoded = context.decodeEmbeddedDocumentUri(URI.parse(item.uri));
 					const sourceScript = decoded && context.language.scripts.get(decoded[0]);
@@ -65,6 +65,6 @@ export function register(context: LanguageServiceContext) {
 			allItems.push(...items);
 		}
 
-		return { items: allItems };
+		return allItems;
 	};
 }

--- a/packages/language-service/lib/features/provideWorkspaceDiagnostics.ts
+++ b/packages/language-service/lib/features/provideWorkspaceDiagnostics.ts
@@ -1,0 +1,70 @@
+import type * as vscode from 'vscode-languageserver-protocol';
+import type { LanguageServiceContext } from '../types';
+import { notEmpty } from '../utils/common';
+import { NoneCancellationToken } from '../utils/cancellation';
+import { URI } from 'vscode-uri';
+import { transformDiagnostic } from './provideDiagnostics';
+import { shouldReportDiagnostics } from '@volar/language-core';
+
+export function register(context: LanguageServiceContext) {
+
+	return async (token = NoneCancellationToken): Promise<vscode.WorkspaceDiagnosticReport> => {
+
+		const allItems: vscode.WorkspaceDocumentDiagnosticReport[] = [];
+
+		for (const plugin of context.plugins) {
+			if (context.disabledServicePlugins.has(plugin[1])) {
+				continue;
+			}
+			if (token.isCancellationRequested) {
+				break;
+			}
+			if (!plugin[1].provideWorkspaceDiagnostics) {
+				continue;
+			}
+			const report = await plugin[1].provideWorkspaceDiagnostics(token);
+			if (!report) {
+				continue;
+			}
+			const items = report.items
+				.map<vscode.WorkspaceDocumentDiagnosticReport>(item => {
+					const decoded = context.decodeEmbeddedDocumentUri(URI.parse(item.uri));
+					const sourceScript = decoded && context.language.scripts.get(decoded[0]);
+					const virtualCode = decoded && sourceScript?.generated?.embeddedCodes.get(decoded[1]);
+
+					if (virtualCode && sourceScript) {
+						if (item.kind === 'unchanged') {
+							return {
+								...item,
+								uri: sourceScript.id.toString(),
+							};
+						}
+						else {
+							const map = context.documents.getMap(virtualCode, sourceScript);
+							return {
+								...item,
+								items: item.items
+									.map(error => transformDiagnostic(context, error, map, shouldReportDiagnostics))
+									.filter(notEmpty)
+							};
+						}
+					}
+					else {
+						if (item.kind === 'unchanged') {
+							return item;
+						}
+						return {
+							...item,
+							items: item.items
+								.map(error => transformDiagnostic(context, error, undefined, shouldReportDiagnostics))
+								.filter(notEmpty)
+						};
+					}
+				});
+
+			allItems.push(...items);
+		}
+
+		return { items: allItems };
+	};
+}

--- a/packages/language-service/lib/types.ts
+++ b/packages/language-service/lib/types.ts
@@ -59,6 +59,7 @@ export interface LanguageServiceContext {
 	};
 	documents: {
 		get(uri: URI, languageId: string, snapshot: ts.IScriptSnapshot): TextDocument;
+		getMap(virtualCode: VirtualCode, sourceScript: SourceScript<URI>): SourceMapWithDocuments;
 		getMaps(virtualCode: VirtualCode): Generator<SourceMapWithDocuments>;
 		getLinkedCodeMap(virtualCode: VirtualCode, documentUri: URI): LinkedCodeMapWithDocument | undefined;
 	};
@@ -133,8 +134,10 @@ export interface LanguageServicePlugin<P = any> {
 			codeActionKinds?: string[];
 			resolveProvider?: boolean;
 		};
-		// TODO: interFileDependencies, workspaceDiagnostics
-		diagnosticProvider?: boolean;
+		// TODO: interFileDependencies
+		diagnosticProvider?: {
+			workspaceDiagnostics?: boolean;
+		};
 	};
 	create(context: LanguageServiceContext, languageService: LanguageService): LanguageServicePluginInstance<P>;
 }
@@ -176,6 +179,7 @@ export interface LanguageServicePluginInstance<P = any> {
 	provideWorkspaceSymbols?(query: string, token: vscode.CancellationToken): NullableProviderResult<vscode.WorkspaceSymbol[]>;
 	provideDiagnostics?(document: TextDocument, token: vscode.CancellationToken): NullableProviderResult<vscode.Diagnostic[]>;
 	provideSemanticDiagnostics?(document: TextDocument, token: vscode.CancellationToken): NullableProviderResult<vscode.Diagnostic[]>;
+	provideWorkspaceDiagnostics?(token: vscode.CancellationToken): NullableProviderResult<vscode.WorkspaceDiagnosticReport>;
 	provideFileReferences?(document: TextDocument, token: vscode.CancellationToken): NullableProviderResult<vscode.Location[]>; // volar specific
 	provideReferencesCodeLensRanges?(document: TextDocument, token: vscode.CancellationToken): NullableProviderResult<vscode.Range[]>; // volar specific
 	provideAutoInsertSnippet?(document: TextDocument, position: vscode.Position, lastChange: { rangeOffset: number; rangeLength: number; text: string; }, token: vscode.CancellationToken): NullableProviderResult<string>; // volar specific

--- a/packages/language-service/lib/types.ts
+++ b/packages/language-service/lib/types.ts
@@ -179,7 +179,7 @@ export interface LanguageServicePluginInstance<P = any> {
 	provideWorkspaceSymbols?(query: string, token: vscode.CancellationToken): NullableProviderResult<vscode.WorkspaceSymbol[]>;
 	provideDiagnostics?(document: TextDocument, token: vscode.CancellationToken): NullableProviderResult<vscode.Diagnostic[]>;
 	provideSemanticDiagnostics?(document: TextDocument, token: vscode.CancellationToken): NullableProviderResult<vscode.Diagnostic[]>;
-	provideWorkspaceDiagnostics?(token: vscode.CancellationToken): NullableProviderResult<vscode.WorkspaceDiagnosticReport>;
+	provideWorkspaceDiagnostics?(token: vscode.CancellationToken): NullableProviderResult<vscode.WorkspaceDocumentDiagnosticReport[]>;
 	provideFileReferences?(document: TextDocument, token: vscode.CancellationToken): NullableProviderResult<vscode.Location[]>; // volar specific
 	provideReferencesCodeLensRanges?(document: TextDocument, token: vscode.CancellationToken): NullableProviderResult<vscode.Range[]>; // volar specific
 	provideAutoInsertSnippet?(document: TextDocument, position: vscode.Position, lastChange: { rangeOffset: number; rangeLength: number; text: string; }, token: vscode.CancellationToken): NullableProviderResult<string>; // volar specific

--- a/tsslint.config.ts
+++ b/tsslint.config.ts
@@ -176,6 +176,7 @@ export default defineConfig({
 						ts.isIdentifier(parameter.name)
 						&& !parameter.type
 						&& !parameter.dotDotDotToken
+						&& !parameter.initializer
 						&& sourceFile.text[parameter.getStart(sourceFile) - 1] === '('
 						&& sourceFile.text[parameter.getEnd()] === ')'
 					) {


### PR DESCRIPTION
Close #43, implement `connection.languages.diagnostics.onWorkspace` of language server.

### LS Plugin Code Sample

```ts
const plugin: LanguageServicePlugin = {
	capabilities: {
		diagnosticProvider: {
			workspaceDiagnostics: true,
		},
	},
	create(context): LanguageServicePluginInstance<Provide> {
		return {
			provideWorkspaceDiagnostics() {
				return [{
					uri: 'file://a.css',
					items: [{
						severity: 2,
						source: 'html1',
						message: 'Only one style tag is allowed.',
						// ...
					}]
				}];
			}
		};
	},
}
```