### PR TITLE
refactor(monaco): move ATA to `@volar/jsdelivr`

### DIFF
--- a/packages/jsdelivr/LICENSE
+++ b/packages/jsdelivr/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024-present Johnson Chu
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/jsdelivr/index.ts
+++ b/packages/jsdelivr/index.ts
@@ -1,0 +1,1 @@
+export * from './lib/npm';

--- a/packages/jsdelivr/lib/npm.ts
+++ b/packages/jsdelivr/lib/npm.ts
@@ -4,7 +4,7 @@ import type { URI } from 'vscode-uri';
 const textCache = new Map<string, Promise<string | undefined>>();
 const jsonCache = new Map<string, Promise<any>>();
 
-export function createJsDelivrNpmFileSystem(
+export function createNpmFileSystem(
 	getCdnPath = (uri: URI): string | undefined => {
 		if (uri.path === '/node_modules') {
 			return '';

--- a/packages/jsdelivr/package.json
+++ b/packages/jsdelivr/package.json
@@ -1,0 +1,18 @@
+{
+	"name": "@volar/jsdelivr",
+	"version": "2.4.0-alpha.0",
+	"license": "MIT",
+	"files": [
+		"**/*.js",
+		"**/*.d.ts"
+	],
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/volarjs/volar.js.git",
+		"directory": "packages/jsdelivr"
+	},
+	"devDependencies": {
+		"@volar/language-service": "2.4.0-alpha.0",
+		"vscode-uri": "^3.0.8"
+	}
+}

--- a/packages/jsdelivr/tsconfig.json
+++ b/packages/jsdelivr/tsconfig.json
@@ -1,0 +1,7 @@
+{
+	"extends": "../../tsconfig.base.json",
+	"include": [ "*", "lib/**/*" ],
+	"references": [
+		{ "path": "../language-service/tsconfig.json" },
+	],
+}

--- a/packages/monaco/README.md
+++ b/packages/monaco/README.md
@@ -49,27 +49,25 @@ self.onmessage = () => {
 import * as worker from 'monaco-editor-core/esm/vs/editor/editor.worker';
 import type * as monaco from 'monaco-editor-core';
 -import { createSimpleWorkerService, ServiceEnvironment } from '@volar/monaco/worker';
-+import {
-+	createTypeScriptWorkerService,
-+	ServiceEnvironment,
-+} from '@volar/monaco/worker';
++import { createTypeScriptWorkerService, ServiceEnvironment } from '@volar/monaco/worker';
 +import * as ts from 'typescript';
-+import { create as createTypeScriptService } from 'volar-service-typescript';
++import { create as createTypeScriptPlugins } from 'volar-service-typescript';
++import { URI } from 'vscode-uri';
 
 self.onmessage = () => {
 	worker.initialize((ctx: monaco.worker.IWorkerContext) => {
 		const env: ServiceEnvironment = {
 			workspaceFolder: 'file:///',
-+			typescript: {
-+				uriToFileName: uri => uri.substring('file://'.length),
-+				fileNameToUri: fileName => 'file://' + fileName,
-+			},
 		};
 -		return createSimpleWorkerService({
 +		return createTypeScriptWorkerService({
 +			typescript: ts,
 +			compilerOptions: {
 +				// ...
++			},
++			uriConverter: {
++				asFileName: uri => uri.fsPath,
++				asUri: fileName => URI.file(fileName),
 +			},
 			workerContext: ctx,
 			env,
@@ -78,7 +76,7 @@ self.onmessage = () => {
 			],
 			languageServicePlugins: [
 				// ...
-+				createTypeScriptService(ts),
++				...createTypeScriptPlugins(ts),
 			],
 		});
 	});
@@ -90,11 +88,8 @@ self.onmessage = () => {
 ```diff
 import * as worker from 'monaco-editor-core/esm/vs/editor/editor.worker';
 import type * as monaco from 'monaco-editor-core';
-import {
-	createTypeScriptWorkerService,
-	ServiceEnvironment,
-+	createJsDelivrNpmFileSystem,
-} from '@volar/monaco/worker';
+import { createTypeScriptWorkerService, ServiceEnvironment } from '@volar/monaco/worker';
++import { createNpmFileSystem } from '@volar/jsdelivr';
 import * as ts from 'typescript';
 import { create as createTypeScriptService } from 'volar-service-typescript';
 
@@ -107,7 +102,7 @@ self.onmessage = () => {
 				fileNameToUri: fileName => 'file://' + fileName,
 			},
 		};
-+		env.fs = createJsDelivrNpmFileSystem();
++		env.fs = createNpmFileSystem();
 		return createTypeScriptWorkerService({
 			typescript: ts,
 			compilerOptions: {

--- a/packages/monaco/worker.ts
+++ b/packages/monaco/worker.ts
@@ -15,7 +15,6 @@ import type * as ts from 'typescript';
 import { URI } from 'vscode-uri';
 
 export * from '@volar/language-service';
-export * from './lib/ata.js';
 
 const fsFileSnapshots = createUriMap<[number | undefined, ts.IScriptSnapshot | undefined]>();
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -75,6 +75,15 @@ importers:
         specifier: ^1.0.11
         version: 1.0.11
 
+  packages/jsdelivr:
+    devDependencies:
+      '@volar/language-service':
+        specifier: 2.4.0-alpha.0
+        version: link:../language-service
+      vscode-uri:
+        specifier: ^3.0.8
+        version: 3.0.8
+
   packages/kit:
     dependencies:
       '@volar/language-service':

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,7 @@
 	"include": [ "packages/*/tests" ],
 	"references": [
 		{ "path": "./packages/eslint/tsconfig.json" },
+		{ "path": "./packages/jsdelivr/tsconfig.json" },
 		{ "path": "./packages/kit/tsconfig.json" },
 		{ "path": "./packages/typescript/tsconfig.json" },
 		{ "path": "./packages/vscode/tsconfig.json" },


### PR DESCRIPTION
In #126 `@volar/cdn` was merged into `@volar/monaco`, which was the wrong refactoring because ATA is not specific to Monaco and Web IDE also relies on it.

This PR add `@volar/jsdelivr` module to reimplement `@volar/cdn`.