### PR TITLE
fix(typescript): improve accuracy of `runTsc` extensions parameter behavior

### DIFF
--- a/packages/typescript/lib/quickstart/runTsc.ts
+++ b/packages/typescript/lib/quickstart/runTsc.ts
@@ -43,7 +43,6 @@ export function runTsc(
 				tsc = replace(tsc, /supportedTSExtensions = .*(?=;)/, s => s + `.map((group, i) => i === 0 ? group.splice(0, 0, ${extsText}) && group : group)`);
 				tsc = replace(tsc, /supportedJSExtensions = .*(?=;)/, s => s + `.map((group, i) => i === 0 ? group.splice(0, 0, ${extsText}) && group : group)`);
 				tsc = replace(tsc, /allSupportedExtensions = .*(?=;)/, s => s + `.map((group, i) => i === 0 ? group.splice(0, 0, ${extsText}) && group : group)`);
-
 			}
 			if (extraExtensionsToRemove.length) {
 				const extsText = extraExtensionsToRemove.map(ext => `"${ext}"`).join(', ');

--- a/packages/typescript/lib/quickstart/runTsc.ts
+++ b/packages/typescript/lib/quickstart/runTsc.ts
@@ -37,17 +37,19 @@ export function runTsc(
 			}
 			const needPatchExtenstions = extraSupportedExtensions.filter(ext => !extraExtensionsToRemove.includes(ext));
 
-			// add allow extensions
+			// Add allow extensions
 			if (extraSupportedExtensions.length) {
 				const extsText = extraSupportedExtensions.map(ext => `"${ext}"`).join(', ');
 				tsc = replace(tsc, /supportedTSExtensions = .*(?=;)/, s => s + `.map((group, i) => i === 0 ? group.splice(0, 0, ${extsText}) && group : group)`);
 				tsc = replace(tsc, /supportedJSExtensions = .*(?=;)/, s => s + `.map((group, i) => i === 0 ? group.splice(0, 0, ${extsText}) && group : group)`);
 				tsc = replace(tsc, /allSupportedExtensions = .*(?=;)/, s => s + `.map((group, i) => i === 0 ? group.splice(0, 0, ${extsText}) && group : group)`);
 			}
+			// Use to emit basename.xxx to basename.d.ts instead of basename.xxx.d.ts
 			if (extraExtensionsToRemove.length) {
 				const extsText = extraExtensionsToRemove.map(ext => `"${ext}"`).join(', ');
 				tsc = replace(tsc, /extensionsToRemove = .*(?=;)/, s => s + `.concat([${extsText}])`);
 			}
+			// Support for basename.xxx to basename.xxx.d.ts
 			if (needPatchExtenstions.length) {
 				const extsText = needPatchExtenstions.map(ext => `"${ext}"`).join(', ');
 				tsc = replace(tsc, /function changeExtension\(/, s => `function changeExtension(path, newExtension) {

--- a/packages/typescript/lib/quickstart/runTsc.ts
+++ b/packages/typescript/lib/quickstart/runTsc.ts
@@ -9,9 +9,9 @@ export let getLanguagePlugins: (ts: typeof import('typescript'), options: ts.Cre
 
 export function runTsc(
 	tscPath: string,
-	extensionsOrOptions: string[] | {
-		supportedExtensions: string[];
-		extensionsToRemove: string[];
+	options: string[] | {
+		extraSupportedExtensions: string[];
+		extraExtensionsToRemove: string[];
 	},
 	_getLanguagePlugins: typeof getLanguagePlugins
 ) {
@@ -25,19 +25,37 @@ export function runTsc(
 		if (args[0] === tscPath) {
 			let tsc = (readFileSync as any)(...args) as string;
 
-			const supportedExtensions = Array.isArray(extensionsOrOptions) ? extensionsOrOptions : extensionsOrOptions.supportedExtensions;
-			const extensionsToRemove = Array.isArray(extensionsOrOptions) ? [] : extensionsOrOptions.extensionsToRemove;
+			let extraSupportedExtensions: string[];
+			let extraExtensionsToRemove: string[];
+			if (Array.isArray(options)) {
+				extraSupportedExtensions = options;
+				extraExtensionsToRemove = [];
+			}
+			else {
+				extraSupportedExtensions = options.extraSupportedExtensions;
+				extraExtensionsToRemove = options.extraExtensionsToRemove;
+			}
+			const needPatchExtenstions = extraSupportedExtensions.filter(ext => !extraExtensionsToRemove.includes(ext));
 
 			// add allow extensions
-			if (supportedExtensions.length) {
-				const extsText = supportedExtensions.map(ext => `"${ext}"`).join(', ');
-				tsc = replace(tsc, /supportedTSExtensions = .*(?=;)/, s => s + `.concat([[${extsText}]])`);
-				tsc = replace(tsc, /supportedJSExtensions = .*(?=;)/, s => s + `.concat([[${extsText}]])`);
-				tsc = replace(tsc, /allSupportedExtensions = .*(?=;)/, s => s + `.concat([[${extsText}]])`);
+			if (extraSupportedExtensions.length) {
+				const extsText = extraSupportedExtensions.map(ext => `"${ext}"`).join(', ');
+				tsc = replace(tsc, /supportedTSExtensions = .*(?=;)/, s => s + `.map((group, i) => i === 0 ? group.splice(0, 0, ${extsText}) && group : group)`);
+				tsc = replace(tsc, /supportedJSExtensions = .*(?=;)/, s => s + `.map((group, i) => i === 0 ? group.splice(0, 0, ${extsText}) && group : group)`);
+				tsc = replace(tsc, /allSupportedExtensions = .*(?=;)/, s => s + `.map((group, i) => i === 0 ? group.splice(0, 0, ${extsText}) && group : group)`);
+
 			}
-			if (extensionsToRemove.length) {
-				const extsText = extensionsToRemove.map(ext => `"${ext}"`).join(', ');
+			if (extraExtensionsToRemove.length) {
+				const extsText = extraExtensionsToRemove.map(ext => `"${ext}"`).join(', ');
 				tsc = replace(tsc, /extensionsToRemove = .*(?=;)/, s => s + `.concat([${extsText}])`);
+			}
+			if (needPatchExtenstions.length) {
+				const extsText = needPatchExtenstions.map(ext => `"${ext}"`).join(', ');
+				tsc = replace(tsc, /function changeExtension\(/, s => `function changeExtension(path, newExtension) {
+					return [${extsText}].some(ext => path.endsWith(ext))
+						? path + newExtension
+						: _changeExtension(path, newExtension)
+					}\n` + s.replace('changeExtension', '_changeExtension'));
 			}
 
 			// proxy createProgram


### PR DESCRIPTION
This PR will solve the `error TS5055: Cannot write file 'xxx/yyy.vue.d.ts' because it would overwrite input file.` error, and the problem that `--clean` cannot clean the `.vue.d.ts` file.

### Details

- extra extensions need to be added to the first group of `supportedTSExtensions`, which will make tsc think that `.vue` and `.vue.d.ts` are associated file types, thus solving the problem that `.vue` and `.vue.d.ts` are considered multiple source file problem.
- Extra extensions need to be located in front of `.d.ts.` tsc depends on the order to determine the priority of `.vue` and `.vue.d.ts`.
- Patch `changeExtension` to resolve tsc not knowing it should convert `xxx.vue` to `xxx.vue.d.ts` instead of `xxx.d.ts`.