### PR TITLE
chore(monaco): update to monaco-languageserver-types 0.4

### DIFF
--- a/packages/monaco/lib/provider.ts
+++ b/packages/monaco/lib/provider.ts
@@ -231,7 +231,7 @@ export async function createLanguageFeaturesProvider(
 			);
 
 			if (codeResult) {
-				const monacoResult = codeResult.map(codeAction => toCodeAction(codeAction));
+				const monacoResult = codeResult.map(toCodeAction);
 				for (let i = 0; i < monacoResult.length; i++) {
 					codeActions.set(monacoResult[i], codeResult[i]);
 				}

--- a/packages/monaco/package.json
+++ b/packages/monaco/package.json
@@ -15,7 +15,7 @@
 	"dependencies": {
 		"@volar/language-service": "2.4.0-alpha.16",
 		"@volar/typescript": "2.4.0-alpha.16",
-		"monaco-languageserver-types": "^0.3.4",
+		"monaco-languageserver-types": "^0.4.0",
 		"monaco-types": "^0.1.0",
 		"vscode-uri": "^3.0.8"
 	},

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -176,8 +176,8 @@ importers:
         specifier: 2.4.0-alpha.16
         version: link:../typescript
       monaco-languageserver-types:
-        specifier: ^0.3.4
-        version: 0.3.4
+        specifier: ^0.4.0
+        version: 0.4.0
       monaco-types:
         specifier: ^0.1.0
         version: 0.1.0
@@ -2006,8 +2006,8 @@ packages:
   monaco-editor-core@0.50.0:
     resolution: {integrity: sha512-XKdublTat9qDKwJhMbm6nnTUKA75MU7jWVooZeXcZKP0/y2jscNWQ9FpCiRtWk33Teemihx155WQ7o7xgf89eA==}
 
-  monaco-languageserver-types@0.3.4:
-    resolution: {integrity: sha512-d58sP5yNhjs8uG1ESXs0hFnuX2YfdMhiGeWhdgTUZyG9aaWgyI4dDwrK1khf1mPF2u9Sljv42sfYqPFZnqYMYg==}
+  monaco-languageserver-types@0.4.0:
+    resolution: {integrity: sha512-QQ3BZiU5LYkJElGncSNb5AKoJ/LCs6YBMCJMAz9EA7v+JaOdn3kx2cXpPTcZfKA5AEsR0vc97sAw+5mdNhVBmw==}
 
   monaco-types@0.1.0:
     resolution: {integrity: sha512-aWK7SN9hAqNYi0WosPoMjenMeXJjwCxDibOqWffyQ/qXdzB/86xshGQobRferfmNz7BSNQ8GB0MD0oby9/5fTQ==}
@@ -4780,7 +4780,7 @@ snapshots:
 
   monaco-editor-core@0.50.0: {}
 
-  monaco-languageserver-types@0.3.4:
+  monaco-languageserver-types@0.4.0:
     dependencies:
       monaco-types: 0.1.0
       vscode-languageserver-protocol: 3.17.5


### PR DESCRIPTION
The most important change for Volar, is that the default diagnostic severity is now error.

See https://github.com/remcohaszing/monaco-languageserver-types/releases/tag/v0.4.0