### PR TITLE
refactor(source-map): improve range mapping accuracy

### DIFF
--- a/packages/language-service/lib/documents.ts
+++ b/packages/language-service/lib/documents.ts
@@ -26,13 +26,13 @@ export class SourceMapWithDocuments {
 	}
 
 	public * getSourceRanges(range: vscode.Range, filter: (data: CodeInformation) => boolean = () => true) {
-		for (const result of this.findRanges(range, filter, 'getSourcePositionsBase', 'matchSourcePosition')) {
+		for (const result of this.findRanges(range, filter, this.embeddedDocument, this.sourceDocument, 'getSourceStartEnd', 'getSourcePositions')) {
 			yield result;
 		}
 	}
 
 	public * getGeneratedRanges(range: vscode.Range, filter: (data: CodeInformation) => boolean = () => true) {
-		for (const result of this.findRanges(range, filter, 'getGeneratedPositionsBase', 'matchGeneratedPosition')) {
+		for (const result of this.findRanges(range, filter, this.sourceDocument, this.embeddedDocument, 'getGeneratedStartEnd', 'getGeneratedPositions')) {
 			yield result;
 		}
 	}
@@ -40,61 +40,34 @@ export class SourceMapWithDocuments {
 	protected * findRanges(
 		range: vscode.Range,
 		filter: (data: CodeInformation) => boolean,
-		api: 'getSourcePositionsBase' | 'getGeneratedPositionsBase',
-		api2: 'matchSourcePosition' | 'matchGeneratedPosition'
+		fromDoc: TextDocument,
+		toDoc: TextDocument,
+		api: 'getSourceStartEnd' | 'getGeneratedStartEnd',
+		api2: 'getSourcePositions' | 'getGeneratedPositions'
 	) {
-		const failedLookUps: (readonly [vscode.Position, Mapping<CodeInformation>])[] = [];
-		for (const mapped of this[api](range.start, filter)) {
-			const end = this[api2](range.end, mapped[1]);
-			if (end) {
-				yield { start: mapped[0], end } as vscode.Range;
+		for (const [mappedStart, mappedEnd, mapping] of this.map[api](fromDoc.offsetAt(range.start), fromDoc.offsetAt(range.end))) {
+			if (!filter(mapping.data)) {
+				continue;
 			}
-			else {
-				failedLookUps.push(mapped);
+			yield { start: toDoc.positionAt(mappedStart), end: toDoc.positionAt(mappedEnd) };
+		}
+		for (const mappedStart of this[api2](range.start, filter)) {
+			for (const mappedEnd of this[api2](range.end, filter)) {
+				yield { start: mappedStart, end: mappedEnd };
+				break;
 			}
-		}
-		for (const failedLookUp of failedLookUps) {
-			for (const mapped of this[api](range.end, filter)) {
-				yield { start: failedLookUp[0], end: mapped[0] } as vscode.Range;
-			}
-		}
-	}
-
-	// Position APIs
-
-	public getSourcePosition(position: vscode.Position, filter: (data: CodeInformation) => boolean = () => true) {
-		for (const mapped of this.getSourcePositions(position, filter)) {
-			return mapped;
-		}
-	}
-
-	public getGeneratedPosition(position: vscode.Position, filter: (data: CodeInformation) => boolean = () => true) {
-		for (const mapped of this.getGeneratedPositions(position, filter)) {
-			return mapped;
 		}
 	}
 
 	public * getSourcePositions(position: vscode.Position, filter: (data: CodeInformation) => boolean = () => true) {
-		for (const mapped of this.getSourcePositionsBase(position, filter)) {
+		for (const mapped of this.findPositions(position, filter, this.embeddedDocument, this.sourceDocument, 'generatedOffsets', 'sourceOffsets')) {
 			yield mapped[0];
 		}
 	}
 
 	public * getGeneratedPositions(position: vscode.Position, filter: (data: CodeInformation) => boolean = () => true) {
-		for (const mapped of this.getGeneratedPositionsBase(position, filter)) {
-			yield mapped[0];
-		}
-	}
-
-	public * getSourcePositionsBase(position: vscode.Position, filter: (data: CodeInformation) => boolean = () => true) {
-		for (const mapped of this.findPositions(position, filter, this.embeddedDocument, this.sourceDocument, 'generatedOffsets', 'sourceOffsets')) {
-			yield mapped;
-		}
-	}
-
-	public * getGeneratedPositionsBase(position: vscode.Position, filter: (data: CodeInformation) => boolean = () => true) {
 		for (const mapped of this.findPositions(position, filter, this.sourceDocument, this.embeddedDocument, 'sourceOffsets', 'generatedOffsets')) {
-			yield mapped;
+			yield mapped[0];
 		}
 	}
 

--- a/packages/language-service/lib/features/provideDocumentFormattingEdits.ts
+++ b/packages/language-service/lib/features/provideDocumentFormattingEdits.ts
@@ -98,9 +98,7 @@ export function register(context: LanguageServiceContext) {
 
 					if (onTypeParams) {
 
-						const embeddedPosition = docMap.getGeneratedPosition(onTypeParams.position);
-
-						if (embeddedPosition) {
+						for (const embeddedPosition of docMap.getGeneratedPositions(onTypeParams.position)) {
 							embeddedCodeResult = await tryFormat(
 								docMap.sourceDocument,
 								docMap.embeddedDocument,
@@ -110,6 +108,7 @@ export function register(context: LanguageServiceContext) {
 								embeddedPosition,
 								onTypeParams.ch
 							);
+							break;
 						}
 					}
 					else if (embeddedRange) {

--- a/packages/language-service/lib/features/provideInlayHints.ts
+++ b/packages/language-service/lib/features/provideInlayHints.ts
@@ -62,12 +62,11 @@ export function register(context: LanguageServiceContext) {
 				}
 				return inlayHints
 					.map((_inlayHint): vscode.InlayHint | undefined => {
-						const position = map.getSourcePosition(_inlayHint.position, isInlayHintsEnabled);
 						const edits = _inlayHint.textEdits
 							?.map(textEdit => transformTextEdit(textEdit, range => map.getSourceRange(range), map.embeddedDocument))
 							.filter(notEmpty);
 
-						if (position) {
+						for (const position of map.getSourcePositions(_inlayHint.position, isInlayHintsEnabled)) {
 							return {
 								..._inlayHint,
 								position,

--- a/packages/language-service/lib/features/provideSelectionRanges.ts
+++ b/packages/language-service/lib/features/provideSelectionRanges.ts
@@ -17,7 +17,11 @@ export function register(context: LanguageServiceContext) {
 			() => positions,
 			function* (map) {
 				const result = positions
-					.map(position => map.getGeneratedPosition(position, isSelectionRangesEnabled))
+					.map(position => {
+						for (const mappedPosition of map.getGeneratedPositions(position, isSelectionRangesEnabled)) {
+							return mappedPosition;
+						}
+					})
 					.filter(notEmpty);
 				if (result.length) {
 					yield result;

--- a/packages/language-service/lib/utils/transform.ts
+++ b/packages/language-service/lib/utils/transform.ts
@@ -42,11 +42,15 @@ export function transformDocumentLinkTarget(_target: string, context: LanguageSe
 				}
 			}
 			else {
-				const sourcePos = map.getSourcePosition({ line: startLine, character: startCharacter });
-				if (sourcePos) {
+				let mapped = false;
+				for (const sourcePos of map.getSourcePositions({ line: startLine, character: startCharacter })) {
+					mapped = true;
 					target = target.with({
 						fragment: 'L' + (sourcePos.line + 1) + ',' + (sourcePos.character + 1),
 					});
+					break;
+				}
+				if (mapped) {
 					break;
 				}
 			}

--- a/packages/source-map/lib/sourceMap.ts
+++ b/packages/source-map/lib/sourceMap.ts
@@ -23,6 +23,23 @@ export class SourceMap<Data = unknown> {
 
 	constructor(public readonly mappings: Mapping<Data>[]) { }
 
+	getSourceStartEnd(generatedStart: number, generatedEnd: number) {
+		return this.findMatchingStartEnd(generatedStart, generatedEnd, 'generatedOffsets', 'sourceOffsets');
+	}
+
+	getGeneratedStartEnd(sourceStart: number, sourceEnd: number) {
+		return this.findMatchingStartEnd(sourceStart, sourceEnd, 'sourceOffsets', 'generatedOffsets');
+	}
+
+	* findMatchingStartEnd(start: number, end: number, fromRange: CodeRangeKey, toRange: CodeRangeKey) {
+		for (const [mappedStart, mapping] of this.findMatching(start, fromRange, toRange)) {
+			const mappedEnd = translateOffset(end, mapping[fromRange], mapping[toRange], getLengths(mapping, fromRange), getLengths(mapping, toRange));
+			if (mappedEnd !== undefined) {
+				yield [mappedStart, mappedEnd, mapping] as const;
+			}
+		};
+	}
+
 	getSourceOffsets(generatedOffset: number) {
 		return this.findMatching(generatedOffset, 'generatedOffsets', 'sourceOffsets');
 	}

--- a/packages/source-map/tests/sourceMap.spec.ts
+++ b/packages/source-map/tests/sourceMap.spec.ts
@@ -1,0 +1,162 @@
+import { describe, expect, test } from 'vitest';
+import { SourceMap } from '../lib/sourceMap';
+
+describe('sourceMap', () => {
+	test('Angular template', () => {
+		const map = new SourceMap([
+			{
+				sourceOffsets: [
+					`{{|data?.icon?.toString()}}`.indexOf('|'),
+					//  ^^^^
+				],
+				generatedOffsets: [
+					`(null as any ? ((null as any ? ((null as any ? (this.|data)!.icon : undefined)!.toString : undefined))!() : undefined)`.indexOf('|'),
+					//                                                     ^^^^
+				],
+				lengths: [
+					`data`.length,
+				],
+				data: {},
+			},
+			{
+				sourceOffsets: [
+					`{{data?.|icon?.toString()}}`.indexOf('|'),
+					//        ^^^^
+				],
+				generatedOffsets: [
+					`(null as any ? ((null as any ? ((null as any ? (this.data)!.|icon : undefined)!.toString : undefined))!() : undefined)`.indexOf('|'),
+					//                                                            ^^^^
+				],
+				lengths: [
+					`icon`.length,
+				],
+				data: {},
+			},
+			{
+				sourceOffsets: [
+					`{{data?.icon?.|toString()}}`.indexOf('|'),
+					//              ^^^^^^^^
+				],
+				generatedOffsets: [
+					`(null as any ? ((null as any ? ((null as any ? (this.data)!.icon : undefined)!.|toString : undefined))!() : undefined)`.indexOf('|'),
+					//                                                                               ^^^^^^^^
+				],
+				lengths: [
+					`toString`.length,
+				],
+				data: {},
+			},
+			{
+				sourceOffsets: [
+					`{{data?.icon?.|toString()}}`.indexOf('|'),
+					//                      ^^
+				],
+				generatedOffsets: [
+					`(null as any ? ((null as any ? ((null as any ? (this.data)!.icon : undefined)!.toString : undefined))!|() : undefined)`.indexOf('|'),
+					//                                                                                                      ^^
+				],
+				lengths: [
+					`()`.length,
+				],
+				data: {},
+			},
+			{
+				sourceOffsets: [
+					`{{|data?.icon?.toString()}}`.indexOf('|'),
+					// ^
+					`{{data?.icon|?.toString()}}`.indexOf('|'),
+					//           ^
+				],
+				generatedOffsets: [
+					`(null as any ? ((null as any ? (|(null as any ? (this.data)!.icon : undefined)!.toString : undefined))!() : undefined)`.indexOf('|'),
+					//                               ^
+					`(null as any ? ((null as any ? ((null as any ? (this.data)!.icon : undefined)|!.toString : undefined))!() : undefined)`.indexOf('|'),
+					//                                                                            ^
+				],
+				lengths: [0, 0],
+				data: {},
+			},
+			{
+				sourceOffsets: [
+					`{{|data?.icon?.toString()}}`.indexOf('|'),
+					// ^
+					`{{data?.icon?.toString|()}}`.indexOf('|'),
+					//                     ^
+				],
+				generatedOffsets: [
+					`(null as any ? (|(null as any ? ((null as any ? (this.data)!.icon : undefined)!.toString : undefined))!() : undefined)`.indexOf('|'),
+					//               ^
+					`(null as any ? ((null as any ? ((null as any ? (this.data)!.icon : undefined)!.toString : undefined))|!() : undefined)`.indexOf('|'),
+					//                                                                                                    ^
+				],
+				lengths: [0, 0],
+				data: {},
+			},
+			{
+				sourceOffsets: [
+					`{{|data?.icon?.toString()}}`.indexOf('|'),
+					// ^
+					`{{data?.icon?.toString()|}}`.indexOf('|'),
+					//                       ^
+				],
+				generatedOffsets: [
+					0,
+					`(null as any ? ((null as any ? ((null as any ? (this.data)!.icon : undefined)!.toString : undefined))!() : undefined)`.length,
+				],
+				lengths: [0, 0],
+				data: {},
+			},
+		]);
+
+		expect([...map.getGeneratedStartEnd(
+			`{{|data?.icon?.toString()}}`.indexOf('|'),
+			`{{data|?.icon?.toString()}}`.indexOf('|')
+		)].map(mapped => mapped.slice(0, 2))).toEqual([
+			[
+				`(null as any ? ((null as any ? ((null as any ? (this.|data)!.icon : undefined)!.toString : undefined))!() : undefined)`.indexOf('|'),
+				//                                                    ^
+				`(null as any ? ((null as any ? ((null as any ? (this.data|)!.icon : undefined)!.toString : undefined))!() : undefined)`.indexOf('|'),
+				//                                                        ^
+			],
+		]);
+
+		expect([...map.getGeneratedStartEnd(
+			`{{|data?.icon?.toString()}}`.indexOf('|'),
+			`{{data?.ic|on?.toString()}}`.indexOf('|')
+		)].map(mapped => mapped.slice(0, 2))).toEqual([]);
+
+		expect([...map.getGeneratedStartEnd(
+			`{{|data?.icon?.toString()}}`.indexOf('|'),
+			`{{data?.icon|?.toString()}}`.indexOf('|')
+		)].map(mapped => mapped.slice(0, 2))).toEqual([
+			[
+				`(null as any ? ((null as any ? (|(null as any ? (this.data)!.icon : undefined)!.toString : undefined))!() : undefined)`.indexOf('|'),
+				//                               ^
+				`(null as any ? ((null as any ? ((null as any ? (this.data)!.icon : undefined)|!.toString : undefined))!() : undefined)`.indexOf('|'),
+				//                                                                            ^
+			],
+		]);
+
+		expect([...map.getGeneratedStartEnd(
+			`{{|data?.icon?.toString()}}`.indexOf('|'),
+			`{{data?.icon?.toString|()}}`.indexOf('|')
+		)].map(mapped => mapped.slice(0, 2))).toEqual([
+			[
+				`(null as any ? (|(null as any ? ((null as any ? (this.data)!.icon : undefined)!.toString : undefined))!() : undefined)`.indexOf('|'),
+				//               ^
+				`(null as any ? ((null as any ? ((null as any ? (this.data)!.icon : undefined)!.toString : undefined))|!() : undefined)`.indexOf('|'),
+				//                                                                                                    ^
+			],
+		]);
+
+		expect([...map.getGeneratedStartEnd(
+			`{{|data?.icon?.toString()}}`.indexOf('|'),
+			`{{data?.icon?.toString()|}}`.indexOf('|')
+		)].map(mapped => mapped.slice(0, 2))).toEqual([
+			[
+				0,
+				`(null as any ? ((null as any ? ((null as any ? (this.data)!.icon : undefined)!.toString : undefined))!() : undefined)`.length,
+			],
+		]);
+	});
+});

--- a/packages/typescript/lib/node/transform.ts
+++ b/packages/typescript/lib/node/transform.ts
@@ -245,9 +245,25 @@ export function* toSourceRanges(
 ): Generator<[fileName: string, start: number, end: number]> {
 	if (sourceScript) {
 		const map = language.maps.get(serviceScript.code, sourceScript);
+		let mapped = false;
 		for (const [sourceStart, sourceEnd, mapping] of map.getSourceStartEnd(start - getMappingOffset(language, serviceScript), end - getMappingOffset(language, serviceScript))) {
 			if (filter(mapping.data)) {
+				mapped = true;
 				yield [sourceScript.id, sourceStart, sourceEnd];
+			}
+		}
+		if (!mapped) {
+			// fallback
+			for (const sourceStart of toSourceOffsets(sourceScript, language, serviceScript, start, filter)) {
+				for (const sourceEnd of toSourceOffsets(sourceScript, language, serviceScript, end, filter)) {
+					if (
+						sourceStart[0] === sourceEnd[0]
+						&& sourceEnd[1] >= sourceStart[1]
+					) {
+						yield [sourceStart[0], sourceStart[1], sourceEnd[1]];
+						break;
+					}
+				}
 			}
 		}
 	}
@@ -297,13 +313,25 @@ export function* toGeneratedRanges(
 	filter: (data: CodeInformation) => boolean
 ) {
 	const map = language.maps.get(serviceScript.code, sourceScript);
+	let mapped = false;
 	for (const [generateStart, generateEnd, mapping] of map.getGeneratedStartEnd(start, end)) {
 		if (filter(mapping.data)) {
+			mapped = true;
 			yield [
 				generateStart + getMappingOffset(language, serviceScript),
 				generateEnd + getMappingOffset(language, serviceScript),
-				mapping,
 			] as const;
+		}
+	}
+	if (!mapped) {
+		// fallback
+		for (const [generatedStart] of toGeneratedOffsets(language, serviceScript, sourceScript, start, filter)) {
+			for (const [generatedEnd] of toGeneratedOffsets(language, serviceScript, sourceScript, end, filter)) {
+				if (generatedEnd >= generatedStart) {
+					yield [generatedStart, generatedEnd] as const;
+					break;
+				}
+			}
 		}
 	}
 }


### PR DESCRIPTION
Add range mapping APIs (`getSourceStartEnd`, `getGeneratedStartEnd`), which will only try to map start, end positions from the same mapping item.

This is the range mapping behavior that was originally `@volar/language-service`, and is now moved into the `@volar/source-map` core so that it is also valid in the TS plugin.