### PR TITLE
refactor(language-server): respect server capabilities when register language features handlers

### DIFF
--- a/packages/language-server/lib/register/registerLanguageFeatures.ts
+++ b/packages/language-server/lib/register/registerLanguageFeatures.ts
@@ -5,6 +5,35 @@ import { AutoInsertRequest, FindFileReferenceRequest } from '../../protocol';
 import type { LanguageServer } from '../types';
 
 export function registerLanguageFeatures(server: LanguageServer) {
+	const {
+		documentFormattingProvider,
+		documentRangeFormattingProvider,
+		documentOnTypeFormattingProvider,
+		selectionRangeProvider,
+		foldingRangeProvider,
+		linkedEditingRangeProvider,
+		documentSymbolProvider,
+		colorProvider,
+		completionProvider,
+		hoverProvider,
+		signatureHelpProvider,
+		renameProvider,
+		codeLensProvider,
+		codeActionProvider,
+		referencesProvider,
+		implementationProvider,
+		definitionProvider,
+		typeDefinitionProvider,
+		documentHighlightProvider,
+		documentLinkProvider,
+		workspaceSymbolProvider,
+		callHierarchyProvider,
+		semanticTokensProvider,
+		diagnosticProvider,
+		inlayHintProvider,
+		experimental,
+	} = server.initializeResult.capabilities;
+
 	let lastCompleteUri: string;
 	let lastCompleteLs: LanguageService | undefined;
 	let lastCodeLensLs: LanguageService | undefined;
@@ -13,305 +42,378 @@ export function registerLanguageFeatures(server: LanguageServer) {
 	let lastDocumentLinkLs: LanguageService | undefined;
 	let lastInlayHintLs: LanguageService | undefined;
 
-	server.connection.onDocumentFormatting(async (params, token) => {
-		const uri = URI.parse(params.textDocument.uri);
-		return await worker(uri, token, languageService => {
-			return languageService.getDocumentFormattingEdits(uri, params.options, undefined, undefined, token);
+	if (documentFormattingProvider) {
+		server.connection.onDocumentFormatting(async (params, token) => {
+			const uri = URI.parse(params.textDocument.uri);
+			return await worker(uri, token, languageService => {
+				return languageService.getDocumentFormattingEdits(uri, params.options, undefined, undefined, token);
+			});
 		});
-	});
-	server.connection.onDocumentRangeFormatting(async (params, token) => {
-		const uri = URI.parse(params.textDocument.uri);
-		return await worker(uri, token, languageService => {
-			return languageService.getDocumentFormattingEdits(uri, params.options, params.range, undefined, token);
+	}
+	if (documentRangeFormattingProvider) {
+		server.connection.onDocumentRangeFormatting(async (params, token) => {
+			const uri = URI.parse(params.textDocument.uri);
+			return await worker(uri, token, languageService => {
+				return languageService.getDocumentFormattingEdits(uri, params.options, params.range, undefined, token);
+			});
 		});
-	});
-	server.connection.onDocumentOnTypeFormatting(async (params, token) => {
-		const uri = URI.parse(params.textDocument.uri);
-		return await worker(uri, token, languageService => {
-			return languageService.getDocumentFormattingEdits(uri, params.options, undefined, params, token);
+	}
+	if (documentOnTypeFormattingProvider) {
+		server.connection.onDocumentOnTypeFormatting(async (params, token) => {
+			const uri = URI.parse(params.textDocument.uri);
+			return await worker(uri, token, languageService => {
+				return languageService.getDocumentFormattingEdits(uri, params.options, undefined, params, token);
+			});
 		});
-	});
-	server.connection.onSelectionRanges(async (params, token) => {
-		const uri = URI.parse(params.textDocument.uri);
-		return await worker(uri, token, languageService => {
-			return languageService.getSelectionRanges(uri, params.positions, token);
+	}
+	if (selectionRangeProvider) {
+		server.connection.onSelectionRanges(async (params, token) => {
+			const uri = URI.parse(params.textDocument.uri);
+			return await worker(uri, token, languageService => {
+				return languageService.getSelectionRanges(uri, params.positions, token);
+			});
 		});
-	});
-	server.connection.onFoldingRanges(async (params, token) => {
-		const uri = URI.parse(params.textDocument.uri);
-		return await worker(uri, token, languageService => {
-			return languageService.getFoldingRanges(uri, token);
+	}
+	if (foldingRangeProvider) {
+		server.connection.onFoldingRanges(async (params, token) => {
+			const uri = URI.parse(params.textDocument.uri);
+			return await worker(uri, token, languageService => {
+				return languageService.getFoldingRanges(uri, token);
+			});
 		});
-	});
-	server.connection.languages.onLinkedEditingRange(async (params, token) => {
-		const uri = URI.parse(params.textDocument.uri);
-		return await worker(uri, token, languageService => {
-			return languageService.getLinkedEditingRanges(uri, params.position, token);
+	}
+	if (linkedEditingRangeProvider) {
+		server.connection.languages.onLinkedEditingRange(async (params, token) => {
+			const uri = URI.parse(params.textDocument.uri);
+			return await worker(uri, token, languageService => {
+				return languageService.getLinkedEditingRanges(uri, params.position, token);
+			});
 		});
-	});
-	server.connection.onDocumentSymbol(async (params, token) => {
-		const uri = URI.parse(params.textDocument.uri);
-		return await worker(uri, token, languageService => {
-			return languageService.getDocumentSymbols(uri, token);
+	}
+	if (documentSymbolProvider) {
+		server.connection.onDocumentSymbol(async (params, token) => {
+			const uri = URI.parse(params.textDocument.uri);
+			return await worker(uri, token, languageService => {
+				return languageService.getDocumentSymbols(uri, token);
+			});
 		});
-	});
-	server.connection.onDocumentColor(async (params, token) => {
-		const uri = URI.parse(params.textDocument.uri);
-		return await worker(uri, token, languageService => {
-			return languageService.getDocumentColors(uri, token);
+	}
+	if (colorProvider) {
+		server.connection.onDocumentColor(async (params, token) => {
+			const uri = URI.parse(params.textDocument.uri);
+			return await worker(uri, token, languageService => {
+				return languageService.getDocumentColors(uri, token);
+			});
 		});
-	});
-	server.connection.onColorPresentation(async (params, token) => {
-		const uri = URI.parse(params.textDocument.uri);
-		return await worker(uri, token, languageService => {
-			return languageService.getColorPresentations(uri, params.color, params.range, token);
+		server.connection.onColorPresentation(async (params, token) => {
+			const uri = URI.parse(params.textDocument.uri);
+			return await worker(uri, token, languageService => {
+				return languageService.getColorPresentations(uri, params.color, params.range, token);
+			});
 		});
-	});
-
-	server.connection.onCompletion(async (params, token) => {
-		const uri = URI.parse(params.textDocument.uri);
-		return await worker(uri, token, async languageService => {
-			lastCompleteUri = params.textDocument.uri;
-			lastCompleteLs = languageService;
-			const list = await languageService.getCompletionItems(
-				uri,
-				params.position,
-				params.context,
-				token
-			);
-			for (const item of list.items) {
+	}
+	if (completionProvider) {
+		server.connection.onCompletion(async (params, token) => {
+			const uri = URI.parse(params.textDocument.uri);
+			return await worker(uri, token, async languageService => {
+				lastCompleteUri = params.textDocument.uri;
+				lastCompleteLs = languageService;
+				const list = await languageService.getCompletionItems(
+					uri,
+					params.position,
+					params.context,
+					token
+				);
+				for (const item of list.items) {
+					fixTextEdit(item);
+				}
+				return list;
+			});
+		});
+	}
+	if (completionProvider?.resolveProvider) {
+		server.connection.onCompletionResolve(async (item, token) => {
+			if (lastCompleteUri && lastCompleteLs) {
+				item = await lastCompleteLs.resolveCompletionItem(item, token);
 				fixTextEdit(item);
 			}
-			return list;
+			return item;
 		});
-	});
-	server.connection.onCompletionResolve(async (item, token) => {
-		if (lastCompleteUri && lastCompleteLs) {
-			item = await lastCompleteLs.resolveCompletionItem(item, token);
-			fixTextEdit(item);
-		}
-		return item;
-	});
-	server.connection.onHover(async (params, token) => {
-		const uri = URI.parse(params.textDocument.uri);
-		return await worker(uri, token, languageService => {
-			return languageService.getHover(uri, params.position, token);
+	}
+	if (hoverProvider) {
+		server.connection.onHover(async (params, token) => {
+			const uri = URI.parse(params.textDocument.uri);
+			return await worker(uri, token, languageService => {
+				return languageService.getHover(uri, params.position, token);
+			});
 		});
-	});
-	server.connection.onSignatureHelp(async (params, token) => {
-		const uri = URI.parse(params.textDocument.uri);
-		return await worker(uri, token, languageService => {
-			return languageService.getSignatureHelp(uri, params.position, params.context, token);
+	}
+	if (signatureHelpProvider) {
+		server.connection.onSignatureHelp(async (params, token) => {
+			const uri = URI.parse(params.textDocument.uri);
+			return await worker(uri, token, languageService => {
+				return languageService.getSignatureHelp(uri, params.position, params.context, token);
+			});
 		});
-	});
-	server.connection.onPrepareRename(async (params, token) => {
-		const uri = URI.parse(params.textDocument.uri);
-		return await worker(uri, token, async languageService => {
-			const result = await languageService.getRenameRange(uri, params.position, token);
-			if (result && 'message' in result) {
-				return new vscode.ResponseError(0, result.message);
-			}
-			return result;
+	}
+	if (renameProvider) {
+		server.connection.onRenameRequest(async (params, token) => {
+			const uri = URI.parse(params.textDocument.uri);
+			return await worker(uri, token, languageService => {
+				return languageService.getRenameEdits(uri, params.position, params.newName, token);
+			});
 		});
-	});
-	server.connection.onRenameRequest(async (params, token) => {
-		const uri = URI.parse(params.textDocument.uri);
-		return await worker(uri, token, languageService => {
-			return languageService.getRenameEdits(uri, params.position, params.newName, token);
-		});
-	});
-	server.connection.onCodeLens(async (params, token) => {
-		const uri = URI.parse(params.textDocument.uri);
-		return await worker(uri, token, languageService => {
-			lastCodeLensLs = languageService;
-			return languageService.getCodeLenses(uri, token);
-		});
-	});
-	server.connection.onCodeLensResolve(async (codeLens, token) => {
-		return await lastCodeLensLs?.resolveCodeLens(codeLens, token) ?? codeLens;
-	});
-	server.connection.onCodeAction(async (params, token) => {
-		const uri = URI.parse(params.textDocument.uri);
-		return await worker(uri, token, async languageService => {
-			lastCodeActionLs = languageService;
-			let codeActions = await languageService.getCodeActions(uri, params.range, params.context, token) ?? [];
-			for (const codeAction of codeActions) {
-				if (codeAction.data && typeof codeAction.data === 'object') {
-					(codeAction.data as any).uri = params.textDocument.uri;
+	}
+	if (typeof renameProvider === 'object' && renameProvider.prepareProvider) {
+		server.connection.onPrepareRename(async (params, token) => {
+			const uri = URI.parse(params.textDocument.uri);
+			return await worker(uri, token, async languageService => {
+				const result = await languageService.getRenameRange(uri, params.position, token);
+				if (result && 'message' in result) {
+					return new vscode.ResponseError(0, result.message);
 				}
-				else {
-					codeAction.data = { uri: params.textDocument.uri };
+				return result;
+			});
+		});
+	}
+	if (codeLensProvider) {
+		server.connection.onCodeLens(async (params, token) => {
+			const uri = URI.parse(params.textDocument.uri);
+			return await worker(uri, token, languageService => {
+				lastCodeLensLs = languageService;
+				return languageService.getCodeLenses(uri, token);
+			});
+		});
+	}
+	if (codeLensProvider?.resolveProvider) {
+		server.connection.onCodeLensResolve(async (codeLens, token) => {
+			return await lastCodeLensLs?.resolveCodeLens(codeLens, token) ?? codeLens;
+		});
+	}
+	if (codeActionProvider) {
+		server.connection.onCodeAction(async (params, token) => {
+			const uri = URI.parse(params.textDocument.uri);
+			return await worker(uri, token, async languageService => {
+				lastCodeActionLs = languageService;
+				let codeActions = await languageService.getCodeActions(uri, params.range, params.context, token) ?? [];
+				for (const codeAction of codeActions) {
+					if (codeAction.data && typeof codeAction.data === 'object') {
+						(codeAction.data as any).uri = params.textDocument.uri;
+					}
+					else {
+						codeAction.data = { uri: params.textDocument.uri };
+					}
 				}
+				if (!server.initializeParams?.capabilities.textDocument?.codeAction?.disabledSupport) {
+					codeActions = codeActions.filter(codeAction => !codeAction.disabled);
+				}
+				return codeActions;
+			});
+		});
+	}
+	if (typeof codeActionProvider === 'object' && codeActionProvider.resolveProvider) {
+		server.connection.onCodeActionResolve(async (codeAction, token) => {
+			return await lastCodeActionLs?.resolveCodeAction(codeAction, token) ?? codeAction;
+		});
+	}
+	if (referencesProvider) {
+		server.connection.onReferences(async (params, token) => {
+			const uri = URI.parse(params.textDocument.uri);
+			return await worker(uri, token, languageService => {
+				return languageService.getReferences(uri, params.position, { includeDeclaration: true }, token);
+			});
+		});
+	}
+	if (implementationProvider) {
+		server.connection.onImplementation(async (params, token) => {
+			const uri = URI.parse(params.textDocument.uri);
+			return await worker(uri, token, languageService => {
+				return languageService.getImplementations(uri, params.position, token);
+			});
+		});
+	}
+	if (definitionProvider) {
+		server.connection.onDefinition(async (params, token) => {
+			const uri = URI.parse(params.textDocument.uri);
+			return await worker(uri, token, languageService => {
+				return languageService.getDefinition(uri, params.position, token);
+			});
+		});
+	}
+	if (typeDefinitionProvider) {
+		server.connection.onTypeDefinition(async (params, token) => {
+			const uri = URI.parse(params.textDocument.uri);
+			return await worker(uri, token, languageService => {
+				return languageService.getTypeDefinition(uri, params.position, token);
+			});
+		});
+	}
+	if (documentHighlightProvider) {
+		server.connection.onDocumentHighlight(async (params, token) => {
+			const uri = URI.parse(params.textDocument.uri);
+			return await worker(uri, token, languageService => {
+				return languageService.getDocumentHighlights(uri, params.position, token);
+			});
+		});
+	}
+	if (documentLinkProvider) {
+		server.connection.onDocumentLinks(async (params, token) => {
+			const uri = URI.parse(params.textDocument.uri);
+			return await worker(uri, token, languageService => {
+				lastDocumentLinkLs = languageService;
+				return languageService.getDocumentLinks(uri, token);
+			});
+		});
+	}
+	if (documentLinkProvider?.resolveProvider) {
+		server.connection.onDocumentLinkResolve(async (link, token) => {
+			return await lastDocumentLinkLs?.resolveDocumentLink(link, token);
+		});
+	}
+	if (workspaceSymbolProvider) {
+		server.connection.onWorkspaceSymbol(async (params, token) => {
+			let results: vscode.WorkspaceSymbol[] = [];
+			for (const languageService of await server.project.getExistingLanguageServices()) {
+				if (token.isCancellationRequested) {
+					return;
+				}
+				results = results.concat(await languageService.getWorkspaceSymbols(params.query, token));
 			}
-			if (!server.initializeParams?.capabilities.textDocument?.codeAction?.disabledSupport) {
-				codeActions = codeActions.filter(codeAction => !codeAction.disabled);
-			}
-			return codeActions;
+			return results;
 		});
-	});
-	server.connection.onCodeActionResolve(async (codeAction, token) => {
-		return await lastCodeActionLs?.resolveCodeAction(codeAction, token) ?? codeAction;
-	});
-	server.connection.onReferences(async (params, token) => {
-		const uri = URI.parse(params.textDocument.uri);
-		return await worker(uri, token, languageService => {
-			return languageService.getReferences(uri, params.position, { includeDeclaration: true }, token);
+	}
+	if (typeof workspaceSymbolProvider === 'object' && workspaceSymbolProvider.resolveProvider) {
+		// TODO: onWorkspaceSymbolResolve
+	}
+	if (callHierarchyProvider) {
+		server.connection.languages.callHierarchy.onPrepare(async (params, token) => {
+			const uri = URI.parse(params.textDocument.uri);
+			return await worker(uri, token, languageService => {
+				lastCallHierarchyLs = languageService;
+				return languageService.getCallHierarchyItems(uri, params.position, token);
+			}) ?? [];
 		});
-	});
-	server.connection.onRequest(FindFileReferenceRequest.type, async (params, token) => {
-		const uri = URI.parse(params.textDocument.uri);
-		return await worker(uri, token, languageService => {
-			return languageService.getFileReferences(uri, token);
+		server.connection.languages.callHierarchy.onIncomingCalls(async (params, token) => {
+			return await lastCallHierarchyLs?.getCallHierarchyIncomingCalls(params.item, token) ?? [];
 		});
-	});
-	server.connection.onImplementation(async (params, token) => {
-		const uri = URI.parse(params.textDocument.uri);
-		return await worker(uri, token, languageService => {
-			return languageService.getImplementations(uri, params.position, token);
+		server.connection.languages.callHierarchy.onOutgoingCalls(async (params, token) => {
+			return await lastCallHierarchyLs?.getCallHierarchyOutgoingCalls(params.item, token) ?? [];
 		});
-	});
-	server.connection.onDefinition(async (params, token) => {
-		const uri = URI.parse(params.textDocument.uri);
-		return await worker(uri, token, languageService => {
-			return languageService.getDefinition(uri, params.position, token);
+	}
+	if (semanticTokensProvider?.full) {
+		server.connection.languages.semanticTokens.on(async (params, token, _, resultProgress) => {
+			const uri = URI.parse(params.textDocument.uri);
+			return await worker(uri, token, async languageService => {
+				return await languageService?.getSemanticTokens(
+					uri,
+					undefined,
+					server.initializeResult.capabilities.semanticTokensProvider!.legend,
+					token,
+					tokens => resultProgress?.report(tokens)
+				);
+			}) ?? { data: [] };
 		});
-	});
-	server.connection.onTypeDefinition(async (params, token) => {
-		const uri = URI.parse(params.textDocument.uri);
-		return await worker(uri, token, languageService => {
-			return languageService.getTypeDefinition(uri, params.position, token);
+	}
+	if (semanticTokensProvider?.range) {
+		server.connection.languages.semanticTokens.onRange(async (params, token, _, resultProgress) => {
+			const uri = URI.parse(params.textDocument.uri);
+			return await worker(uri, token, async languageService => {
+				return await languageService?.getSemanticTokens(
+					uri,
+					params.range,
+					server.initializeResult.capabilities.semanticTokensProvider!.legend,
+					token,
+					tokens => resultProgress?.report(tokens)
+				);
+			}) ?? { data: [] };
 		});
-	});
-	server.connection.onDocumentHighlight(async (params, token) => {
-		const uri = URI.parse(params.textDocument.uri);
-		return await worker(uri, token, languageService => {
-			return languageService.getDocumentHighlights(uri, params.position, token);
-		});
-	});
-	server.connection.onDocumentLinks(async (params, token) => {
-		const uri = URI.parse(params.textDocument.uri);
-		return await worker(uri, token, languageService => {
-			lastDocumentLinkLs = languageService;
-			return languageService.getDocumentLinks(uri, token);
-		});
-	});
-	server.connection.onDocumentLinkResolve(async (link, token) => {
-		return await lastDocumentLinkLs?.resolveDocumentLink(link, token);
-	});
-	server.connection.onWorkspaceSymbol(async (params, token) => {
-		let results: vscode.WorkspaceSymbol[] = [];
-		for (const languageService of await server.project.getExistingLanguageServices()) {
-			if (token.isCancellationRequested) {
-				return;
-			}
-			results = results.concat(await languageService.getWorkspaceSymbols(params.query, token));
-		}
-		return results;
-	});
-	// TODO: onWorkspaceSymbolResolve
-	server.connection.languages.callHierarchy.onPrepare(async (params, token) => {
-		const uri = URI.parse(params.textDocument.uri);
-		return await worker(uri, token, languageService => {
-			lastCallHierarchyLs = languageService;
-			return languageService.getCallHierarchyItems(uri, params.position, token);
-		}) ?? [];
-	});
-	server.connection.languages.callHierarchy.onIncomingCalls(async (params, token) => {
-		return await lastCallHierarchyLs?.getCallHierarchyIncomingCalls(params.item, token) ?? [];
-	});
-	server.connection.languages.callHierarchy.onOutgoingCalls(async (params, token) => {
-		return await lastCallHierarchyLs?.getCallHierarchyOutgoingCalls(params.item, token) ?? [];
-	});
-	server.connection.languages.semanticTokens.on(async (params, token, _, resultProgress) => {
-		const uri = URI.parse(params.textDocument.uri);
-		return await worker(uri, token, async languageService => {
-			return await languageService?.getSemanticTokens(
-				uri,
-				undefined,
-				server.initializeResult.capabilities.semanticTokensProvider!.legend,
-				token,
-				tokens => resultProgress?.report(tokens)
-			);
-		}) ?? { data: [] };
-	});
-	server.connection.languages.semanticTokens.onRange(async (params, token, _, resultProgress) => {
-		const uri = URI.parse(params.textDocument.uri);
-		return await worker(uri, token, async languageService => {
-			return await languageService?.getSemanticTokens(
-				uri,
-				params.range,
-				server.initializeResult.capabilities.semanticTokensProvider!.legend,
-				token,
-				tokens => resultProgress?.report(tokens)
-			);
-		}) ?? { data: [] };
-	});
-	server.connection.languages.diagnostics.on(async (params, token, _workDoneProgressReporter, resultProgressReporter) => {
-		const uri = URI.parse(params.textDocument.uri);
-		const result = await worker(uri, token, languageService => {
-			return languageService.getDiagnostics(
-				uri,
-				token,
-				errors => {
-					// resultProgressReporter is undefined in vscode
-					resultProgressReporter?.report({
-						relatedDocuments: {
-							[params.textDocument.uri]: {
-								kind: vscode.DocumentDiagnosticReportKind.Full,
-								items: errors,
+	}
+	if (diagnosticProvider) {
+		server.connection.languages.diagnostics.on(async (params, token, _workDoneProgressReporter, resultProgressReporter) => {
+			const uri = URI.parse(params.textDocument.uri);
+			const result = await worker(uri, token, languageService => {
+				return languageService.getDiagnostics(
+					uri,
+					token,
+					errors => {
+						// resultProgressReporter is undefined in vscode
+						resultProgressReporter?.report({
+							relatedDocuments: {
+								[params.textDocument.uri]: {
+									kind: vscode.DocumentDiagnosticReportKind.Full,
+									items: errors,
+								},
 							},
-						},
-					});
+						});
+					}
+				);
+			});
+			return {
+				kind: vscode.DocumentDiagnosticReportKind.Full,
+				items: result ?? [],
+			};
+		});
+	}
+	if (diagnosticProvider?.workspaceDiagnostics) {
+		server.connection.languages.diagnostics.onWorkspace(async (_params, token) => {
+			const items: vscode.WorkspaceDocumentDiagnosticReport[] = [];
+			for (const languageService of await server.project.getExistingLanguageServices()) {
+				if (token.isCancellationRequested) {
+					break;
 				}
-			);
-		});
-		return {
-			kind: vscode.DocumentDiagnosticReportKind.Full,
-			items: result ?? [],
-		};
-	});
-	server.connection.languages.diagnostics.onWorkspace(async (_params, token) => {
-		const items: vscode.WorkspaceDocumentDiagnosticReport[] = [];
-		for (const languageService of await server.project.getExistingLanguageServices()) {
-			if (token.isCancellationRequested) {
-				break;
+				const result = await languageService.getWorkspaceDiagnostics(token);
+				items.push(...result);
 			}
-			const result = await languageService.getWorkspaceDiagnostics(token);
-			items.push(...result);
-		}
-		return { items };
-	});
-	server.connection.languages.inlayHint.on(async (params, token) => {
-		const uri = URI.parse(params.textDocument.uri);
-		return await worker(uri, token, languageService => {
-			lastInlayHintLs = languageService;
-			return languageService.getInlayHints(uri, params.range, token);
+			return { items };
 		});
-	});
-	server.connection.languages.inlayHint.resolve(async (hint, token) => {
-		return await lastInlayHintLs?.resolveInlayHint(hint, token) ?? hint;
-	});
-	server.connection.workspace.onWillRenameFiles(async (params, token) => {
-		const _edits = await Promise.all(params.files.map(async file => {
-			const oldUri = URI.parse(file.oldUri);
-			const newUri = URI.parse(file.newUri);
-			return await worker(oldUri, token, languageService => {
-				return languageService.getFileRenameEdits(oldUri, newUri, token) ?? null;
-			}) ?? null;
-		}));
-		const edits = _edits.filter((edit): edit is NonNullable<typeof edit> => !!edit);
-		if (edits.length) {
-			mergeWorkspaceEdits(edits[0], ...edits.slice(1));
-			return edits[0];
-		}
-		return null;
-	});
-	server.connection.onRequest(AutoInsertRequest.type, async (params, token) => {
-		const uri = URI.parse(params.textDocument.uri);
-		return await worker(uri, token, languageService => {
-			return languageService.getAutoInsertSnippet(uri, params.selection, params.change, token);
+	}
+	if (inlayHintProvider) {
+		server.connection.languages.inlayHint.on(async (params, token) => {
+			const uri = URI.parse(params.textDocument.uri);
+			return await worker(uri, token, languageService => {
+				lastInlayHintLs = languageService;
+				return languageService.getInlayHints(uri, params.range, token);
+			});
 		});
-	});
+	}
+	if (typeof inlayHintProvider === 'object' && inlayHintProvider.resolveProvider) {
+		server.connection.languages.inlayHint.resolve(async (hint, token) => {
+			return await lastInlayHintLs?.resolveInlayHint(hint, token) ?? hint;
+		});
+	}
+	if (experimental?.fileRenameProvider) {
+		server.connection.workspace.onWillRenameFiles(async (params, token) => {
+			const _edits = await Promise.all(params.files.map(async file => {
+				const oldUri = URI.parse(file.oldUri);
+				const newUri = URI.parse(file.newUri);
+				return await worker(oldUri, token, languageService => {
+					return languageService.getFileRenameEdits(oldUri, newUri, token) ?? null;
+				}) ?? null;
+			}));
+			const edits = _edits.filter((edit): edit is NonNullable<typeof edit> => !!edit);
+			if (edits.length) {
+				mergeWorkspaceEdits(edits[0], ...edits.slice(1));
+				return edits[0];
+			}
+			return null;
+		});
+	}
+	if (experimental?.autoInsertionProvider) {
+		server.connection.onRequest(AutoInsertRequest.type, async (params, token) => {
+			const uri = URI.parse(params.textDocument.uri);
+			return await worker(uri, token, languageService => {
+				return languageService.getAutoInsertSnippet(uri, params.selection, params.change, token);
+			});
+		});
+	}
+	if (experimental?.fileReferencesProvider) {
+		server.connection.onRequest(FindFileReferenceRequest.type, async (params, token) => {
+			const uri = URI.parse(params.textDocument.uri);
+			return await worker(uri, token, languageService => {
+				return languageService.getFileReferences(uri, token);
+			});
+		});
+	}
 
 	function worker<T>(uri: URI, token: vscode.CancellationToken, cb: (languageService: LanguageService) => T) {
 		return new Promise<T | undefined>(resolve => {

--- a/packages/language-server/lib/server.ts
+++ b/packages/language-server/lib/server.ts
@@ -221,22 +221,31 @@ export function createServerBase(
 					}
 				}
 			}
-			status.initializeResult.autoInsertion = {
+			status.initializeResult.capabilities.experimental ??= {};
+			status.initializeResult.capabilities.experimental.autoInsertionProvider = {
 				triggerCharacters: [],
 				configurationSections: [],
 			};
 			for (const [char, sections] of triggerCharacterToConfigurationSections) {
 				if (sections.size) {
-					for (const section of sections) {
-						status.initializeResult.autoInsertion.triggerCharacters.push(char);
-						status.initializeResult.autoInsertion.configurationSections.push(section);
-					}
+					status.initializeResult.capabilities.experimental.autoInsertionProvider.triggerCharacters.push(char);
+					status.initializeResult.capabilities.experimental.autoInsertionProvider.configurationSections!.push([...sections]);
 				}
 				else {
-					status.initializeResult.autoInsertion.triggerCharacters.push(char);
-					status.initializeResult.autoInsertion.configurationSections.push(null);
+					status.initializeResult.autoInsertionProvider.triggerCharacters.push(char);
+					status.initializeResult.autoInsertionProvider.configurationSections.push(null);
 				}
 			}
+		}
+
+		if (capabilitiesArr.some(data => data.fileRenameProvider)) {
+			status.initializeResult.capabilities.experimental ??= {};
+			status.initializeResult.capabilities.experimental.fileRenameProvider = true;
+		}
+
+		if (capabilitiesArr.some(data => data.fileReferencesProvider)) {
+			status.initializeResult.capabilities.experimental ??= {};
+			status.initializeResult.capabilities.experimental.fileReferencesProvider = true;
 		}
 
 		return status.initializeResult;

--- a/packages/language-server/lib/types.ts
+++ b/packages/language-server/lib/types.ts
@@ -11,9 +11,11 @@ export interface LanguageServerProject {
 
 export type LanguageServer = ReturnType<typeof createServerBase>;
 
-export interface VolarInitializeResult extends InitializeResult {
-	autoInsertion?: {
+export interface VolarInitializeResult extends InitializeResult<{
+	fileReferencesProvider?: boolean;
+	fileRenameProvider?: boolean;
+	autoInsertionProvider?: {
 		triggerCharacters: string[];
-		configurationSections: (string | null)[];
+		configurationSections?: (string[] | null)[];
 	};
-};
+}> { }

--- a/packages/language-service/lib/types.ts
+++ b/packages/language-service/lib/types.ts
@@ -135,6 +135,8 @@ export interface LanguageServicePlugin<P = any> {
 		diagnosticProvider?: {
 			workspaceDiagnostics?: boolean;
 		};
+		fileReferencesProvider?: boolean;
+		fileRenameProvider?: boolean;
 	};
 	create(context: LanguageServiceContext): LanguageServicePluginInstance<P>;
 }


### PR DESCRIPTION
Language features handlers should be registered with respect to language server capabilities. This can avoid unnecessary registration and go some way to solving the problem of hidden side effects discovered by @Andarist.

Additionally, the refactoring mentioned at https://github.com/mdx-js/mdx-analyzer/pull/446#discussion_r1632408332 was also implemented.