### PR TITLE
fix(language-core): should re-export `SourceMap`

### DIFF
--- a/packages/language-core/index.ts
+++ b/packages/language-core/index.ts
@@ -1,4 +1,4 @@
-export { Mapping } from '@volar/source-map';
+export { Mapping, SourceMap } from '@volar/source-map';
 export * from './lib/editorFeatures';
 export * from './lib/linkedCodeMap';
 export * from './lib/types';


### PR DESCRIPTION
fix https://github.com/slidevjs/slidev/issues/1695.

#207 removed the re-exporting of `SourceMap` (https://github.com/volarjs/volar.js/pull/207/files#diff-9b91681a6cad2a7185ae1fa36e153880167c7081a2a664a52c279e3c7f89a52eL1), which should be a breaking change. However, because #207 has been published in a patch version, users installing the downstream packages like `twoslash-vue` and `slidev` will install the new version without being notified. This caused errors, which can only be fixed by overriding the dependencies manually.

This PR re-adds the re-exporting of `SourceMap`. I don't know whether it's good to re-export it, but I think it should be re-added until the next major (or at least minor) version.