### PR TITLE
feat(language-service): add support for workspace symbol resolve

### DIFF
--- a/packages/language-server/lib/server.ts
+++ b/packages/language-server/lib/server.ts
@@ -129,7 +129,9 @@ export function createServerBase(
 			callHierarchyProvider: capabilitiesArr.some(data => data.callHierarchyProvider) || undefined,
 			hoverProvider: capabilitiesArr.some(data => data.hoverProvider) || undefined,
 			documentHighlightProvider: capabilitiesArr.some(data => data.documentHighlightProvider) || undefined,
-			workspaceSymbolProvider: capabilitiesArr.some(data => data.workspaceSymbolProvider) || undefined,
+			workspaceSymbolProvider: capabilitiesArr.some(data => data.workspaceSymbolProvider)
+				? { resolveProvider: capabilitiesArr.some(data => data.workspaceSymbolProvider?.resolveProvider) || undefined }
+				: undefined,
 			renameProvider: capabilitiesArr.some(data => data.renameProvider)
 				? { prepareProvider: capabilitiesArr.some(data => data.renameProvider?.prepareProvider) || undefined }
 				: undefined,
@@ -144,7 +146,6 @@ export function createServerBase(
 				: undefined,
 			signatureHelpProvider: capabilitiesArr.some(data => data.signatureHelpProvider)
 				? {
-
 					triggerCharacters: [...new Set(capabilitiesArr.map(data => data.signatureHelpProvider?.triggerCharacters ?? []).flat())],
 					retriggerCharacters: [...new Set(capabilitiesArr.map(data => data.signatureHelpProvider?.retriggerCharacters ?? []).flat())],
 				}

--- a/packages/language-service/lib/features/provideWorkspaceSymbols.ts
+++ b/packages/language-service/lib/features/provideWorkspaceSymbols.ts
@@ -5,6 +5,11 @@ import { NoneCancellationToken } from '../utils/cancellation';
 import { DocumentsAndMap, getSourceRange } from '../utils/featureWorkers';
 import { transformWorkspaceSymbol } from '../utils/transform';
 
+export interface WorkspaceSymbolData {
+	original: Pick<vscode.WorkspaceSymbol, 'data'>;
+	pluginIndex: number;
+}
+
 export function register(context: LanguageServiceContext) {
 
 	return async (query: string, token = NoneCancellationToken) => {
@@ -52,6 +57,15 @@ export function register(context: LanguageServiceContext) {
 					}
 				}))
 				.filter(symbol => !!symbol);
+
+			symbols?.forEach(symbol => {
+				symbol.data = {
+					original: {
+						data: symbol.data,
+					},
+					pluginIndex: context.plugins.indexOf(plugin),
+				} satisfies WorkspaceSymbolData;
+			});
 
 			symbolsList.push(symbols);
 		}

--- a/packages/language-service/lib/features/resolveWorkspaceSymbol.ts
+++ b/packages/language-service/lib/features/resolveWorkspaceSymbol.ts
@@ -1,0 +1,23 @@
+import type * as vscode from 'vscode-languageserver-protocol';
+import type { LanguageServiceContext } from '../types';
+import type { WorkspaceSymbolData } from './provideWorkspaceSymbols';
+import { NoneCancellationToken } from '../utils/cancellation';
+
+export function register(context: LanguageServiceContext) {
+
+	return async (symbol: vscode.WorkspaceSymbol, token = NoneCancellationToken) => {
+
+		const data: WorkspaceSymbolData | undefined = symbol.data;
+		if (data) {
+			const plugin = context.plugins[data.pluginIndex];
+			if (!plugin[1].resolveWorkspaceSymbol) {
+				return symbol;
+			}
+
+			Object.assign(symbol, data.original);
+			symbol = await plugin[1].resolveWorkspaceSymbol(symbol, token);
+		}
+
+		return symbol;
+	};
+}

--- a/packages/language-service/lib/languageService.ts
+++ b/packages/language-service/lib/languageService.ts
@@ -36,6 +36,7 @@ import * as codeLensResolve from './features/resolveCodeLens';
 import * as completionResolve from './features/resolveCompletionItem';
 import * as documentLinkResolve from './features/resolveDocumentLink';
 import * as inlayHintResolve from './features/resolveInlayHint';
+import * as workspaceSymbolResolve from './features/resolveWorkspaceSymbol';
 import type { LanguageServiceContext, LanguageServiceEnvironment, LanguageServicePlugin } from './types';
 import { UriMap, createUriMap } from './utils/uriMap';
 
@@ -227,6 +228,7 @@ function createLanguageServiceBase(
 		resolveCodeLens: codeLensResolve.register(context),
 		resolveDocumentLink: documentLinkResolve.register(context),
 		resolveInlayHint: inlayHintResolve.register(context),
+		resolveWorkspaceSymbol: workspaceSymbolResolve.register(context),
 
 		...callHierarchy.register(context),
 

--- a/packages/language-service/lib/types.ts
+++ b/packages/language-service/lib/types.ts
@@ -96,7 +96,9 @@ export interface LanguageServicePlugin<P = any> {
 		callHierarchyProvider?: boolean;
 		hoverProvider?: boolean;
 		documentHighlightProvider?: boolean;
-		workspaceSymbolProvider?: boolean;
+		workspaceSymbolProvider?: {
+			resolveProvider?: boolean;
+		};
 		renameProvider?: {
 			prepareProvider?: boolean;
 		};
@@ -189,6 +191,7 @@ export interface LanguageServicePluginInstance<P = any> {
 	resolveCompletionItem?(item: vscode.CompletionItem, token: vscode.CancellationToken): ProviderResult<vscode.CompletionItem>;
 	resolveDocumentLink?(link: vscode.DocumentLink, token: vscode.CancellationToken): ProviderResult<vscode.DocumentLink>;
 	resolveInlayHint?(inlayHint: vscode.InlayHint, token: vscode.CancellationToken): ProviderResult<vscode.InlayHint>;
+	resolveWorkspaceSymbol?(symbol: vscode.WorkspaceSymbol, token: vscode.CancellationToken): ProviderResult<vscode.WorkspaceSymbol>;
 	resolveEmbeddedCodeFormattingOptions?(sourceScript: SourceScript<URI>, embeddedCode: VirtualCode, options: EmbeddedCodeFormattingOptions, token: vscode.CancellationToken): NullableProviderResult<EmbeddedCodeFormattingOptions>; // volar specific
 	transformCompletionItem?(item: vscode.CompletionItem): vscode.CompletionItem | undefined; // volar specific
 	transformCodeAction?(item: vscode.CodeAction): vscode.CodeAction | undefined; // volar specific


### PR DESCRIPTION
Implemented `connection.onWorkspaceSymbolResolve`. (Currently no language service plugin needs to use it)