### PR TITLE
refactor(monaco): correctly implement the proxy object of LangaugeService for worker

### DIFF
--- a/packages/language-server/lib/register/registerLanguageFeatures.ts
+++ b/packages/language-server/lib/register/registerLanguageFeatures.ts
@@ -405,7 +405,7 @@ export function registerLanguageFeatures(server: LanguageServer) {
 	if (executeCommandProvider) {
 		server.connection.onExecuteCommand(async (params, token) => {
 			for (const languageService of await server.project.getExistingLanguageServices()) {
-				if (languageService.executeCommand && languageService.getCommands().includes(params.command)) {
+				if (languageService.executeCommand && languageService.commands.includes(params.command)) {
 					try {
 						return await languageService.executeCommand(params.command, params.arguments ?? [], token);
 					} catch { }

--- a/packages/language-service/lib/features/provideAutoInsertSnippet.ts
+++ b/packages/language-service/lib/features/provideAutoInsertSnippet.ts
@@ -1,14 +1,13 @@
 import { isAutoInsertEnabled } from '@volar/language-core';
 import type * as vscode from 'vscode-languageserver-protocol';
 import { URI } from 'vscode-uri';
-import type { LanguageServiceContext, UriComponents } from '../types';
+import type { LanguageServiceContext } from '../types';
 import { NoneCancellationToken } from '../utils/cancellation';
 import { getGeneratedPositions, languageFeatureWorker } from '../utils/featureWorkers';
 
 export function register(context: LanguageServiceContext) {
 
-	return (_uri: URI | UriComponents, selection: vscode.Position, change: { rangeOffset: number; rangeLength: number; text: string; }, token = NoneCancellationToken) => {
-		const uri = _uri instanceof URI ? _uri : URI.from(_uri);
+	return (uri: URI, selection: vscode.Position, change: { rangeOffset: number; rangeLength: number; text: string; }, token = NoneCancellationToken) => {
 
 		return languageFeatureWorker(
 			context,

--- a/packages/language-service/lib/features/provideCallHierarchyItems.ts
+++ b/packages/language-service/lib/features/provideCallHierarchyItems.ts
@@ -1,7 +1,7 @@
 import { isCallHierarchyEnabled } from '@volar/language-core';
 import type * as vscode from 'vscode-languageserver-protocol';
 import { URI } from 'vscode-uri';
-import type { LanguageServiceContext, UriComponents } from '../types';
+import type { LanguageServiceContext } from '../types';
 import { NoneCancellationToken } from '../utils/cancellation';
 import * as dedupe from '../utils/dedupe';
 import { DocumentsAndMap, getGeneratedPositions, getSourceRange, languageFeatureWorker } from '../utils/featureWorkers';
@@ -17,9 +17,8 @@ export function register(context: LanguageServiceContext) {
 
 	return {
 
-		getCallHierarchyItems(_uri: URI | UriComponents, position: vscode.Position, token = NoneCancellationToken) {
-			const uri = _uri instanceof URI ? _uri : URI.from(_uri);
-
+		getCallHierarchyItems(uri: URI, position: vscode.Position, token = NoneCancellationToken) {
+	
 			return languageFeatureWorker(
 				context,
 				uri,

--- a/packages/language-service/lib/features/provideCodeActions.ts
+++ b/packages/language-service/lib/features/provideCodeActions.ts
@@ -1,7 +1,7 @@
 import { isCodeActionsEnabled } from '@volar/language-core';
 import type * as vscode from 'vscode-languageserver-protocol';
 import { URI } from 'vscode-uri';
-import type { LanguageServiceContext, UriComponents } from '../types';
+import type { LanguageServiceContext } from '../types';
 import { NoneCancellationToken } from '../utils/cancellation';
 import { findOverlapCodeRange } from '../utils/common';
 import * as dedupe from '../utils/dedupe';
@@ -18,8 +18,7 @@ export interface ServiceCodeActionData {
 
 export function register(context: LanguageServiceContext) {
 
-	return async (_uri: URI | UriComponents, range: vscode.Range, codeActionContext: vscode.CodeActionContext, token = NoneCancellationToken) => {
-		const uri = _uri instanceof URI ? _uri : URI.from(_uri);
+	return async (uri: URI, range: vscode.Range, codeActionContext: vscode.CodeActionContext, token = NoneCancellationToken) => {
 		const sourceScript = context.language.scripts.get(uri);
 		if (!sourceScript) {
 			return;

--- a/packages/language-service/lib/features/provideCodeLenses.ts
+++ b/packages/language-service/lib/features/provideCodeLenses.ts
@@ -1,7 +1,7 @@
 import { isCodeLensEnabled } from '@volar/language-core';
 import type * as vscode from 'vscode-languageserver-protocol';
 import { URI } from 'vscode-uri';
-import type { LanguageServiceContext, UriComponents } from '../types';
+import type { LanguageServiceContext } from '../types';
 import { NoneCancellationToken } from '../utils/cancellation';
 import { documentFeatureWorker, getSourceRange } from '../utils/featureWorkers';
 
@@ -22,8 +22,7 @@ export interface ServiceReferencesCodeLensData {
 
 export function register(context: LanguageServiceContext) {
 
-	return async (_uri: URI | UriComponents, token = NoneCancellationToken) => {
-		const uri = _uri instanceof URI ? _uri : URI.from(_uri);
+	return async (uri: URI, token = NoneCancellationToken) => {
 
 		return await documentFeatureWorker(
 			context,

--- a/packages/language-service/lib/features/provideColorPresentations.ts
+++ b/packages/language-service/lib/features/provideColorPresentations.ts
@@ -1,14 +1,13 @@
 import { isColorEnabled } from '@volar/language-core';
 import type * as vscode from 'vscode-languageserver-protocol';
 import { URI } from 'vscode-uri';
-import type { LanguageServiceContext, UriComponents } from '../types';
+import type { LanguageServiceContext } from '../types';
 import { NoneCancellationToken } from '../utils/cancellation';
 import { getGeneratedRanges, getSourceRange, languageFeatureWorker } from '../utils/featureWorkers';
 
 export function register(context: LanguageServiceContext) {
 
-	return (_uri: URI | UriComponents, color: vscode.Color, range: vscode.Range, token = NoneCancellationToken) => {
-		const uri = _uri instanceof URI ? _uri : URI.from(_uri);
+	return (uri: URI, color: vscode.Color, range: vscode.Range, token = NoneCancellationToken) => {
 
 		return languageFeatureWorker(
 			context,

--- a/packages/language-service/lib/features/provideCompletionItems.ts
+++ b/packages/language-service/lib/features/provideCompletionItems.ts
@@ -2,7 +2,7 @@ import { isCompletionEnabled, SourceScript, VirtualCode, type CodeInformation } 
 import type * as vscode from 'vscode-languageserver-protocol';
 import type { TextDocument } from 'vscode-languageserver-textdocument';
 import { URI } from 'vscode-uri';
-import type { LanguageServiceContext, LanguageServicePluginInstance, UriComponents } from '../types';
+import type { LanguageServiceContext, LanguageServicePluginInstance } from '../types';
 import { NoneCancellationToken } from '../utils/cancellation';
 import { DocumentsAndMap, forEachEmbeddedDocument, getGeneratedPositions, getSourceRange } from '../utils/featureWorkers';
 import { transformCompletionList } from '../utils/transform';
@@ -26,12 +26,11 @@ export function register(context: LanguageServiceContext) {
 	} | undefined;
 
 	return async (
-		_uri: URI | UriComponents,
+		uri: URI,
 		position: vscode.Position,
 		completionContext: vscode.CompletionContext = { triggerKind: 1 satisfies typeof vscode.CompletionTriggerKind.Invoked, },
 		token = NoneCancellationToken
 	) => {
-		const uri = _uri instanceof URI ? _uri : URI.from(_uri);
 		let langaugeIdAndSnapshot: SourceScript<URI> | VirtualCode | undefined;
 		let sourceScript: SourceScript<URI> | undefined;
 

--- a/packages/language-service/lib/features/provideDefinition.ts
+++ b/packages/language-service/lib/features/provideDefinition.ts
@@ -2,7 +2,7 @@ import type { CodeInformation } from '@volar/language-core';
 import type * as vscode from 'vscode-languageserver-protocol';
 import type { TextDocument } from 'vscode-languageserver-textdocument';
 import { URI } from 'vscode-uri';
-import type { LanguageServiceContext, UriComponents } from '../types';
+import type { LanguageServiceContext } from '../types';
 import { NoneCancellationToken } from '../utils/cancellation';
 import * as dedupe from '../utils/dedupe';
 import { DocumentsAndMap, getGeneratedPositions, getLinkedCodePositions, getSourceRange, getSourceRanges, languageFeatureWorker } from '../utils/featureWorkers';
@@ -13,8 +13,7 @@ export function register(
 	isValidPosition: (data: CodeInformation) => boolean
 ) {
 
-	return (_uri: URI | UriComponents, position: vscode.Position, token = NoneCancellationToken) => {
-		const uri = _uri instanceof URI ? _uri : URI.from(_uri);
+	return (uri: URI, position: vscode.Position, token = NoneCancellationToken) => {
 
 		return languageFeatureWorker(
 			context,

--- a/packages/language-service/lib/features/provideDiagnostics.ts
+++ b/packages/language-service/lib/features/provideDiagnostics.ts
@@ -3,7 +3,7 @@ import type * as ts from 'typescript';
 import type * as vscode from 'vscode-languageserver-protocol';
 import type { TextDocument } from 'vscode-languageserver-textdocument';
 import { URI } from 'vscode-uri';
-import type { LanguageServiceContext, UriComponents } from '../types';
+import type { LanguageServiceContext } from '../types';
 import { NoneCancellationToken } from '../utils/cancellation';
 import { sleep } from '../utils/common';
 import * as dedupe from '../utils/dedupe';
@@ -147,11 +147,10 @@ export function register(context: LanguageServiceContext) {
 	});
 
 	return async (
-		_uri: URI | UriComponents,
+		uri: URI,
 		token = NoneCancellationToken,
 		response?: (result: vscode.Diagnostic[]) => void
 	) => {
-		const uri = _uri instanceof URI ? _uri : URI.from(_uri);
 
 		let langaugeIdAndSnapshot: SourceScript<URI> | VirtualCode | undefined;
 

--- a/packages/language-service/lib/features/provideDocumentColors.ts
+++ b/packages/language-service/lib/features/provideDocumentColors.ts
@@ -1,14 +1,13 @@
 import { isColorEnabled } from '@volar/language-core';
 import type * as vscode from 'vscode-languageserver-protocol';
 import { URI } from 'vscode-uri';
-import type { LanguageServiceContext, UriComponents } from '../types';
+import type { LanguageServiceContext } from '../types';
 import { NoneCancellationToken } from '../utils/cancellation';
 import { documentFeatureWorker, getSourceRange } from '../utils/featureWorkers';
 
 export function register(context: LanguageServiceContext) {
 
-	return (_uri: URI | UriComponents, token = NoneCancellationToken) => {
-		const uri = _uri instanceof URI ? _uri : URI.from(_uri);
+	return (uri: URI, token = NoneCancellationToken) => {
 
 		return documentFeatureWorker(
 			context,

--- a/packages/language-service/lib/features/provideDocumentDropEdits.ts
+++ b/packages/language-service/lib/features/provideDocumentDropEdits.ts
@@ -1,14 +1,13 @@
 import type * as vscode from 'vscode-languageserver-protocol';
 import { URI } from 'vscode-uri';
-import type { DataTransferItem, LanguageServiceContext, UriComponents } from '../types';
+import type { DataTransferItem, LanguageServiceContext } from '../types';
 import { NoneCancellationToken } from '../utils/cancellation';
 import { getGeneratedPositions, languageFeatureWorker } from '../utils/featureWorkers';
 import { transformWorkspaceEdit } from '../utils/transform';
 
 export function register(context: LanguageServiceContext) {
 
-	return (_uri: URI | UriComponents, position: vscode.Position, dataTransfer: Map<string, DataTransferItem>, token = NoneCancellationToken) => {
-		const uri = _uri instanceof URI ? _uri : URI.from(_uri);
+	return (uri: URI, position: vscode.Position, dataTransfer: Map<string, DataTransferItem>, token = NoneCancellationToken) => {
 
 		return languageFeatureWorker(
 			context,

--- a/packages/language-service/lib/features/provideDocumentFormattingEdits.ts
+++ b/packages/language-service/lib/features/provideDocumentFormattingEdits.ts
@@ -2,7 +2,7 @@ import { SourceScript, VirtualCode, forEachEmbeddedCode, isFormattingEnabled } f
 import type * as vscode from 'vscode-languageserver-protocol';
 import { TextDocument } from 'vscode-languageserver-textdocument';
 import { URI } from 'vscode-uri';
-import type { EmbeddedCodeFormattingOptions, LanguageServiceContext, UriComponents } from '../types';
+import type { EmbeddedCodeFormattingOptions, LanguageServiceContext } from '../types';
 import { NoneCancellationToken } from '../utils/cancellation';
 import { findOverlapCodeRange, stringToSnapshot } from '../utils/common';
 import { DocumentsAndMap, getGeneratedPositions, getSourceRange } from '../utils/featureWorkers';
@@ -10,7 +10,7 @@ import { DocumentsAndMap, getGeneratedPositions, getSourceRange } from '../utils
 export function register(context: LanguageServiceContext) {
 
 	return async (
-		_uri: URI | UriComponents,
+		uri: URI,
 		options: vscode.FormattingOptions,
 		range: vscode.Range | undefined,
 		onTypeParams: {
@@ -19,7 +19,6 @@ export function register(context: LanguageServiceContext) {
 		} | undefined,
 		token = NoneCancellationToken
 	) => {
-		const uri = _uri instanceof URI ? _uri : URI.from(_uri);
 		const sourceScript = context.language.scripts.get(uri);
 		if (!sourceScript) {
 			return;

--- a/packages/language-service/lib/features/provideDocumentHighlights.ts
+++ b/packages/language-service/lib/features/provideDocumentHighlights.ts
@@ -2,15 +2,14 @@ import { isHighlightEnabled } from '@volar/language-core';
 import type * as vscode from 'vscode-languageserver-protocol';
 import type { TextDocument } from 'vscode-languageserver-textdocument';
 import { URI } from 'vscode-uri';
-import type { LanguageServiceContext, UriComponents } from '../types';
+import type { LanguageServiceContext } from '../types';
 import { NoneCancellationToken } from '../utils/cancellation';
 import * as dedupe from '../utils/dedupe';
 import { getGeneratedPositions, getLinkedCodePositions, getSourceRange, languageFeatureWorker } from '../utils/featureWorkers';
 
 export function register(context: LanguageServiceContext) {
 
-	return (_uri: URI | UriComponents, position: vscode.Position, token = NoneCancellationToken) => {
-		const uri = _uri instanceof URI ? _uri : URI.from(_uri);
+	return (uri: URI, position: vscode.Position, token = NoneCancellationToken) => {
 
 		return languageFeatureWorker(
 			context,

--- a/packages/language-service/lib/features/provideDocumentLinks.ts
+++ b/packages/language-service/lib/features/provideDocumentLinks.ts
@@ -1,7 +1,7 @@
 import { isDocumentLinkEnabled } from '@volar/language-core';
 import type * as vscode from 'vscode-languageserver-protocol';
 import { URI } from 'vscode-uri';
-import type { LanguageServiceContext, UriComponents } from '../types';
+import type { LanguageServiceContext } from '../types';
 import { NoneCancellationToken } from '../utils/cancellation';
 import { documentFeatureWorker, getSourceRange } from '../utils/featureWorkers';
 import { transformDocumentLinkTarget } from '../utils/transform';
@@ -14,8 +14,7 @@ export interface DocumentLinkData {
 
 export function register(context: LanguageServiceContext) {
 
-	return async (_uri: URI | UriComponents, token = NoneCancellationToken) => {
-		const uri = _uri instanceof URI ? _uri : URI.from(_uri);
+	return async (uri: URI, token = NoneCancellationToken) => {
 
 		return await documentFeatureWorker(
 			context,

--- a/packages/language-service/lib/features/provideDocumentSemanticTokens.ts
+++ b/packages/language-service/lib/features/provideDocumentSemanticTokens.ts
@@ -1,7 +1,7 @@
 import { isSemanticTokensEnabled } from '@volar/language-core';
 import type * as vscode from 'vscode-languageserver-protocol';
 import { URI } from 'vscode-uri';
-import type { LanguageServiceContext, SemanticToken, UriComponents } from '../types';
+import type { LanguageServiceContext, SemanticToken } from '../types';
 import { SemanticTokensBuilder } from '../utils/SemanticTokensBuilder';
 import { NoneCancellationToken } from '../utils/cancellation';
 import { findOverlapCodeRange } from '../utils/common';
@@ -10,13 +10,12 @@ import { getSourceRange, languageFeatureWorker } from '../utils/featureWorkers';
 export function register(context: LanguageServiceContext) {
 
 	return async (
-		_uri: URI | UriComponents,
+		uri: URI,
 		range: vscode.Range | undefined,
 		legend: vscode.SemanticTokensLegend,
 		token = NoneCancellationToken,
 		_reportProgress?: (tokens: vscode.SemanticTokens) => void // TODO
 	): Promise<vscode.SemanticTokens | undefined> => {
-		const uri = _uri instanceof URI ? _uri : URI.from(_uri);
 		const sourceScript = context.language.scripts.get(uri);
 		if (!sourceScript) {
 			return;

--- a/packages/language-service/lib/features/provideDocumentSymbols.ts
+++ b/packages/language-service/lib/features/provideDocumentSymbols.ts
@@ -1,7 +1,7 @@
 import { isSymbolsEnabled } from '@volar/language-core';
 import type * as vscode from 'vscode-languageserver-protocol';
 import { URI } from 'vscode-uri';
-import type { LanguageServiceContext, UriComponents } from '../types';
+import type { LanguageServiceContext } from '../types';
 import { NoneCancellationToken } from '../utils/cancellation';
 import { isInsideRange } from '../utils/common';
 import { documentFeatureWorker, getSourceRange } from '../utils/featureWorkers';
@@ -9,8 +9,7 @@ import { transformDocumentSymbol } from '../utils/transform';
 
 export function register(context: LanguageServiceContext) {
 
-	return (_uri: URI | UriComponents, token = NoneCancellationToken): Promise<vscode.DocumentSymbol[] | undefined> => {
-		const uri = _uri instanceof URI ? _uri : URI.from(_uri);
+	return (uri: URI, token = NoneCancellationToken): Promise<vscode.DocumentSymbol[] | undefined> => {
 
 		return documentFeatureWorker(
 			context,

--- a/packages/language-service/lib/features/provideFileReferences.ts
+++ b/packages/language-service/lib/features/provideFileReferences.ts
@@ -1,15 +1,14 @@
 import { isReferencesEnabled } from '@volar/language-core';
 import type * as vscode from 'vscode-languageserver-protocol';
 import { URI } from 'vscode-uri';
-import type { LanguageServiceContext, NullableProviderResult, UriComponents } from '../types';
+import type { LanguageServiceContext, NullableProviderResult } from '../types';
 import { NoneCancellationToken } from '../utils/cancellation';
 import * as dedupe from '../utils/dedupe';
 import { documentFeatureWorker, DocumentsAndMap, getSourceRange } from '../utils/featureWorkers';
 
 export function register(context: LanguageServiceContext) {
 
-	return (_uri: URI | UriComponents, token = NoneCancellationToken): NullableProviderResult<vscode.Location[]> => {
-		const uri = _uri instanceof URI ? _uri : URI.from(_uri);
+	return (uri: URI, token = NoneCancellationToken): NullableProviderResult<vscode.Location[]> => {
 
 		return documentFeatureWorker(
 			context,

--- a/packages/language-service/lib/features/provideFileRenameEdits.ts
+++ b/packages/language-service/lib/features/provideFileRenameEdits.ts
@@ -1,5 +1,5 @@
 import { URI } from 'vscode-uri';
-import type { LanguageServiceContext, UriComponents } from '../types';
+import type { LanguageServiceContext } from '../types';
 import { NoneCancellationToken } from '../utils/cancellation';
 import * as dedupe from '../utils/dedupe';
 import { transformWorkspaceEdit } from '../utils/transform';
@@ -8,9 +8,7 @@ import type * as _ from 'vscode-languageserver-protocol';
 
 export function register(context: LanguageServiceContext) {
 
-	return async (_oldUri: URI | UriComponents, _newUri: URI | UriComponents, token = NoneCancellationToken) => {
-		const oldUri = _oldUri instanceof URI ? _oldUri : URI.from(_oldUri);
-		const newUri = _newUri instanceof URI ? _newUri : URI.from(_newUri);
+	return async (oldUri: URI, newUri: URI, token = NoneCancellationToken) => {
 
 		for (const plugin of context.plugins) {
 			if (context.disabledServicePlugins.has(plugin[1])) {

--- a/packages/language-service/lib/features/provideFoldingRanges.ts
+++ b/packages/language-service/lib/features/provideFoldingRanges.ts
@@ -1,6 +1,6 @@
 import { isFoldingRangesEnabled } from '@volar/language-core';
 import { URI } from 'vscode-uri';
-import type { LanguageServiceContext, UriComponents } from '../types';
+import type { LanguageServiceContext } from '../types';
 import { NoneCancellationToken } from '../utils/cancellation';
 import { documentFeatureWorker, getSourceRange } from '../utils/featureWorkers';
 import { transformFoldingRanges } from '../utils/transform';
@@ -9,8 +9,7 @@ import type * as _ from 'vscode-languageserver-protocol';
 
 export function register(context: LanguageServiceContext) {
 
-	return (_uri: URI | UriComponents, token = NoneCancellationToken) => {
-		const uri = _uri instanceof URI ? _uri : URI.from(_uri);
+	return (uri: URI, token = NoneCancellationToken) => {
 
 		return documentFeatureWorker(
 			context,

--- a/packages/language-service/lib/features/provideHover.ts
+++ b/packages/language-service/lib/features/provideHover.ts
@@ -1,7 +1,7 @@
 import { isHoverEnabled } from '@volar/language-core';
 import type * as vscode from 'vscode-languageserver-protocol';
 import { URI } from 'vscode-uri';
-import type { LanguageServiceContext, UriComponents } from '../types';
+import type { LanguageServiceContext } from '../types';
 import { NoneCancellationToken } from '../utils/cancellation';
 import { isInsideRange } from '../utils/common';
 import { getGeneratedPositions, getSourceRange, languageFeatureWorker } from '../utils/featureWorkers';
@@ -10,8 +10,7 @@ import { errorMarkups } from './provideDiagnostics';
 
 export function register(context: LanguageServiceContext) {
 
-	return async (_uri: URI | UriComponents, position: vscode.Position, token = NoneCancellationToken) => {
-		const uri = _uri instanceof URI ? _uri : URI.from(_uri);
+	return async (uri: URI, position: vscode.Position, token = NoneCancellationToken) => {
 
 		let hover = await languageFeatureWorker(
 			context,

--- a/packages/language-service/lib/features/provideInlayHints.ts
+++ b/packages/language-service/lib/features/provideInlayHints.ts
@@ -1,7 +1,7 @@
 import { isInlayHintsEnabled } from '@volar/language-core';
 import type * as vscode from 'vscode-languageserver-protocol';
 import { URI } from 'vscode-uri';
-import type { LanguageServiceContext, UriComponents } from '../types';
+import type { LanguageServiceContext } from '../types';
 import { NoneCancellationToken } from '../utils/cancellation';
 import { findOverlapCodeRange } from '../utils/common';
 import { getSourcePositions, getSourceRange, languageFeatureWorker } from '../utils/featureWorkers';
@@ -15,8 +15,7 @@ export interface InlayHintData {
 
 export function register(context: LanguageServiceContext) {
 
-	return async (_uri: URI | UriComponents, range: vscode.Range, token = NoneCancellationToken) => {
-		const uri = _uri instanceof URI ? _uri : URI.from(_uri);
+	return async (uri: URI, range: vscode.Range, token = NoneCancellationToken) => {
 		const sourceScript = context.language.scripts.get(uri);
 		if (!sourceScript) {
 			return;

--- a/packages/language-service/lib/features/provideLinkedEditingRanges.ts
+++ b/packages/language-service/lib/features/provideLinkedEditingRanges.ts
@@ -1,14 +1,13 @@
 import { isLinkedEditingEnabled } from '@volar/language-core';
 import type * as vscode from 'vscode-languageserver-protocol';
 import { URI } from 'vscode-uri';
-import type { LanguageServiceContext, UriComponents } from '../types';
+import type { LanguageServiceContext } from '../types';
 import { NoneCancellationToken } from '../utils/cancellation';
 import { getGeneratedPositions, getSourceRange, languageFeatureWorker } from '../utils/featureWorkers';
 
 export function register(context: LanguageServiceContext) {
 
-	return (_uri: URI | UriComponents, position: vscode.Position, token = NoneCancellationToken) => {
-		const uri = _uri instanceof URI ? _uri : URI.from(_uri);
+	return (uri: URI, position: vscode.Position, token = NoneCancellationToken) => {
 
 		return languageFeatureWorker(
 			context,

--- a/packages/language-service/lib/features/provideReferences.ts
+++ b/packages/language-service/lib/features/provideReferences.ts
@@ -2,15 +2,14 @@ import { isReferencesEnabled } from '@volar/language-core';
 import type * as vscode from 'vscode-languageserver-protocol';
 import type { TextDocument } from 'vscode-languageserver-textdocument';
 import { URI } from 'vscode-uri';
-import type { LanguageServiceContext, UriComponents } from '../types';
+import type { LanguageServiceContext } from '../types';
 import { NoneCancellationToken } from '../utils/cancellation';
 import * as dedupe from '../utils/dedupe';
 import { DocumentsAndMap, getGeneratedPositions, getLinkedCodePositions, getSourceRange, languageFeatureWorker } from '../utils/featureWorkers';
 
 export function register(context: LanguageServiceContext) {
 
-	return (_uri: URI | UriComponents, position: vscode.Position, referenceContext: vscode.ReferenceContext, token = NoneCancellationToken) => {
-		const uri = _uri instanceof URI ? _uri : URI.from(_uri);
+	return (uri: URI, position: vscode.Position, referenceContext: vscode.ReferenceContext, token = NoneCancellationToken) => {
 
 		return languageFeatureWorker(
 			context,

--- a/packages/language-service/lib/features/provideRenameEdits.ts
+++ b/packages/language-service/lib/features/provideRenameEdits.ts
@@ -2,7 +2,7 @@ import { isRenameEnabled, resolveRenameNewName, type CodeInformation } from '@vo
 import type * as vscode from 'vscode-languageserver-protocol';
 import type { TextDocument } from 'vscode-languageserver-textdocument';
 import { URI } from 'vscode-uri';
-import type { LanguageServiceContext, UriComponents } from '../types';
+import type { LanguageServiceContext } from '../types';
 import { NoneCancellationToken } from '../utils/cancellation';
 import * as dedupe from '../utils/dedupe';
 import { getGeneratedPositions, getLinkedCodePositions, languageFeatureWorker } from '../utils/featureWorkers';
@@ -10,8 +10,7 @@ import { pushEditToDocumentChanges, transformWorkspaceEdit } from '../utils/tran
 
 export function register(context: LanguageServiceContext) {
 
-	return (_uri: URI | UriComponents, position: vscode.Position, newName: string, token = NoneCancellationToken) => {
-		const uri = _uri instanceof URI ? _uri : URI.from(_uri);
+	return (uri: URI, position: vscode.Position, newName: string, token = NoneCancellationToken) => {
 
 		return languageFeatureWorker(
 			context,

--- a/packages/language-service/lib/features/provideRenameRange.ts
+++ b/packages/language-service/lib/features/provideRenameRange.ts
@@ -1,14 +1,13 @@
 import { isRenameEnabled } from '@volar/language-core';
 import type * as vscode from 'vscode-languageserver-protocol';
 import { URI } from 'vscode-uri';
-import type { LanguageServiceContext, UriComponents } from '../types';
+import type { LanguageServiceContext } from '../types';
 import { NoneCancellationToken } from '../utils/cancellation';
 import { getGeneratedPositions, getSourceRange, languageFeatureWorker } from '../utils/featureWorkers';
 
 export function register(context: LanguageServiceContext) {
 
-	return (_uri: URI | UriComponents, position: vscode.Position, token = NoneCancellationToken) => {
-		const uri = _uri instanceof URI ? _uri : URI.from(_uri);
+	return (uri: URI, position: vscode.Position, token = NoneCancellationToken) => {
 
 		return languageFeatureWorker(
 			context,

--- a/packages/language-service/lib/features/provideSelectionRanges.ts
+++ b/packages/language-service/lib/features/provideSelectionRanges.ts
@@ -1,7 +1,7 @@
 import { isSelectionRangesEnabled } from '@volar/language-core';
 import type * as vscode from 'vscode-languageserver-protocol';
 import { URI } from 'vscode-uri';
-import type { LanguageServiceContext, UriComponents } from '../types';
+import type { LanguageServiceContext } from '../types';
 import { NoneCancellationToken } from '../utils/cancellation';
 import { isEqualRange, isInsideRange } from '../utils/common';
 import { getGeneratedPositions, getSourceRange, languageFeatureWorker } from '../utils/featureWorkers';
@@ -9,8 +9,7 @@ import { transformSelectionRanges } from '../utils/transform';
 
 export function register(context: LanguageServiceContext) {
 
-	return (_uri: URI | UriComponents, positions: vscode.Position[], token = NoneCancellationToken) => {
-		const uri = _uri instanceof URI ? _uri : URI.from(_uri);
+	return (uri: URI, positions: vscode.Position[], token = NoneCancellationToken) => {
 
 		return languageFeatureWorker(
 			context,

--- a/packages/language-service/lib/features/provideSignatureHelp.ts
+++ b/packages/language-service/lib/features/provideSignatureHelp.ts
@@ -1,14 +1,14 @@
 import { isSignatureHelpEnabled } from '@volar/language-core';
 import type * as vscode from 'vscode-languageserver-protocol';
 import { URI } from 'vscode-uri';
-import type { LanguageServiceContext, UriComponents } from '../types';
+import type { LanguageServiceContext } from '../types';
 import { NoneCancellationToken } from '../utils/cancellation';
 import { getGeneratedPositions, languageFeatureWorker } from '../utils/featureWorkers';
 
 export function register(context: LanguageServiceContext) {
 
 	return (
-		_uri: URI | UriComponents,
+		uri: URI,
 		position: vscode.Position,
 		signatureHelpContext: vscode.SignatureHelpContext = {
 			triggerKind: 1 satisfies typeof vscode.SignatureHelpTriggerKind.Invoked,
@@ -16,7 +16,6 @@ export function register(context: LanguageServiceContext) {
 		},
 		token = NoneCancellationToken
 	) => {
-		const uri = _uri instanceof URI ? _uri : URI.from(_uri);
 
 		return languageFeatureWorker(
 			context,

--- a/packages/language-service/lib/languageService.ts
+++ b/packages/language-service/lib/languageService.ts
@@ -182,20 +182,18 @@ function createLanguageServiceBase(
 	plugins: LanguageServicePlugin[],
 	context: LanguageServiceContext
 ) {
+	const tokenModifiers = plugins.map(plugin => plugin.capabilities.semanticTokensProvider?.legend?.tokenModifiers ?? []).flat();
+	const tokenTypes = plugins.map(plugin => plugin.capabilities.semanticTokensProvider?.legend?.tokenTypes ?? []).flat();
 	return {
-		getSemanticTokenLegend: () => {
-			const tokenModifiers = plugins.map(plugin => plugin.capabilities.semanticTokensProvider?.legend?.tokenModifiers ?? []).flat();
-			const tokenTypes = plugins.map(plugin => plugin.capabilities.semanticTokensProvider?.legend?.tokenTypes ?? []).flat();
-			return {
-				tokenModifiers: [...new Set(tokenModifiers)],
-				tokenTypes: [...new Set(tokenTypes)],
-			};
+		semanticTokenLegend: {
+			tokenModifiers: [...new Set(tokenModifiers)],
+			tokenTypes: [...new Set(tokenTypes)],
 		},
-		getCommands: () => plugins.map(plugin => plugin.capabilities.executeCommandProvider?.commands ?? []).flat(),
-		getTriggerCharacters: () => plugins.map(plugin => plugin.capabilities.completionProvider?.triggerCharacters ?? []).flat(),
-		getAutoFormatTriggerCharacters: () => plugins.map(plugin => plugin.capabilities.documentOnTypeFormattingProvider?.triggerCharacters ?? []).flat(),
-		getSignatureHelpTriggerCharacters: () => plugins.map(plugin => plugin.capabilities.signatureHelpProvider?.triggerCharacters ?? []).flat(),
-		getSignatureHelpRetriggerCharacters: () => plugins.map(plugin => plugin.capabilities.signatureHelpProvider?.retriggerCharacters ?? []).flat(),
+		commands: plugins.map(plugin => plugin.capabilities.executeCommandProvider?.commands ?? []).flat(),
+		triggerCharacters: plugins.map(plugin => plugin.capabilities.completionProvider?.triggerCharacters ?? []).flat(),
+		autoFormatTriggerCharacters: plugins.map(plugin => plugin.capabilities.documentOnTypeFormattingProvider?.triggerCharacters ?? []).flat(),
+		signatureHelpTriggerCharacters: plugins.map(plugin => plugin.capabilities.signatureHelpProvider?.triggerCharacters ?? []).flat(),
+		signatureHelpRetriggerCharacters: plugins.map(plugin => plugin.capabilities.signatureHelpProvider?.retriggerCharacters ?? []).flat(),
 
 		executeCommand(command: string, args: any[], token = NoneCancellationToken) {
 			for (const plugin of context.plugins) {

--- a/packages/language-service/lib/types.ts
+++ b/packages/language-service/lib/types.ts
@@ -8,14 +8,6 @@ import type { UriMap } from './utils/uriMap';
 
 export type * from 'vscode-languageserver-protocol';
 
-export interface UriComponents {
-	scheme: string;
-	authority: string;
-	path: string;
-	query: string;
-	fragment: string;
-}
-
 export interface LanguageServiceEnvironment {
 	workspaceFolders: URI[];
 	locale?: string;

--- a/packages/monaco/lib/editor.ts
+++ b/packages/monaco/lib/editor.ts
@@ -1,6 +1,6 @@
-import type { LanguageService } from '@volar/language-service';
 import { fromPosition, toMarkerData, toTextEdit } from 'monaco-languageserver-types';
 import type { editor, IDisposable, MonacoEditor, Uri } from 'monaco-types';
+import { WorkerLanguageService } from '../worker.js';
 import { markers } from './markers.js';
 
 interface IInternalEditorModel extends editor.IModel {
@@ -9,7 +9,7 @@ interface IInternalEditorModel extends editor.IModel {
 }
 
 export function activateMarkers(
-	worker: editor.MonacoWebWorker<LanguageService>,
+	worker: editor.MonacoWebWorker<WorkerLanguageService>,
 	languages: string[],
 	markersOwn: string,
 	getSyncUris: () => Uri[],
@@ -107,7 +107,7 @@ export function activateMarkers(
 }
 
 export function activateAutoInsertion(
-	worker: editor.MonacoWebWorker<LanguageService>,
+	worker: editor.MonacoWebWorker<WorkerLanguageService>,
 	languages: string[],
 	getSyncUris: () => Uri[],
 	editor: MonacoEditor['editor']

--- a/packages/monaco/lib/languages.ts
+++ b/packages/monaco/lib/languages.ts
@@ -1,4 +1,3 @@
-import type { LanguageService } from '@volar/language-service';
 import type {
 	IDisposable,
 	MonacoEditor,
@@ -6,10 +5,11 @@ import type {
 	editor,
 	languages,
 } from 'monaco-types';
+import { WorkerLanguageService } from '../worker.js';
 import { createLanguageFeaturesProvider } from './provider.js';
 
 export async function registerProviders(
-	worker: editor.MonacoWebWorker<LanguageService>,
+	worker: editor.MonacoWebWorker<WorkerLanguageService>,
 	language: languages.LanguageSelector,
 	getSyncUris: () => Uri[],
 	languages: MonacoEditor['languages']

--- a/packages/monaco/lib/provider.ts
+++ b/packages/monaco/lib/provider.ts
@@ -6,7 +6,6 @@ import type {
 	Diagnostic,
 	DocumentLink,
 	InlayHint,
-	LanguageService,
 } from '@volar/language-service';
 import {
 	fromCompletionContext,
@@ -36,10 +35,11 @@ import {
 	toWorkspaceEdit,
 } from 'monaco-languageserver-types';
 import type { Uri, editor, languages } from 'monaco-types';
+import { WorkerLanguageService } from '../worker.js';
 import { markers } from './markers.js';
 
 export async function createLanguageFeaturesProvider(
-	worker: editor.MonacoWebWorker<LanguageService>,
+	worker: editor.MonacoWebWorker<WorkerLanguageService>,
 	getSyncUris: () => Uri[]
 ): Promise<
 	languages.HoverProvider &

--- a/packages/monaco/worker.ts
+++ b/packages/monaco/worker.ts
@@ -290,8 +290,8 @@ export class WorkerLanguageService {
 	getDiagnostics(uri: UriComponents, ...restArgs: TrimParams<LanguageService['getDiagnostics']>) {
 		return this.languageService.getDiagnostics(URI.from(uri), ...restArgs);
 	}
-	getWorkspaceDiagnostics(...restArgs: TrimParams<LanguageService['getWorkspaceDiagnostics']>) {
-		return this.languageService.getWorkspaceDiagnostics(...restArgs);
+	getWorkspaceDiagnostics(...args: Parameters<LanguageService['getWorkspaceDiagnostics']>) {
+		return this.languageService.getWorkspaceDiagnostics(...args);
 	}
 	getReferences(uri: UriComponents, ...restArgs: TrimParams<LanguageService['getReferences']>) {
 		return this.languageService.getReferences(URI.from(uri), ...restArgs);
@@ -385,4 +385,4 @@ export class WorkerLanguageService {
 	}
 }
 
-type TrimParams<T> = T extends ((...args: [any, ...infer U]) => any) ? U : never;
+type TrimParams<T> = T extends ((...args: [uri: any, ...infer U, token: any]) => any) ? U : never;


### PR DESCRIPTION
The instantiation of URI objects should not be done in `@volar/language-service`, but should be done by the proxy object of LangaugeService in the worker.