### PR TITLE
refactor(language-core): decoupled from TypeScript project context

### DIFF
--- a/packages/language-core/index.ts
+++ b/packages/language-core/index.ts
@@ -5,10 +5,10 @@ export * from './lib/types';
 export * from './lib/utils';
 
 import { SourceMap } from '@volar/source-map';
-import type * as ts from 'typescript';
 import { LinkedCodeMap } from './lib/linkedCodeMap';
 import type {
 	CodegenContext,
+	IScriptSnapshot,
 	Language,
 	LanguagePlugin,
 	Mapper,
@@ -25,8 +25,8 @@ export function createLanguage<T>(
 	sync: (id: T) => void
 ) {
 	const virtualCodeToSourceScriptMap = new WeakMap<VirtualCode, SourceScript<T>>();
-	const virtualCodeToSourceMap = new WeakMap<ts.IScriptSnapshot, WeakMap<ts.IScriptSnapshot, Mapper>>();
-	const virtualCodeToLinkedCodeMap = new WeakMap<ts.IScriptSnapshot, [ts.IScriptSnapshot, LinkedCodeMap | undefined]>();
+	const virtualCodeToSourceMap = new WeakMap<IScriptSnapshot, WeakMap<IScriptSnapshot, Mapper>>();
+	const virtualCodeToLinkedCodeMap = new WeakMap<IScriptSnapshot, [IScriptSnapshot, LinkedCodeMap | undefined]>();
 	const language: Language<T> = {
 		mapperFactory: defaultMapperFactory,
 		plugins,

--- a/packages/typescript/index.ts
+++ b/packages/typescript/index.ts
@@ -1,7 +1,59 @@
+export * from './lib/common';
 export * from './lib/node/decorateLanguageService';
 export * from './lib/node/decorateLanguageServiceHost';
 export * from './lib/node/decorateProgram';
 export * from './lib/node/proxyCreateProgram';
 export * from './lib/protocol/createProject';
 export * from './lib/protocol/createSys';
-export * from './lib/common';
+
+import type { VirtualCode } from '@volar/language-core';
+import type * as ts from 'typescript';
+
+declare module '@volar/language-core' {
+	export interface Language<T> {
+		typescript?: {
+			configFileName: string | undefined;
+			sys: ts.System & {
+				version?: number;
+				sync?(): Promise<number>;
+			};
+			languageServiceHost: ts.LanguageServiceHost;
+			getExtraServiceScript(fileName: string): TypeScriptExtraServiceScript | undefined;
+			asScriptId(fileName: string): T;
+			asFileName(scriptId: T): string;
+		};
+	}
+
+	export interface LanguagePlugin<T = unknown, K extends VirtualCode = VirtualCode> {
+		typescript?: TypeScriptGenericOptions<K> & TypeScriptNonTSPluginOptions<K>;
+	}
+}
+
+/**
+ * The following options available to all situations.
+ */
+interface TypeScriptGenericOptions<K> {
+	extraFileExtensions: ts.FileExtensionInfo[];
+	resolveHiddenExtensions?: boolean;
+	getServiceScript(root: K): TypeScriptServiceScript | undefined;
+}
+
+/**
+ * The following options will not be available in TS plugin.
+ */
+interface TypeScriptNonTSPluginOptions<K> {
+	getExtraServiceScripts?(fileName: string, rootVirtualCode: K): TypeScriptExtraServiceScript[];
+	resolveLanguageServiceHost?(host: ts.LanguageServiceHost): ts.LanguageServiceHost;
+}
+
+export interface TypeScriptServiceScript {
+	code: VirtualCode;
+	extension: '.ts' | '.js' | '.mts' | '.mjs' | '.cjs' | '.cts' | '.d.ts' | string;
+	scriptKind: ts.ScriptKind;
+	/** See #188 */
+	preventLeadingOffset?: boolean;
+}
+
+export interface TypeScriptExtraServiceScript extends TypeScriptServiceScript {
+	fileName: string;
+}

--- a/packages/typescript/lib/node/transform.ts
+++ b/packages/typescript/lib/node/transform.ts
@@ -1,8 +1,9 @@
-import type { CodeInformation, SourceScript, TypeScriptServiceScript } from '@volar/language-core';
+import type { CodeInformation, SourceScript } from '@volar/language-core';
 import { Language, shouldReportDiagnostics } from '@volar/language-core';
 import type * as ts from 'typescript';
-import { getServiceScript } from './utils';
 import type { TextChange } from "typescript";
+import type { TypeScriptServiceScript } from '../..';
+import { getServiceScript } from './utils';
 
 const transformedDiagnostics = new WeakMap<ts.Diagnostic, ts.Diagnostic | undefined>();
 const transformedSourceFile = new WeakSet<ts.SourceFile>();

--- a/packages/typescript/lib/node/utils.ts
+++ b/packages/typescript/lib/node/utils.ts
@@ -1,4 +1,5 @@
-import type { Language, SourceScript, TypeScriptServiceScript } from '@volar/language-core';
+import type { Language, SourceScript } from '@volar/language-core';
+import type { TypeScriptServiceScript } from '../..';
 
 export function getServiceScript(language: Language<string>, fileName: string)
 	: [serviceScript: TypeScriptServiceScript, targetScript: SourceScript<string>, sourceScript: SourceScript<string>]

--- a/packages/typescript/lib/protocol/createProject.ts
+++ b/packages/typescript/lib/protocol/createProject.ts
@@ -1,6 +1,7 @@
-import { FileMap, Language, TypeScriptExtraServiceScript, forEachEmbeddedCode } from '@volar/language-core';
+import { FileMap, Language, forEachEmbeddedCode } from '@volar/language-core';
 import * as path from 'path-browserify';
 import type * as ts from 'typescript';
+import type { TypeScriptExtraServiceScript } from '../..';
 import { createResolveModuleName } from '../resolveModuleName';
 import type { createSys } from './createSys';
 


### PR DESCRIPTION
The `Language` and `LanguagePlugin` interface definitions in `@vue/language-core` are no longer coupled with TypeScript. Instead, options specific to TypeScript projects are defined in `@volar/typescript` through TS declaration merging.