### PR TITLE
refactor(language-core): pluginized source map factory function

### DIFF
--- a/packages/eslint/index.ts
+++ b/packages/eslint/index.ts
@@ -92,9 +92,9 @@ export function createProcessor(
 					messagesArr[i] = messagesArr[i].filter(message => {
 						const start = embeddedDocument.offsetAt({ line: message.line - 1, character: message.column - 1 });
 						const end = embeddedDocument.offsetAt({ line: (message.endLine ?? message.line) - 1, character: (message.endColumn ?? message.column) - 1 });
-						for (const [sourceStart, mapping] of map.getSourceOffsets(start)) {
+						for (const [sourceStart, mapping] of map.toSourceLocation(start)) {
 							if (isDiagnosticsEnabled(mapping.data)) {
-								for (const [sourceEnd, mapping] of map.getSourceOffsets(end)) {
+								for (const [sourceEnd, mapping] of map.toSourceLocation(end)) {
 									if (isDiagnosticsEnabled(mapping.data)) {
 										const sourcePosition = sourceDocument.positionAt(sourceStart);
 										const sourceEndPosition = sourceDocument.positionAt(sourceEnd);

--- a/packages/language-core/lib/linkedCodeMap.ts
+++ b/packages/language-core/lib/linkedCodeMap.ts
@@ -2,10 +2,10 @@ import { SourceMap } from '@volar/source-map';
 
 export class LinkedCodeMap extends SourceMap<any> {
 	*getLinkedOffsets(start: number) {
-		for (const mapped of this.getGeneratedOffsets(start)) {
+		for (const mapped of this.toGeneratedLocation(start)) {
 			yield mapped[0];
 		}
-		for (const mapped of this.getSourceOffsets(start)) {
+		for (const mapped of this.toSourceLocation(start)) {
 			yield mapped[0];
 		}
 	}

--- a/packages/language-core/lib/types.ts
+++ b/packages/language-core/lib/types.ts
@@ -1,8 +1,19 @@
-import type { Mapping, SourceMap } from '@volar/source-map';
+import type { Mapping } from '@volar/source-map';
 import type * as ts from 'typescript';
 import type { LinkedCodeMap } from './linkedCodeMap';
 
+export interface Mapper {
+	mappings: Mapping<CodeInformation>[];
+	toSourceRange(start: number, end: number, fallbackToAnyMatch: boolean, filter?: (data: CodeInformation) => boolean): Generator<readonly [number, number, Mapping<CodeInformation>, Mapping<CodeInformation>]>;
+	toGeneratedRange(start: number, end: number, fallbackToAnyMatch: boolean, filter?: (data: CodeInformation) => boolean): Generator<readonly [number, number, Mapping<CodeInformation>, Mapping<CodeInformation>]>;
+	toSourceLocation(generatedOffset: number, filter?: (data: CodeInformation) => boolean): Generator<readonly [number, Mapping<CodeInformation>]>;
+	toGeneratedLocation(sourceOffset: number, filter?: (data: CodeInformation) => boolean): Generator<readonly [number, Mapping<CodeInformation>]>;
+}
+
+export type MapperFactory = (mappings: Mapping<CodeInformation>[]) => Mapper;
+
 export interface Language<T = unknown> {
+	mapperFactory: MapperFactory;
 	plugins: LanguagePlugin<T>[];
 	scripts: {
 		get(id: T): SourceScript<T> | undefined;
@@ -11,8 +22,8 @@ export interface Language<T = unknown> {
 		fromVirtualCode(virtualCode: VirtualCode): SourceScript<T>;
 	};
 	maps: {
-		get(virtualCode: VirtualCode, sourceScript: SourceScript<T>): SourceMap<CodeInformation>;
-		forEach(virtualCode: VirtualCode): Generator<[sourceScript: SourceScript<T>, map: SourceMap<CodeInformation>]>;
+		get(virtualCode: VirtualCode, sourceScript: SourceScript<T>): Mapper;
+		forEach(virtualCode: VirtualCode): Generator<[sourceScript: SourceScript<T>, map: Mapper]>;
 	};
 	linkedCodeMaps: {
 		get(virtualCode: VirtualCode): LinkedCodeMap | undefined;

--- a/packages/language-service/lib/features/provideAutoInsertSnippet.ts
+++ b/packages/language-service/lib/features/provideAutoInsertSnippet.ts
@@ -15,7 +15,7 @@ export function register(context: LanguageServiceContext) {
 			() => ({ selection, change }),
 			function* (docs) {
 				for (const mappedPosition of getGeneratedPositions(docs, selection, isAutoInsertEnabled)) {
-					for (const mapped of docs[2].getGeneratedOffsets(change.rangeOffset)) {
+					for (const mapped of docs[2].toGeneratedLocation(change.rangeOffset)) {
 						yield {
 							selection: mappedPosition,
 							change: {

--- a/packages/language-service/lib/features/provideDocumentFormattingEdits.ts
+++ b/packages/language-service/lib/features/provideDocumentFormattingEdits.ts
@@ -1,4 +1,4 @@
-import { SourceMap, SourceScript, VirtualCode, forEachEmbeddedCode, isFormattingEnabled } from '@volar/language-core';
+import { SourceScript, VirtualCode, forEachEmbeddedCode, isFormattingEnabled } from '@volar/language-core';
 import type * as ts from 'typescript';
 import type * as vscode from 'vscode-languageserver-protocol';
 import { TextDocument } from 'vscode-languageserver-textdocument';
@@ -250,7 +250,6 @@ export function register(context: LanguageServiceContext) {
 	};
 
 	function createDocMap(virtualCode: VirtualCode, documentUri: URI, sourceLanguageId: string, _sourceSnapshot: ts.IScriptSnapshot): DocumentsAndMap {
-		const map = new SourceMap(virtualCode.mappings);
 		const version = fakeVersion++;
 		return [
 			TextDocument.create(
@@ -265,7 +264,7 @@ export function register(context: LanguageServiceContext) {
 				version,
 				virtualCode.snapshot.getText(0, virtualCode.snapshot.getLength())
 			),
-			map,
+			context.language.mapperFactory(virtualCode.mappings),
 		];
 	}
 }

--- a/packages/language-service/lib/utils/common.ts
+++ b/packages/language-service/lib/utils/common.ts
@@ -1,23 +1,23 @@
+import type { CodeInformation, Mapper } from '@volar/language-core';
 import type * as ts from 'typescript';
 import type * as vscode from 'vscode-languageserver-protocol';
-import type { CodeInformation, SourceMap } from '@volar/language-core';
 
 export function findOverlapCodeRange(
 	start: number,
 	end: number,
-	map: SourceMap<CodeInformation>,
+	map: Mapper,
 	filter: (data: CodeInformation) => boolean
 ) {
 	let mappedStart: number | undefined;
 	let mappedEnd: number | undefined;
 
-	for (const [mapped, mapping] of map.getGeneratedOffsets(start)) {
+	for (const [mapped, mapping] of map.toGeneratedLocation(start)) {
 		if (filter(mapping.data)) {
 			mappedStart = mapped;
 			break;
 		}
 	}
-	for (const [mapped, mapping] of map.getGeneratedOffsets(end)) {
+	for (const [mapped, mapping] of map.toGeneratedLocation(end)) {
 		if (filter(mapping.data)) {
 			mappedEnd = mapped;
 			break;

--- a/packages/language-service/lib/utils/featureWorkers.ts
+++ b/packages/language-service/lib/utils/featureWorkers.ts
@@ -1,4 +1,4 @@
-import type { CodeInformation, LinkedCodeMap, SourceMap, SourceScript, VirtualCode } from '@volar/language-core';
+import type { CodeInformation, LinkedCodeMap, Mapper, SourceScript, VirtualCode } from '@volar/language-core';
 import type * as vscode from 'vscode-languageserver-protocol';
 import type { TextDocument } from 'vscode-languageserver-textdocument';
 import type { URI } from 'vscode-uri';
@@ -7,7 +7,7 @@ import type { LanguageServiceContext, LanguageServicePlugin, LanguageServicePlug
 export type DocumentsAndMap = [
 	sourceDocument: TextDocument,
 	embeddedDocument: TextDocument,
-	map: SourceMap<CodeInformation>,
+	map: Mapper,
 ];
 
 export function documentFeatureWorker<T>(
@@ -197,7 +197,7 @@ export function getGeneratedRange(docs: DocumentsAndMap, range: vscode.Range, fi
 }
 
 export function* getSourceRanges([sourceDocument, embeddedDocument, map]: DocumentsAndMap, range: vscode.Range, filter?: (data: CodeInformation) => boolean) {
-	for (const [mappedStart, mappedEnd] of map.getSourceStartEnd(
+	for (const [mappedStart, mappedEnd] of map.toSourceRange(
 		embeddedDocument.offsetAt(range.start),
 		embeddedDocument.offsetAt(range.end),
 		true,
@@ -208,7 +208,7 @@ export function* getSourceRanges([sourceDocument, embeddedDocument, map]: Docume
 }
 
 export function* getGeneratedRanges([sourceDocument, embeddedDocument, map]: DocumentsAndMap, range: vscode.Range, filter?: (data: CodeInformation) => boolean) {
-	for (const [mappedStart, mappedEnd] of map.getGeneratedStartEnd(
+	for (const [mappedStart, mappedEnd] of map.toGeneratedRange(
 		sourceDocument.offsetAt(range.start),
 		sourceDocument.offsetAt(range.end),
 		true,
@@ -219,13 +219,13 @@ export function* getGeneratedRanges([sourceDocument, embeddedDocument, map]: Doc
 }
 
 export function* getSourcePositions([sourceDocument, embeddedDocument, map]: DocumentsAndMap, position: vscode.Position, filter: (data: CodeInformation) => boolean = () => true) {
-	for (const mapped of map.getSourceOffsets(embeddedDocument.offsetAt(position), filter)) {
+	for (const mapped of map.toSourceLocation(embeddedDocument.offsetAt(position), filter)) {
 		yield sourceDocument.positionAt(mapped[0]);
 	}
 }
 
 export function* getGeneratedPositions([sourceDocument, embeddedDocument, map]: DocumentsAndMap, position: vscode.Position, filter: (data: CodeInformation) => boolean = () => true) {
-	for (const mapped of map.getGeneratedOffsets(sourceDocument.offsetAt(position), filter)) {
+	for (const mapped of map.toGeneratedLocation(sourceDocument.offsetAt(position), filter)) {
 		yield embeddedDocument.positionAt(mapped[0]);
 	}
 }

--- a/packages/language-service/tests/findOverlapCodeRange.spec.ts
+++ b/packages/language-service/tests/findOverlapCodeRange.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { findOverlapCodeRange } from '../lib/utils/common';
-import { CodeInformation, Mapping, SourceMap } from '@volar/language-core';
+import { CodeInformation, Mapping, defaultMapperFactory } from '@volar/language-core';
 
 // test code: <html><body><p>Hello</p></body></html>
 
@@ -15,7 +15,7 @@ describe(`Test findOverlapCodeRange()`, () => {
 				data: {},
 			},
 		];
-		const map = new SourceMap(mappings);
+		const map = defaultMapperFactory(mappings);
 
 		expect(findOverlapCodeRange(0, 38, map, () => true)).toEqual({ start: 0, end: 38 });
 		expect(findOverlapCodeRange(6, 31, map, () => true)).toEqual({ start: 6, end: 31 });
@@ -30,7 +30,7 @@ describe(`Test findOverlapCodeRange()`, () => {
 				data: {},
 			},
 		];
-		const map = new SourceMap(mappings);
+		const map = defaultMapperFactory(mappings);
 
 		expect(findOverlapCodeRange(5, 32, map, () => true)).toEqual({ start: 6, end: 31 });
 		expect(findOverlapCodeRange(7, 32, map, () => true)).toEqual({ start: 7, end: 31 });
@@ -46,7 +46,7 @@ describe(`Test findOverlapCodeRange()`, () => {
 				data: {},
 			},
 		];
-		const map = new SourceMap(mappings);
+		const map = defaultMapperFactory(mappings);
 
 		expect(findOverlapCodeRange(5, 32, map, () => true)).toEqual({ start: 7, end: 32 });
 		expect(findOverlapCodeRange(7, 32, map, () => true)).toEqual({ start: 8, end: 32 });
@@ -63,7 +63,7 @@ describe(`Test findOverlapCodeRange()`, () => {
 				data: {},
 			},
 		];
-		const map = new SourceMap(mappings);
+		const map = defaultMapperFactory(mappings);
 
 		expect(findOverlapCodeRange(5, 32, map, () => true)).toEqual({ start: 7, end: 30 });
 		expect(findOverlapCodeRange(7, 32, map, () => true)).toEqual({ start: 8, end: 30 });
@@ -87,7 +87,7 @@ describe(`Test findOverlapCodeRange()`, () => {
 				data: {},
 			},
 		];
-		const map = new SourceMap(mappings);
+		const map = defaultMapperFactory(mappings);
 
 		expect(findOverlapCodeRange(0, 38, map, () => true)).toEqual({ start: 6, end: 33 });
 	});

--- a/packages/source-map/lib/sourceMap.ts
+++ b/packages/source-map/lib/sourceMap.ts
@@ -23,19 +23,19 @@ export class SourceMap<Data = unknown> {
 
 	constructor(public readonly mappings: Mapping<Data>[]) { }
 
-	getSourceStartEnd(generatedStart: number, generatedEnd: number, fallbackToAnyMatch: boolean, filter?: (data: Data) => boolean) {
+	toSourceRange(generatedStart: number, generatedEnd: number, fallbackToAnyMatch: boolean, filter?: (data: Data) => boolean) {
 		return this.findMatchingStartEnd(generatedStart, generatedEnd, fallbackToAnyMatch, 'generatedOffsets', filter);
 	}
 
-	getGeneratedStartEnd(sourceStart: number, sourceEnd: number, fallbackToAnyMatch: boolean, filter?: (data: Data) => boolean) {
+	toGeneratedRange(sourceStart: number, sourceEnd: number, fallbackToAnyMatch: boolean, filter?: (data: Data) => boolean) {
 		return this.findMatchingStartEnd(sourceStart, sourceEnd, fallbackToAnyMatch, 'sourceOffsets', filter);
 	}
 
-	getSourceOffsets(generatedOffset: number, filter?: (data: Data) => boolean) {
+	toSourceLocation(generatedOffset: number, filter?: (data: Data) => boolean) {
 		return this.findMatchingOffsets(generatedOffset, 'generatedOffsets', filter);
 	}
 
-	getGeneratedOffsets(sourceOffset: number, filter?: (data: Data) => boolean) {
+	toGeneratedLocation(sourceOffset: number, filter?: (data: Data) => boolean) {
 		return this.findMatchingOffsets(sourceOffset, 'sourceOffsets', filter);
 	}
 

--- a/packages/source-map/tests/sourceMap.spec.ts
+++ b/packages/source-map/tests/sourceMap.spec.ts
@@ -108,7 +108,7 @@ describe('sourceMap', () => {
 			},
 		]);
 
-		expect([...map.getGeneratedStartEnd(
+		expect([...map.toGeneratedRange(
 			`{{|data?.icon?.toString()}}`.indexOf('|'),
 			`{{data|?.icon?.toString()}}`.indexOf('|'),
 			false
@@ -121,13 +121,13 @@ describe('sourceMap', () => {
 			],
 		]);
 
-		expect([...map.getGeneratedStartEnd(
+		expect([...map.toGeneratedRange(
 			`{{|data?.icon?.toString()}}`.indexOf('|'),
 			`{{data?.ic|on?.toString()}}`.indexOf('|'),
 			false
 		)].map(mapped => mapped.slice(0, 2))).toEqual([]);
 
-		expect([...map.getGeneratedStartEnd(
+		expect([...map.toGeneratedRange(
 			`{{|data?.icon?.toString()}}`.indexOf('|'),
 			`{{data?.icon|?.toString()}}`.indexOf('|'),
 			false
@@ -140,7 +140,7 @@ describe('sourceMap', () => {
 			],
 		]);
 
-		expect([...map.getGeneratedStartEnd(
+		expect([...map.toGeneratedRange(
 			`{{|data?.icon?.toString()}}`.indexOf('|'),
 			`{{data?.icon?.toString|()}}`.indexOf('|'),
 			false
@@ -153,7 +153,7 @@ describe('sourceMap', () => {
 			],
 		]);
 
-		expect([...map.getGeneratedStartEnd(
+		expect([...map.toGeneratedRange(
 			`{{|data?.icon?.toString()}}`.indexOf('|'),
 			`{{data?.icon?.toString()|}}`.indexOf('|'),
 			false
@@ -193,13 +193,13 @@ describe('sourceMap', () => {
 			},
 		]);
 
-		expect([...map.getGeneratedStartEnd(
+		expect([...map.toGeneratedRange(
 			`{{|data?.icon?.toString()}}`.indexOf('|'),
 			`{{data?.icon|?.toString()}}`.indexOf('|'),
 			false
 		)].map(mapped => mapped.slice(0, 2))).toEqual([]);
 
-		expect([...map.getGeneratedStartEnd(
+		expect([...map.toGeneratedRange(
 			`{{|data?.icon?.toString()}}`.indexOf('|'),
 			`{{data?.icon|?.toString()}}`.indexOf('|'),
 			true

--- a/packages/test-utils/index.ts
+++ b/packages/test-utils/index.ts
@@ -1,10 +1,10 @@
+import { defaultMapperFactory, forEachEmbeddedCode } from '@volar/language-core';
 import * as _ from '@volar/language-server/node';
 import * as assert from 'assert';
 import * as cp from 'child_process';
 import * as fs from 'fs';
 import { TextDocument } from 'vscode-languageserver-textdocument';
 import { URI } from 'vscode-uri';
-import { SourceMap, forEachEmbeddedCode } from '@volar/language-core';
 
 export type LanguageServerHandle = ReturnType<typeof startLanguageServer>;
 
@@ -449,7 +449,7 @@ export function* printSnapshot(
 
 	let lineOffset = 0;
 
-	const map = new SourceMap(file.mappings);
+	const map = defaultMapperFactory(file.mappings);
 
 	for (let i = 0; i < virtualCodeLines.length; i++) {
 		const line = virtualCodeLines[i];
@@ -464,7 +464,7 @@ export function* printSnapshot(
 			length: number;
 		}[] = [];
 		for (let offset = 0; offset < line.length; offset++) {
-			for (const [sourceOffset, mapping] of map.getSourceOffsets(lineOffset + offset)) {
+			for (const [sourceOffset, mapping] of map.toSourceLocation(lineOffset + offset)) {
 				let log = logs.find(log => log.mapping === mapping && log.lineOffset + log.length + 1 === offset);
 				if (log) {
 					log.length++;

--- a/packages/typescript/lib/node/transform.ts
+++ b/packages/typescript/lib/node/transform.ts
@@ -245,7 +245,7 @@ export function* toSourceRanges(
 ): Generator<[fileName: string, start: number, end: number]> {
 	if (sourceScript) {
 		const map = language.maps.get(serviceScript.code, sourceScript);
-		for (const [sourceStart, sourceEnd] of map.getSourceStartEnd(
+		for (const [sourceStart, sourceEnd] of map.toSourceRange(
 			start - getMappingOffset(language, serviceScript),
 			end - getMappingOffset(language, serviceScript),
 			true,
@@ -256,7 +256,7 @@ export function* toSourceRanges(
 	}
 	else {
 		for (const [sourceScript, map] of language.maps.forEach(serviceScript.code)) {
-			for (const [sourceStart, sourceEnd] of map.getSourceStartEnd(
+			for (const [sourceStart, sourceEnd] of map.toSourceRange(
 				start - getMappingOffset(language, serviceScript),
 				end - getMappingOffset(language, serviceScript),
 				true,
@@ -277,7 +277,7 @@ export function* toSourceOffsets(
 ): Generator<[fileName: string, offset: number]> {
 	if (sourceScript) {
 		const map = language.maps.get(serviceScript.code, sourceScript);
-		for (const [sourceOffset, mapping] of map.getSourceOffsets(position - getMappingOffset(language, serviceScript))) {
+		for (const [sourceOffset, mapping] of map.toSourceLocation(position - getMappingOffset(language, serviceScript))) {
 			if (filter(mapping.data)) {
 				yield [sourceScript.id, sourceOffset];
 			}
@@ -285,7 +285,7 @@ export function* toSourceOffsets(
 	}
 	else {
 		for (const [sourceScript, map] of language.maps.forEach(serviceScript.code)) {
-			for (const [sourceOffset, mapping] of map.getSourceOffsets(position - getMappingOffset(language, serviceScript))) {
+			for (const [sourceOffset, mapping] of map.toSourceLocation(position - getMappingOffset(language, serviceScript))) {
 				if (filter(mapping.data)) {
 					yield [sourceScript.id, sourceOffset];
 				}
@@ -303,7 +303,7 @@ export function* toGeneratedRanges(
 	filter: (data: CodeInformation) => boolean
 ) {
 	const map = language.maps.get(serviceScript.code, sourceScript);
-	for (const [generateStart, generateEnd] of map.getGeneratedStartEnd(start, end, true, filter)) {
+	for (const [generateStart, generateEnd] of map.toGeneratedRange(start, end, true, filter)) {
 		yield [
 			generateStart + getMappingOffset(language, serviceScript),
 			generateEnd + getMappingOffset(language, serviceScript),
@@ -331,7 +331,7 @@ export function* toGeneratedOffsets(
 	filter: (data: CodeInformation) => boolean
 ) {
 	const map = language.maps.get(serviceScript.code, sourceScript);
-	for (const [generateOffset, mapping] of map.getGeneratedOffsets(position)) {
+	for (const [generateOffset, mapping] of map.toGeneratedLocation(position)) {
 		if (filter(mapping.data)) {
 			yield [generateOffset + getMappingOffset(language, serviceScript), mapping] as const;
 		}


### PR DESCRIPTION
Closes #203

Define the factory function of the source map through `Language.mapperFactory`, which allows the insertion of customized mapping logic.

## Motivation

Individual frameworks may require somewhat special mapping processing logic. For example, WebStorm-Angular requires special processing for overlapping mapping ranges. These processing may not be common to all frameworks, so it is best to make the mapping behavior itself customizable.

## Usage

After creating the Language instance, set `mapperFactory` property to override the default SourceMap factory function.

```ts
createLanguageServicePlugin((ts, info) => ({
	languagePlugins: [/* ... */],
	setup(language) {
		language.mapperFactory = mappings => new MySourceMap(mappings);
	},
});
```