### PR TITLE
feat(monaco): implement CancellationToken for workers

### DIFF
--- a/packages/language-server/lib/register/registerLanguageFeatures.ts
+++ b/packages/language-server/lib/register/registerLanguageFeatures.ts
@@ -334,8 +334,8 @@ export function registerLanguageFeatures(server: LanguageServer) {
 					uri,
 					undefined,
 					server.initializeResult.capabilities.semanticTokensProvider!.legend,
-					token,
-					tokens => resultProgress?.report(tokens)
+					tokens => resultProgress?.report(tokens),
+					token
 				);
 			}) ?? { data: [] };
 		});
@@ -348,8 +348,8 @@ export function registerLanguageFeatures(server: LanguageServer) {
 					uri,
 					params.range,
 					server.initializeResult.capabilities.semanticTokensProvider!.legend,
-					token,
-					tokens => resultProgress?.report(tokens)
+					tokens => resultProgress?.report(tokens),
+					token
 				);
 			}) ?? { data: [] };
 		});
@@ -360,7 +360,6 @@ export function registerLanguageFeatures(server: LanguageServer) {
 			const result = await worker(uri, token, languageService => {
 				return languageService.getDiagnostics(
 					uri,
-					token,
 					errors => {
 						// resultProgressReporter is undefined in vscode
 						resultProgressReporter?.report({
@@ -371,7 +370,8 @@ export function registerLanguageFeatures(server: LanguageServer) {
 								},
 							},
 						});
-					}
+					},
+					token
 				);
 			});
 			return {

--- a/packages/language-server/lib/server.ts
+++ b/packages/language-server/lib/server.ts
@@ -510,9 +510,9 @@ export function createServerBase(
 	async function pushDiagnostics(project: LanguageServerProject, uriStr: string, version: number, cancel: vscode.CancellationToken) {
 		const uri = URI.parse(uriStr);
 		const languageService = await project.getLanguageService(uri);
-		const errors = await languageService.getDiagnostics(uri, cancel, result => {
+		const errors = await languageService.getDiagnostics(uri, result => {
 			connection.sendDiagnostics({ uri: uriStr, diagnostics: result, version });
-		});
+		}, cancel);
 
 		connection.sendDiagnostics({ uri: uriStr, diagnostics: errors, version });
 	}

--- a/packages/language-service/lib/features/provideDiagnostics.ts
+++ b/packages/language-service/lib/features/provideDiagnostics.ts
@@ -148,8 +148,8 @@ export function register(context: LanguageServiceContext) {
 
 	return async (
 		uri: URI,
-		token = NoneCancellationToken,
-		response?: (result: vscode.Diagnostic[]) => void
+		response?: (result: vscode.Diagnostic[]) => void,
+		token = NoneCancellationToken
 	) => {
 
 		let langaugeIdAndSnapshot: SourceScript<URI> | VirtualCode | undefined;

--- a/packages/language-service/lib/features/provideDocumentSemanticTokens.ts
+++ b/packages/language-service/lib/features/provideDocumentSemanticTokens.ts
@@ -13,8 +13,8 @@ export function register(context: LanguageServiceContext) {
 		uri: URI,
 		range: vscode.Range | undefined,
 		legend: vscode.SemanticTokensLegend,
-		token = NoneCancellationToken,
-		_reportProgress?: (tokens: vscode.SemanticTokens) => void // TODO
+		_reportProgress?: (tokens: vscode.SemanticTokens) => void, // TODO
+		token = NoneCancellationToken
 	): Promise<vscode.SemanticTokens | undefined> => {
 		const sourceScript = context.language.scripts.get(uri);
 		if (!sourceScript) {

--- a/packages/monaco/lib/requestId.ts
+++ b/packages/monaco/lib/requestId.ts
@@ -1,0 +1,11 @@
+import type { CancellationToken } from 'monaco-types';
+import type { WorkerLanguageService } from '../worker.js';
+
+const requestIdMap = new WeakMap<WorkerLanguageService, number>();
+
+export function getRequestId(token: CancellationToken, languageService: WorkerLanguageService) {
+	const nextRequestId = (requestIdMap.get(languageService) ?? 0) + 1;
+	requestIdMap.set(languageService, nextRequestId);
+	token.onCancellationRequested(() => languageService.cancelRequest(nextRequestId));
+	return nextRequestId;
+}


### PR DESCRIPTION
Now need to pass in `requestId` when calling `WorkerLanguageService` APIs, and it can notify `WorkerLanguageService` to cancel the request by calling `cancelRequest(requestId)`. These API changes are internal and developers shouldn't care about it.