### PR TITLE
refactor(language-service): move project context from `Language` to language service option

### DIFF
--- a/packages/kit/lib/createFormatter.ts
+++ b/packages/kit/lib/createFormatter.ts
@@ -16,7 +16,8 @@ export function createFormatter(
 	const languageService = createLanguageService(
 		language,
 		services,
-		env
+		env,
+		{}
 	);
 
 	return {

--- a/packages/kit/lib/utils.ts
+++ b/packages/kit/lib/utils.ts
@@ -15,6 +15,6 @@ export function asPosix(path: string) {
 	return path.replace(/\\/g, '/') as path.PosixPath;
 }
 
-export const uriToFileName = (uri: URI) => uri.fsPath.replace(/\\/g, '/');
+export const asFileName = (uri: URI) => uri.fsPath.replace(/\\/g, '/');
 
-export const fileNameToUri = (fileName: string) => URI.file(fileName);
+export const asUri = (fileName: string) => URI.file(fileName);

--- a/packages/language-server/lib/project/simpleProject.ts
+++ b/packages/language-server/lib/project/simpleProject.ts
@@ -30,7 +30,8 @@ export function createSimpleProject(languagePlugins: LanguagePlugin<URI>[]): Lan
 			languageService = createLanguageService(
 				language,
 				server.languageServicePlugins,
-				createLanguageServiceEnvironment(server, [...server.workspaceFolders.keys()])
+				createLanguageServiceEnvironment(server, [...server.workspaceFolders.keys()]),
+				{}
 			);
 		},
 		getLanguageService() {

--- a/packages/language-server/lib/project/typescriptProjectLs.ts
+++ b/packages/language-server/lib/project/typescriptProjectLs.ts
@@ -134,24 +134,26 @@ export async function createTypeScriptLS(
 			}
 		}
 	);
-	language.typescript = {
-		configFileName: typeof tsconfig === 'string' ? tsconfig : undefined,
-		sys,
-		asScriptId: asUri,
-		asFileName: asFileName,
-		...createLanguageServiceHost(
-			ts,
-			sys,
-			language,
-			asUri,
-			projectHost
-		),
-	};
 	setup(language);
 	const languageService = createLanguageService(
 		language,
 		server.languageServicePlugins,
-		serviceEnv
+		serviceEnv,
+		{
+			typescript: {
+				configFileName: typeof tsconfig === 'string' ? tsconfig : undefined,
+				sys,
+				asUri,
+				asFileName,
+				...createLanguageServiceHost(
+					ts,
+					sys,
+					language,
+					asUri,
+					projectHost
+				),
+			}
+		}
 	);
 
 	return {

--- a/packages/language-service/lib/languageService.ts
+++ b/packages/language-service/lib/languageService.ts
@@ -37,7 +37,7 @@ import * as completionResolve from './features/resolveCompletionItem';
 import * as documentLinkResolve from './features/resolveDocumentLink';
 import * as inlayHintResolve from './features/resolveInlayHint';
 import * as workspaceSymbolResolve from './features/resolveWorkspaceSymbol';
-import type { LanguageServiceContext, LanguageServiceEnvironment, LanguageServicePlugin } from './types';
+import type { LanguageServiceContext, LanguageServiceEnvironment, LanguageServicePlugin, ProjectContext } from './types';
 import { NoneCancellationToken } from './utils/cancellation';
 import { UriMap, createUriMap } from './utils/uriMap';
 
@@ -48,12 +48,14 @@ export const embeddedContentScheme = 'volar-embedded-content';
 export function createLanguageService(
 	language: Language<URI>,
 	plugins: LanguageServicePlugin[],
-	env: LanguageServiceEnvironment
+	env: LanguageServiceEnvironment,
+	project: ProjectContext
 ) {
 	const documentVersions = createUriMap<number>();
 	const snapshot2Doc = new WeakMap<ts.IScriptSnapshot, UriMap<TextDocument>>();
 	const context: LanguageServiceContext = {
 		language,
+		project,
 		getLanguageService: () => langaugeService,
 		documents: {
 			get(uri, languageId, snapshot) {

--- a/packages/language-service/lib/types.ts
+++ b/packages/language-service/lib/types.ts
@@ -44,11 +44,14 @@ export interface LanguageServiceCommand<T extends any[]> {
 	is(value: vscode.Command): boolean;
 }
 
+export interface ProjectContext { }
+
 export interface LanguageServiceContext {
 	language: Language<URI>;
+	project: ProjectContext;
 	getLanguageService(): LanguageService;
 	env: LanguageServiceEnvironment;
-	inject<Provide, K extends keyof Provide = keyof Provide>(
+	inject<Provide = any, K extends keyof Provide = keyof Provide>(
 		key: K,
 		...args: Provide[K] extends (...args: any) => any ? Parameters<Provide[K]> : never
 	): ReturnType<Provide[K] extends (...args: any) => any ? Provide[K] : never> | undefined;

--- a/packages/typescript/index.ts
+++ b/packages/typescript/index.ts
@@ -8,9 +8,10 @@ export * from './lib/protocol/createSys';
 
 import type { VirtualCode } from '@volar/language-core';
 import type * as ts from 'typescript';
+import { URI } from 'vscode-uri';
 
-declare module '@volar/language-core' {
-	export interface Language<T> {
+declare module '@volar/language-service' {
+	export interface ProjectContext {
 		typescript?: {
 			configFileName: string | undefined;
 			sys: ts.System & {
@@ -19,11 +20,13 @@ declare module '@volar/language-core' {
 			};
 			languageServiceHost: ts.LanguageServiceHost;
 			getExtraServiceScript(fileName: string): TypeScriptExtraServiceScript | undefined;
-			asScriptId(fileName: string): T;
-			asFileName(scriptId: T): string;
+			asUri(fileName: string): URI;
+			asFileName(uri: URI): string;
 		};
 	}
+}
 
+declare module '@volar/language-core' {
 	export interface LanguagePlugin<T = unknown, K extends VirtualCode = VirtualCode> {
 		typescript?: TypeScriptGenericOptions<K> & TypeScriptNonTSPluginOptions<K>;
 	}


### PR DESCRIPTION
### Motivation

`Language.typescript` is used to pass TS project context to `volar-service-typescript`. Since `Language.typescript` is specific to LSP context, it should be pass through language service instead of `Language` interface.