### PR TITLE
refactor(langauge-server): Improve LSP diagnostic integration

### DIFF
--- a/packages/language-server/lib/project/typescriptProject.ts
+++ b/packages/language-server/lib/project/typescriptProject.ts
@@ -28,7 +28,7 @@ export function createTypeScriptProject(
 	const inferredProjects = createUriMap<Promise<TypeScriptProjectLS>>();
 	const rootTsConfigs = new Set<string>();
 	const searchedDirs = new Set<string>();
-	const projects: LanguageServerProject = {
+	const project: LanguageServerProject = {
 		setup(_server) {
 			uriConverter = createUriConverter([..._server.workspaceFolders.keys()]);
 			server = _server;
@@ -51,7 +51,7 @@ export function createTypeScriptProject(
 					}
 				}
 
-				server.refresh(projects, !!tsConfigChanges.length);
+				server.diagnosticsSupport?.refresh(project, !!tsConfigChanges.length);
 			});
 		},
 		async getLanguageService(uri) {
@@ -82,7 +82,7 @@ export function createTypeScriptProject(
 			inferredProjects.clear();
 		},
 	};
-	return projects;
+	return project;
 
 	async function findMatchTSConfig(server: LanguageServer, uri: URI) {
 

--- a/packages/language-server/lib/project/typescriptProject.ts
+++ b/packages/language-server/lib/project/typescriptProject.ts
@@ -51,10 +51,7 @@ export function createTypeScriptProject(
 					}
 				}
 
-				if (tsConfigChanges.length) {
-					server.clearPushDiagnostics();
-				}
-				server.refresh(projects);
+				server.refresh(projects, !!tsConfigChanges.length);
 			});
 		},
 		async getLanguageService(uri) {

--- a/packages/language-server/lib/register/registerLanguageFeatures.ts
+++ b/packages/language-server/lib/register/registerLanguageFeatures.ts
@@ -5,36 +5,6 @@ import { AutoInsertRequest, FindFileReferenceRequest } from '../../protocol';
 import type { LanguageServer } from '../types';
 
 export function registerLanguageFeatures(server: LanguageServer) {
-	const {
-		documentFormattingProvider,
-		documentRangeFormattingProvider,
-		documentOnTypeFormattingProvider,
-		selectionRangeProvider,
-		foldingRangeProvider,
-		linkedEditingRangeProvider,
-		documentSymbolProvider,
-		colorProvider,
-		completionProvider,
-		hoverProvider,
-		signatureHelpProvider,
-		renameProvider,
-		codeLensProvider,
-		codeActionProvider,
-		referencesProvider,
-		implementationProvider,
-		definitionProvider,
-		typeDefinitionProvider,
-		documentHighlightProvider,
-		documentLinkProvider,
-		workspaceSymbolProvider,
-		callHierarchyProvider,
-		semanticTokensProvider,
-		diagnosticProvider,
-		inlayHintProvider,
-		executeCommandProvider,
-		experimental,
-	} = server.initializeResult.capabilities;
-
 	let lastCompleteUri: string;
 	let lastCompleteLs: LanguageService | undefined;
 	let lastCodeLensLs: LanguageService | undefined;
@@ -45,412 +15,336 @@ export function registerLanguageFeatures(server: LanguageServer) {
 	let languageServiceToId = new WeakMap<LanguageService, number>();
 	let currentLanguageServiceId = 0;
 
-	const idToLanguageService = new Map<number, WeakRef<LanguageService>>();
+	const languageServiceById = new Map<number, WeakRef<LanguageService>>();
 
-	if (documentFormattingProvider) {
-		server.connection.onDocumentFormatting(async (params, token) => {
-			const uri = URI.parse(params.textDocument.uri);
-			return await worker(uri, token, languageService => {
-				return languageService.getDocumentFormattingEdits(uri, params.options, undefined, undefined, token);
-			});
+	server.connection.onDocumentFormatting(async (params, token) => {
+		const uri = URI.parse(params.textDocument.uri);
+		return await worker(uri, token, languageService => {
+			return languageService.getDocumentFormattingEdits(uri, params.options, undefined, undefined, token);
 		});
-	}
-	if (documentRangeFormattingProvider) {
-		server.connection.onDocumentRangeFormatting(async (params, token) => {
-			const uri = URI.parse(params.textDocument.uri);
-			return await worker(uri, token, languageService => {
-				return languageService.getDocumentFormattingEdits(uri, params.options, params.range, undefined, token);
-			});
+	});
+	server.connection.onDocumentRangeFormatting(async (params, token) => {
+		const uri = URI.parse(params.textDocument.uri);
+		return await worker(uri, token, languageService => {
+			return languageService.getDocumentFormattingEdits(uri, params.options, params.range, undefined, token);
 		});
-	}
-	if (documentOnTypeFormattingProvider) {
-		server.connection.onDocumentOnTypeFormatting(async (params, token) => {
-			const uri = URI.parse(params.textDocument.uri);
-			return await worker(uri, token, languageService => {
-				return languageService.getDocumentFormattingEdits(uri, params.options, undefined, params, token);
-			});
+	});
+	server.connection.onDocumentOnTypeFormatting(async (params, token) => {
+		const uri = URI.parse(params.textDocument.uri);
+		return await worker(uri, token, languageService => {
+			return languageService.getDocumentFormattingEdits(uri, params.options, undefined, params, token);
 		});
-	}
-	if (selectionRangeProvider) {
-		server.connection.onSelectionRanges(async (params, token) => {
-			const uri = URI.parse(params.textDocument.uri);
-			return await worker(uri, token, languageService => {
-				return languageService.getSelectionRanges(uri, params.positions, token);
-			});
+	});
+	server.connection.onSelectionRanges(async (params, token) => {
+		const uri = URI.parse(params.textDocument.uri);
+		return await worker(uri, token, languageService => {
+			return languageService.getSelectionRanges(uri, params.positions, token);
 		});
-	}
-	if (foldingRangeProvider) {
-		server.connection.onFoldingRanges(async (params, token) => {
-			const uri = URI.parse(params.textDocument.uri);
-			return await worker(uri, token, languageService => {
-				return languageService.getFoldingRanges(uri, token);
-			});
+	});
+	server.connection.onFoldingRanges(async (params, token) => {
+		const uri = URI.parse(params.textDocument.uri);
+		return await worker(uri, token, languageService => {
+			return languageService.getFoldingRanges(uri, token);
 		});
-	}
-	if (linkedEditingRangeProvider) {
-		server.connection.languages.onLinkedEditingRange(async (params, token) => {
-			const uri = URI.parse(params.textDocument.uri);
-			return await worker(uri, token, languageService => {
-				return languageService.getLinkedEditingRanges(uri, params.position, token);
-			});
+	});
+	server.connection.languages.onLinkedEditingRange(async (params, token) => {
+		const uri = URI.parse(params.textDocument.uri);
+		return await worker(uri, token, languageService => {
+			return languageService.getLinkedEditingRanges(uri, params.position, token);
 		});
-	}
-	if (documentSymbolProvider) {
-		server.connection.onDocumentSymbol(async (params, token) => {
-			const uri = URI.parse(params.textDocument.uri);
-			return await worker(uri, token, languageService => {
-				return languageService.getDocumentSymbols(uri, token);
-			});
+	});
+	server.connection.onDocumentSymbol(async (params, token) => {
+		const uri = URI.parse(params.textDocument.uri);
+		return await worker(uri, token, languageService => {
+			return languageService.getDocumentSymbols(uri, token);
 		});
-	}
-	if (colorProvider) {
-		server.connection.onDocumentColor(async (params, token) => {
-			const uri = URI.parse(params.textDocument.uri);
-			return await worker(uri, token, languageService => {
-				return languageService.getDocumentColors(uri, token);
-			});
+	});
+	server.connection.onDocumentColor(async (params, token) => {
+		const uri = URI.parse(params.textDocument.uri);
+		return await worker(uri, token, languageService => {
+			return languageService.getDocumentColors(uri, token);
 		});
-		server.connection.onColorPresentation(async (params, token) => {
-			const uri = URI.parse(params.textDocument.uri);
-			return await worker(uri, token, languageService => {
-				return languageService.getColorPresentations(uri, params.color, params.range, token);
-			});
+	});
+	server.connection.onColorPresentation(async (params, token) => {
+		const uri = URI.parse(params.textDocument.uri);
+		return await worker(uri, token, languageService => {
+			return languageService.getColorPresentations(uri, params.color, params.range, token);
 		});
-	}
-	if (completionProvider) {
-		server.connection.onCompletion(async (params, token) => {
-			const uri = URI.parse(params.textDocument.uri);
-			return await worker(uri, token, async languageService => {
-				lastCompleteUri = params.textDocument.uri;
-				lastCompleteLs = languageService;
-				const list = await languageService.getCompletionItems(
-					uri,
-					params.position,
-					params.context,
-					token
-				);
-				for (const item of list.items) {
-					fixTextEdit(item);
-				}
-				return list;
-			});
-		});
-	}
-	if (completionProvider?.resolveProvider) {
-		server.connection.onCompletionResolve(async (item, token) => {
-			if (lastCompleteUri && lastCompleteLs) {
-				item = await lastCompleteLs.resolveCompletionItem(item, token);
+	});
+	server.connection.onCompletion(async (params, token) => {
+		const uri = URI.parse(params.textDocument.uri);
+		return await worker(uri, token, async languageService => {
+			lastCompleteUri = params.textDocument.uri;
+			lastCompleteLs = languageService;
+			const list = await languageService.getCompletionItems(
+				uri,
+				params.position,
+				params.context,
+				token
+			);
+			for (const item of list.items) {
 				fixTextEdit(item);
 			}
-			return item;
+			return list;
 		});
-	}
-	if (hoverProvider) {
-		server.connection.onHover(async (params, token) => {
-			const uri = URI.parse(params.textDocument.uri);
-			return await worker(uri, token, languageService => {
-				return languageService.getHover(uri, params.position, token);
-			});
+	});
+	server.connection.onCompletionResolve(async (item, token) => {
+		if (lastCompleteUri && lastCompleteLs) {
+			item = await lastCompleteLs.resolveCompletionItem(item, token);
+			fixTextEdit(item);
+		}
+		return item;
+	});
+	server.connection.onHover(async (params, token) => {
+		const uri = URI.parse(params.textDocument.uri);
+		return await worker(uri, token, languageService => {
+			return languageService.getHover(uri, params.position, token);
 		});
-	}
-	if (signatureHelpProvider) {
-		server.connection.onSignatureHelp(async (params, token) => {
-			const uri = URI.parse(params.textDocument.uri);
-			return await worker(uri, token, languageService => {
-				return languageService.getSignatureHelp(uri, params.position, params.context, token);
-			});
+	});
+	server.connection.onSignatureHelp(async (params, token) => {
+		const uri = URI.parse(params.textDocument.uri);
+		return await worker(uri, token, languageService => {
+			return languageService.getSignatureHelp(uri, params.position, params.context, token);
 		});
-	}
-	if (renameProvider) {
-		server.connection.onRenameRequest(async (params, token) => {
-			const uri = URI.parse(params.textDocument.uri);
-			return await worker(uri, token, languageService => {
-				return languageService.getRenameEdits(uri, params.position, params.newName, token);
-			});
+	});
+	server.connection.onRenameRequest(async (params, token) => {
+		const uri = URI.parse(params.textDocument.uri);
+		return await worker(uri, token, languageService => {
+			return languageService.getRenameEdits(uri, params.position, params.newName, token);
 		});
-	}
-	if (typeof renameProvider === 'object' && renameProvider.prepareProvider) {
-		server.connection.onPrepareRename(async (params, token) => {
-			const uri = URI.parse(params.textDocument.uri);
-			return await worker(uri, token, async languageService => {
-				const result = await languageService.getRenameRange(uri, params.position, token);
-				if (result && 'message' in result) {
-					return new vscode.ResponseError(0, result.message);
-				}
-				return result;
-			});
-		});
-	}
-	if (codeLensProvider) {
-		server.connection.onCodeLens(async (params, token) => {
-			const uri = URI.parse(params.textDocument.uri);
-			return await worker(uri, token, languageService => {
-				lastCodeLensLs = languageService;
-				return languageService.getCodeLenses(uri, token);
-			});
-		});
-	}
-	if (codeLensProvider?.resolveProvider) {
-		server.connection.onCodeLensResolve(async (codeLens, token) => {
-			return await lastCodeLensLs?.resolveCodeLens(codeLens, token) ?? codeLens;
-		});
-	}
-	if (codeActionProvider) {
-		server.connection.onCodeAction(async (params, token) => {
-			const uri = URI.parse(params.textDocument.uri);
-			return await worker(uri, token, async languageService => {
-				lastCodeActionLs = languageService;
-				let codeActions = await languageService.getCodeActions(uri, params.range, params.context, token) ?? [];
-				for (const codeAction of codeActions) {
-					if (codeAction.data && typeof codeAction.data === 'object') {
-						(codeAction.data as any).uri = params.textDocument.uri;
-					}
-					else {
-						codeAction.data = { uri: params.textDocument.uri };
-					}
-				}
-				if (!server.initializeParams?.capabilities.textDocument?.codeAction?.disabledSupport) {
-					codeActions = codeActions.filter(codeAction => !codeAction.disabled);
-				}
-				return codeActions;
-			});
-		});
-	}
-	if (typeof codeActionProvider === 'object' && codeActionProvider.resolveProvider) {
-		server.connection.onCodeActionResolve(async (codeAction, token) => {
-			return await lastCodeActionLs?.resolveCodeAction(codeAction, token) ?? codeAction;
-		});
-	}
-	if (referencesProvider) {
-		server.connection.onReferences(async (params, token) => {
-			const uri = URI.parse(params.textDocument.uri);
-			return await worker(uri, token, languageService => {
-				return languageService.getReferences(uri, params.position, { includeDeclaration: true }, token);
-			});
-		});
-	}
-	if (implementationProvider) {
-		server.connection.onImplementation(async (params, token) => {
-			const uri = URI.parse(params.textDocument.uri);
-			return await worker(uri, token, languageService => {
-				return languageService.getImplementations(uri, params.position, token);
-			});
-		});
-	}
-	if (definitionProvider) {
-		server.connection.onDefinition(async (params, token) => {
-			const uri = URI.parse(params.textDocument.uri);
-			return await worker(uri, token, languageService => {
-				return languageService.getDefinition(uri, params.position, token);
-			});
-		});
-	}
-	if (typeDefinitionProvider) {
-		server.connection.onTypeDefinition(async (params, token) => {
-			const uri = URI.parse(params.textDocument.uri);
-			return await worker(uri, token, languageService => {
-				return languageService.getTypeDefinition(uri, params.position, token);
-			});
-		});
-	}
-	if (documentHighlightProvider) {
-		server.connection.onDocumentHighlight(async (params, token) => {
-			const uri = URI.parse(params.textDocument.uri);
-			return await worker(uri, token, languageService => {
-				return languageService.getDocumentHighlights(uri, params.position, token);
-			});
-		});
-	}
-	if (documentLinkProvider) {
-		server.connection.onDocumentLinks(async (params, token) => {
-			const uri = URI.parse(params.textDocument.uri);
-			return await worker(uri, token, languageService => {
-				lastDocumentLinkLs = languageService;
-				return languageService.getDocumentLinks(uri, token);
-			});
-		});
-	}
-	if (documentLinkProvider?.resolveProvider) {
-		server.connection.onDocumentLinkResolve(async (link, token) => {
-			return await lastDocumentLinkLs?.resolveDocumentLink(link, token);
-		});
-	}
-	if (workspaceSymbolProvider) {
-		server.connection.onWorkspaceSymbol(async (params, token) => {
-			const symbols: vscode.WorkspaceSymbol[] = [];
-			for (const languageService of await server.project.getExistingLanguageServices()) {
-				if (token.isCancellationRequested) {
-					return;
-				}
-				let languageServiceId = languageServiceToId.get(languageService);
-				if (languageServiceId === undefined) {
-					languageServiceId = currentLanguageServiceId;
-					languageServiceToId.set(languageService, languageServiceId);
-					idToLanguageService.set(languageServiceId, new WeakRef(languageService));
-				}
-				const languageServiceResult = await languageService.getWorkspaceSymbols(params.query, token);
-				for (const symbol of languageServiceResult) {
-					symbol.data = {
-						languageServiceId,
-						originalData: symbol.data,
-					};
-				}
-				symbols.push(...await languageService.getWorkspaceSymbols(params.query, token));
+	});
+	server.connection.onPrepareRename(async (params, token) => {
+		const uri = URI.parse(params.textDocument.uri);
+		return await worker(uri, token, async languageService => {
+			const result = await languageService.getRenameRange(uri, params.position, token);
+			if (result && 'message' in result) {
+				return new vscode.ResponseError(0, result.message);
 			}
-			return symbols;
+			return result;
 		});
-	}
-	if (typeof workspaceSymbolProvider === 'object' && workspaceSymbolProvider.resolveProvider) {
-		server.connection.onWorkspaceSymbolResolve(async (symbol, token) => {
-			const languageServiceId = (symbol.data as any)?.languageServiceId;
-			const languageService = idToLanguageService.get(languageServiceId)?.deref();
-			if (!languageService) {
-				return symbol;
+	});
+	server.connection.onCodeLens(async (params, token) => {
+		const uri = URI.parse(params.textDocument.uri);
+		return await worker(uri, token, languageService => {
+			lastCodeLensLs = languageService;
+			return languageService.getCodeLenses(uri, token);
+		});
+	});
+	server.connection.onCodeLensResolve(async (codeLens, token) => {
+		return await lastCodeLensLs?.resolveCodeLens(codeLens, token) ?? codeLens;
+	});
+	server.connection.onCodeAction(async (params, token) => {
+		const uri = URI.parse(params.textDocument.uri);
+		return await worker(uri, token, async languageService => {
+			lastCodeActionLs = languageService;
+			let codeActions = await languageService.getCodeActions(uri, params.range, params.context, token) ?? [];
+			for (const codeAction of codeActions) {
+				if (codeAction.data && typeof codeAction.data === 'object') {
+					(codeAction.data as any).uri = params.textDocument.uri;
+				}
+				else {
+					codeAction.data = { uri: params.textDocument.uri };
+				}
 			}
-			symbol.data = (symbol.data as any)?.originalData;
-			return await languageService.resolveWorkspaceSymbol?.(symbol, token);
+			if (!server.initializeParams?.capabilities.textDocument?.codeAction?.disabledSupport) {
+				codeActions = codeActions.filter(codeAction => !codeAction.disabled);
+			}
+			return codeActions;
 		});
-	}
-	if (callHierarchyProvider) {
-		server.connection.languages.callHierarchy.onPrepare(async (params, token) => {
-			const uri = URI.parse(params.textDocument.uri);
-			return await worker(uri, token, languageService => {
-				lastCallHierarchyLs = languageService;
-				return languageService.getCallHierarchyItems(uri, params.position, token);
-			}) ?? [];
+	});
+	server.connection.onCodeActionResolve(async (codeAction, token) => {
+		return await lastCodeActionLs?.resolveCodeAction(codeAction, token) ?? codeAction;
+	});
+	server.connection.onReferences(async (params, token) => {
+		const uri = URI.parse(params.textDocument.uri);
+		return await worker(uri, token, languageService => {
+			return languageService.getReferences(uri, params.position, { includeDeclaration: true }, token);
 		});
-		server.connection.languages.callHierarchy.onIncomingCalls(async (params, token) => {
-			return await lastCallHierarchyLs?.getCallHierarchyIncomingCalls(params.item, token) ?? [];
+	});
+	server.connection.onImplementation(async (params, token) => {
+		const uri = URI.parse(params.textDocument.uri);
+		return await worker(uri, token, languageService => {
+			return languageService.getImplementations(uri, params.position, token);
 		});
-		server.connection.languages.callHierarchy.onOutgoingCalls(async (params, token) => {
-			return await lastCallHierarchyLs?.getCallHierarchyOutgoingCalls(params.item, token) ?? [];
+	});
+	server.connection.onDefinition(async (params, token) => {
+		const uri = URI.parse(params.textDocument.uri);
+		return await worker(uri, token, languageService => {
+			return languageService.getDefinition(uri, params.position, token);
 		});
-	}
-	if (semanticTokensProvider?.full) {
-		server.connection.languages.semanticTokens.on(async (params, token, _, resultProgress) => {
-			const uri = URI.parse(params.textDocument.uri);
-			return await worker(uri, token, async languageService => {
-				return await languageService?.getSemanticTokens(
-					uri,
-					undefined,
-					server.initializeResult.capabilities.semanticTokensProvider!.legend,
-					tokens => resultProgress?.report(tokens),
-					token
-				);
-			}) ?? { data: [] };
+	});
+	server.connection.onTypeDefinition(async (params, token) => {
+		const uri = URI.parse(params.textDocument.uri);
+		return await worker(uri, token, languageService => {
+			return languageService.getTypeDefinition(uri, params.position, token);
 		});
-	}
-	if (semanticTokensProvider?.range) {
-		server.connection.languages.semanticTokens.onRange(async (params, token, _, resultProgress) => {
-			const uri = URI.parse(params.textDocument.uri);
-			return await worker(uri, token, async languageService => {
-				return await languageService?.getSemanticTokens(
-					uri,
-					params.range,
-					server.initializeResult.capabilities.semanticTokensProvider!.legend,
-					tokens => resultProgress?.report(tokens),
-					token
-				);
-			}) ?? { data: [] };
+	});
+	server.connection.onDocumentHighlight(async (params, token) => {
+		const uri = URI.parse(params.textDocument.uri);
+		return await worker(uri, token, languageService => {
+			return languageService.getDocumentHighlights(uri, params.position, token);
 		});
-	}
-	if (diagnosticProvider) {
-		server.connection.languages.diagnostics.on(async (params, token, _workDoneProgressReporter, resultProgressReporter) => {
-			const uri = URI.parse(params.textDocument.uri);
-			const result = await worker(uri, token, languageService => {
-				return languageService.getDiagnostics(
-					uri,
-					errors => {
-						// resultProgressReporter is undefined in vscode
-						resultProgressReporter?.report({
-							relatedDocuments: {
-								[params.textDocument.uri]: {
-									kind: vscode.DocumentDiagnosticReportKind.Full,
-									items: errors,
-								},
+	});
+	server.connection.onDocumentLinks(async (params, token) => {
+		const uri = URI.parse(params.textDocument.uri);
+		return await worker(uri, token, languageService => {
+			lastDocumentLinkLs = languageService;
+			return languageService.getDocumentLinks(uri, token);
+		});
+	});
+	server.connection.onDocumentLinkResolve(async (link, token) => {
+		return await lastDocumentLinkLs?.resolveDocumentLink(link, token);
+	});
+	server.connection.onWorkspaceSymbol(async (params, token) => {
+		const symbols: vscode.WorkspaceSymbol[] = [];
+		for (const languageService of await server.project.getExistingLanguageServices()) {
+			if (token.isCancellationRequested) {
+				return;
+			}
+			let languageServiceId = languageServiceToId.get(languageService);
+			if (languageServiceId === undefined) {
+				languageServiceId = currentLanguageServiceId;
+				languageServiceToId.set(languageService, languageServiceId);
+				languageServiceById.set(languageServiceId, new WeakRef(languageService));
+			}
+			const languageServiceResult = await languageService.getWorkspaceSymbols(params.query, token);
+			for (const symbol of languageServiceResult) {
+				symbol.data = {
+					languageServiceId,
+					originalData: symbol.data,
+				};
+			}
+			symbols.push(...await languageService.getWorkspaceSymbols(params.query, token));
+		}
+		return symbols;
+	});
+	server.connection.onWorkspaceSymbolResolve(async (symbol, token) => {
+		const languageServiceId = (symbol.data as any)?.languageServiceId;
+		const languageService = languageServiceById.get(languageServiceId)?.deref();
+		if (!languageService) {
+			return symbol;
+		}
+		symbol.data = (symbol.data as any)?.originalData;
+		return await languageService.resolveWorkspaceSymbol?.(symbol, token);
+	});
+	server.connection.languages.callHierarchy.onPrepare(async (params, token) => {
+		const uri = URI.parse(params.textDocument.uri);
+		return await worker(uri, token, languageService => {
+			lastCallHierarchyLs = languageService;
+			return languageService.getCallHierarchyItems(uri, params.position, token);
+		}) ?? [];
+	});
+	server.connection.languages.callHierarchy.onIncomingCalls(async (params, token) => {
+		return await lastCallHierarchyLs?.getCallHierarchyIncomingCalls(params.item, token) ?? [];
+	});
+	server.connection.languages.callHierarchy.onOutgoingCalls(async (params, token) => {
+		return await lastCallHierarchyLs?.getCallHierarchyOutgoingCalls(params.item, token) ?? [];
+	});
+	server.connection.languages.semanticTokens.on(async (params, token, _, resultProgress) => {
+		const uri = URI.parse(params.textDocument.uri);
+		return await worker(uri, token, async languageService => {
+			return await languageService?.getSemanticTokens(
+				uri,
+				undefined,
+				server.initializeResult.capabilities.semanticTokensProvider!.legend,
+				tokens => resultProgress?.report(tokens),
+				token
+			);
+		}) ?? { data: [] };
+	});
+	server.connection.languages.semanticTokens.onRange(async (params, token, _, resultProgress) => {
+		const uri = URI.parse(params.textDocument.uri);
+		return await worker(uri, token, async languageService => {
+			return await languageService?.getSemanticTokens(
+				uri,
+				params.range,
+				server.initializeResult.capabilities.semanticTokensProvider!.legend,
+				tokens => resultProgress?.report(tokens),
+				token
+			);
+		}) ?? { data: [] };
+	});
+	server.connection.languages.diagnostics.on(async (params, token, _workDoneProgressReporter, resultProgressReporter) => {
+		const uri = URI.parse(params.textDocument.uri);
+		const result = await worker(uri, token, languageService => {
+			return languageService.getDiagnostics(
+				uri,
+				errors => {
+					// resultProgressReporter is undefined in vscode
+					resultProgressReporter?.report({
+						relatedDocuments: {
+							[params.textDocument.uri]: {
+								kind: vscode.DocumentDiagnosticReportKind.Full,
+								items: errors,
 							},
-						});
-					},
-					token
-				);
-			});
-			return {
-				kind: vscode.DocumentDiagnosticReportKind.Full,
-				items: result ?? [],
-			};
+						},
+					});
+				},
+				token
+			);
 		});
-	}
-	if (diagnosticProvider?.workspaceDiagnostics) {
-		server.connection.languages.diagnostics.onWorkspace(async (_params, token) => {
-			const items: vscode.WorkspaceDocumentDiagnosticReport[] = [];
-			for (const languageService of await server.project.getExistingLanguageServices()) {
-				if (token.isCancellationRequested) {
-					break;
-				}
-				const result = await languageService.getWorkspaceDiagnostics(token);
-				items.push(...result);
+		return {
+			kind: vscode.DocumentDiagnosticReportKind.Full,
+			items: result ?? [],
+		};
+	});
+	server.connection.languages.diagnostics.onWorkspace(async (_params, token) => {
+		const items: vscode.WorkspaceDocumentDiagnosticReport[] = [];
+		for (const languageService of await server.project.getExistingLanguageServices()) {
+			if (token.isCancellationRequested) {
+				break;
 			}
-			return { items };
+			const result = await languageService.getWorkspaceDiagnostics(token);
+			items.push(...result);
+		}
+		return { items };
+	});
+	server.connection.languages.inlayHint.on(async (params, token) => {
+		const uri = URI.parse(params.textDocument.uri);
+		return await worker(uri, token, languageService => {
+			lastInlayHintLs = languageService;
+			return languageService.getInlayHints(uri, params.range, token);
 		});
-	}
-	if (inlayHintProvider) {
-		server.connection.languages.inlayHint.on(async (params, token) => {
-			const uri = URI.parse(params.textDocument.uri);
-			return await worker(uri, token, languageService => {
-				lastInlayHintLs = languageService;
-				return languageService.getInlayHints(uri, params.range, token);
-			});
-		});
-	}
-	if (executeCommandProvider) {
-		server.connection.onExecuteCommand(async (params, token) => {
-			for (const languageService of await server.project.getExistingLanguageServices()) {
-				if (languageService.executeCommand && languageService.commands.includes(params.command)) {
-					try {
-						return await languageService.executeCommand(params.command, params.arguments ?? [], token);
-					} catch { }
-				}
+	});
+	server.connection.onExecuteCommand(async (params, token) => {
+		for (const languageService of await server.project.getExistingLanguageServices()) {
+			if (languageService.executeCommand && languageService.commands.includes(params.command)) {
+				try {
+					return await languageService.executeCommand(params.command, params.arguments ?? [], token);
+				} catch { }
 			}
+		}
+	});
+	server.connection.languages.inlayHint.resolve(async (hint, token) => {
+		return await lastInlayHintLs?.resolveInlayHint(hint, token) ?? hint;
+	});
+	server.connection.workspace.onWillRenameFiles(async (params, token) => {
+		const _edits = await Promise.all(params.files.map(async file => {
+			const oldUri = URI.parse(file.oldUri);
+			const newUri = URI.parse(file.newUri);
+			return await worker(oldUri, token, languageService => {
+				return languageService.getFileRenameEdits(oldUri, newUri, token) ?? null;
+			}) ?? null;
+		}));
+		const edits = _edits.filter((edit): edit is NonNullable<typeof edit> => !!edit);
+		if (edits.length) {
+			mergeWorkspaceEdits(edits[0], ...edits.slice(1));
+			return edits[0];
+		}
+		return null;
+	});
+	server.connection.onRequest(AutoInsertRequest.type, async (params, token) => {
+		const uri = URI.parse(params.textDocument.uri);
+		return await worker(uri, token, languageService => {
+			return languageService.getAutoInsertSnippet(uri, params.selection, params.change, token);
 		});
-	}
-	if (typeof inlayHintProvider === 'object' && inlayHintProvider.resolveProvider) {
-		server.connection.languages.inlayHint.resolve(async (hint, token) => {
-			return await lastInlayHintLs?.resolveInlayHint(hint, token) ?? hint;
+	});
+	server.connection.onRequest(FindFileReferenceRequest.type, async (params, token) => {
+		const uri = URI.parse(params.textDocument.uri);
+		return await worker(uri, token, languageService => {
+			return languageService.getFileReferences(uri, token);
 		});
-	}
-	if (experimental?.fileRenameProvider) {
-		server.connection.workspace.onWillRenameFiles(async (params, token) => {
-			const _edits = await Promise.all(params.files.map(async file => {
-				const oldUri = URI.parse(file.oldUri);
-				const newUri = URI.parse(file.newUri);
-				return await worker(oldUri, token, languageService => {
-					return languageService.getFileRenameEdits(oldUri, newUri, token) ?? null;
-				}) ?? null;
-			}));
-			const edits = _edits.filter((edit): edit is NonNullable<typeof edit> => !!edit);
-			if (edits.length) {
-				mergeWorkspaceEdits(edits[0], ...edits.slice(1));
-				return edits[0];
-			}
-			return null;
-		});
-	}
-	if (experimental?.autoInsertionProvider) {
-		server.connection.onRequest(AutoInsertRequest.type, async (params, token) => {
-			const uri = URI.parse(params.textDocument.uri);
-			return await worker(uri, token, languageService => {
-				return languageService.getAutoInsertSnippet(uri, params.selection, params.change, token);
-			});
-		});
-	}
-	if (experimental?.fileReferencesProvider) {
-		server.connection.onRequest(FindFileReferenceRequest.type, async (params, token) => {
-			const uri = URI.parse(params.textDocument.uri);
-			return await worker(uri, token, languageService => {
-				return languageService.getFileReferences(uri, token);
-			});
-		});
-	}
+	});
 
 	function worker<T>(uri: URI, token: vscode.CancellationToken, cb: (languageService: LanguageService) => T) {
 		return new Promise<T | undefined>(resolve => {

--- a/packages/language-server/lib/server.ts
+++ b/packages/language-server/lib/server.ts
@@ -178,14 +178,14 @@ export function createServerBase(
 		};
 
 		if (languageServicePlugins.some(({ capabilities }) => capabilities.diagnosticProvider)) {
-			state.initializeResult.capabilities.diagnosticProvider = {
-				// Unreliable, see https://github.com/microsoft/vscode-languageserver-node/issues/848#issuecomment-2189521060
-				interFileDependencies: false,
-				workspaceDiagnostics: languageServicePlugins.some(({ capabilities }) => capabilities.diagnosticProvider?.workspaceDiagnostics),
-			};
 			const supportsDiagnosticPull = !!params.capabilities.workspace?.diagnostics;
 			const interFileDependencies = state.languageServicePlugins.some(({ capabilities }) => capabilities.diagnosticProvider?.interFileDependencies);
 			if (supportsDiagnosticPull && !interFileDependencies) {
+				state.initializeResult.capabilities.diagnosticProvider = {
+					// Unreliable, see https://github.com/microsoft/vscode-languageserver-node/issues/848#issuecomment-2189521060
+					interFileDependencies: false,
+					workspaceDiagnostics: languageServicePlugins.some(({ capabilities }) => capabilities.diagnosticProvider?.workspaceDiagnostics),
+				};
 				registerDiagnosticsSupport(project, 'pull', false);
 			}
 			else {
@@ -453,11 +453,6 @@ export function createServerBase(
 				connection.sendDiagnostics({ uri: document.uri, diagnostics: [] });
 			});
 			onDidChangeConfiguration(() => refresh(project, false));
-		}
-		if (mode === 'pull' && interFileDependencies) {
-			documents.onDidChangeContent(() => {
-				refresh(project, false);
-			});
 		}
 
 		return { refresh };

--- a/packages/language-server/lib/server.ts
+++ b/packages/language-server/lib/server.ts
@@ -185,8 +185,8 @@ export function createServerBase(
 			};
 			const supportsDiagnosticPull = !!params.capabilities.workspace?.diagnostics;
 			const interFileDependencies = state.languageServicePlugins.some(({ capabilities }) => capabilities.diagnosticProvider?.interFileDependencies);
-			if (supportsDiagnosticPull) {
-				registerDiagnosticsSupport(project, 'pull', interFileDependencies);
+			if (supportsDiagnosticPull && !interFileDependencies) {
+				registerDiagnosticsSupport(project, 'pull', false);
 			}
 			else {
 				registerDiagnosticsSupport(project, 'push', interFileDependencies);

--- a/packages/language-server/lib/server.ts
+++ b/packages/language-server/lib/server.ts
@@ -489,7 +489,7 @@ export function createServerBase(
 				}
 				await updateDiagnosticsBatch(project, [...documents.all()]);
 			}
-			else if (state.initializeResult.capabilities.diagnosticProvider) {
+			else {
 				if (state.initializeParams?.capabilities.workspace?.diagnostics?.refreshSupport) {
 					connection.languages.diagnostics.refresh();
 				}

--- a/packages/language-server/lib/server.ts
+++ b/packages/language-server/lib/server.ts
@@ -97,8 +97,6 @@ export function createServerBase(
 			state.workspaceFolders.set(URI.file(params.rootPath), true);
 		}
 
-		const pluginCapabilities = state.languageServicePlugins.map(plugin => plugin.capabilities);
-
 		state.initializeResult = { capabilities: {} };
 		state.initializeResult.capabilities = {
 			textDocumentSync: vscode.TextDocumentSyncKind.Incremental,
@@ -109,88 +107,98 @@ export function createServerBase(
 					changeNotifications: true,
 				},
 			},
-			selectionRangeProvider: pluginCapabilities.some(data => data.selectionRangeProvider) || undefined,
-			foldingRangeProvider: pluginCapabilities.some(data => data.foldingRangeProvider) || undefined,
-			linkedEditingRangeProvider: pluginCapabilities.some(data => data.linkedEditingRangeProvider) || undefined,
-			colorProvider: pluginCapabilities.some(data => data.colorProvider) || undefined,
-			documentSymbolProvider: pluginCapabilities.some(data => data.documentSymbolProvider) || undefined,
-			documentFormattingProvider: pluginCapabilities.some(data => data.documentFormattingProvider) || undefined,
-			documentRangeFormattingProvider: pluginCapabilities.some(data => data.documentFormattingProvider) || undefined,
-			referencesProvider: pluginCapabilities.some(data => data.referencesProvider) || undefined,
-			implementationProvider: pluginCapabilities.some(data => data.implementationProvider) || undefined,
-			definitionProvider: pluginCapabilities.some(data => data.definitionProvider) || undefined,
-			typeDefinitionProvider: pluginCapabilities.some(data => data.typeDefinitionProvider) || undefined,
-			callHierarchyProvider: pluginCapabilities.some(data => data.callHierarchyProvider) || undefined,
-			hoverProvider: pluginCapabilities.some(data => data.hoverProvider) || undefined,
-			documentHighlightProvider: pluginCapabilities.some(data => data.documentHighlightProvider) || undefined,
-			workspaceSymbolProvider: pluginCapabilities.some(data => data.workspaceSymbolProvider)
-				? { resolveProvider: pluginCapabilities.some(data => data.workspaceSymbolProvider?.resolveProvider) || undefined }
+			selectionRangeProvider: languageServicePlugins.some(({ capabilities }) => capabilities.selectionRangeProvider) || undefined,
+			foldingRangeProvider: languageServicePlugins.some(({ capabilities }) => capabilities.foldingRangeProvider) || undefined,
+			linkedEditingRangeProvider: languageServicePlugins.some(({ capabilities }) => capabilities.linkedEditingRangeProvider) || undefined,
+			colorProvider: languageServicePlugins.some(({ capabilities }) => capabilities.colorProvider) || undefined,
+			documentSymbolProvider: languageServicePlugins.some(({ capabilities }) => capabilities.documentSymbolProvider) || undefined,
+			documentFormattingProvider: languageServicePlugins.some(({ capabilities }) => capabilities.documentFormattingProvider) || undefined,
+			documentRangeFormattingProvider: languageServicePlugins.some(({ capabilities }) => capabilities.documentFormattingProvider) || undefined,
+			referencesProvider: languageServicePlugins.some(({ capabilities }) => capabilities.referencesProvider) || undefined,
+			implementationProvider: languageServicePlugins.some(({ capabilities }) => capabilities.implementationProvider) || undefined,
+			definitionProvider: languageServicePlugins.some(({ capabilities }) => capabilities.definitionProvider) || undefined,
+			typeDefinitionProvider: languageServicePlugins.some(({ capabilities }) => capabilities.typeDefinitionProvider) || undefined,
+			callHierarchyProvider: languageServicePlugins.some(({ capabilities }) => capabilities.callHierarchyProvider) || undefined,
+			hoverProvider: languageServicePlugins.some(({ capabilities }) => capabilities.hoverProvider) || undefined,
+			documentHighlightProvider: languageServicePlugins.some(({ capabilities }) => capabilities.documentHighlightProvider) || undefined,
+			workspaceSymbolProvider: languageServicePlugins.some(({ capabilities }) => capabilities.workspaceSymbolProvider)
+				? { resolveProvider: languageServicePlugins.some(({ capabilities }) => capabilities.workspaceSymbolProvider?.resolveProvider) || undefined }
 				: undefined,
-			renameProvider: pluginCapabilities.some(data => data.renameProvider)
-				? { prepareProvider: pluginCapabilities.some(data => data.renameProvider?.prepareProvider) || undefined }
+			renameProvider: languageServicePlugins.some(({ capabilities }) => capabilities.renameProvider)
+				? { prepareProvider: languageServicePlugins.some(({ capabilities }) => capabilities.renameProvider?.prepareProvider) || undefined }
 				: undefined,
-			documentLinkProvider: pluginCapabilities.some(data => data.documentLinkProvider)
-				? { resolveProvider: pluginCapabilities.some(data => data.documentLinkProvider?.resolveProvider) || undefined }
+			documentLinkProvider: languageServicePlugins.some(({ capabilities }) => capabilities.documentLinkProvider)
+				? { resolveProvider: languageServicePlugins.some(({ capabilities }) => capabilities.documentLinkProvider?.resolveProvider) || undefined }
 				: undefined,
-			codeLensProvider: pluginCapabilities.some(data => data.codeLensProvider)
-				? { resolveProvider: pluginCapabilities.some(data => data.codeLensProvider?.resolveProvider) || undefined }
+			codeLensProvider: languageServicePlugins.some(({ capabilities }) => capabilities.codeLensProvider)
+				? { resolveProvider: languageServicePlugins.some(({ capabilities }) => capabilities.codeLensProvider?.resolveProvider) || undefined }
 				: undefined,
-			inlayHintProvider: pluginCapabilities.some(data => data.inlayHintProvider)
-				? { resolveProvider: pluginCapabilities.some(data => data.inlayHintProvider?.resolveProvider) || undefined }
+			inlayHintProvider: languageServicePlugins.some(({ capabilities }) => capabilities.inlayHintProvider)
+				? { resolveProvider: languageServicePlugins.some(({ capabilities }) => capabilities.inlayHintProvider?.resolveProvider) || undefined }
 				: undefined,
-			signatureHelpProvider: pluginCapabilities.some(data => data.signatureHelpProvider)
+			signatureHelpProvider: languageServicePlugins.some(({ capabilities }) => capabilities.signatureHelpProvider)
 				? {
-					triggerCharacters: [...new Set(pluginCapabilities.map(data => data.signatureHelpProvider?.triggerCharacters ?? []).flat())],
-					retriggerCharacters: [...new Set(pluginCapabilities.map(data => data.signatureHelpProvider?.retriggerCharacters ?? []).flat())],
+					triggerCharacters: [...new Set(languageServicePlugins.map(({ capabilities }) => capabilities.signatureHelpProvider?.triggerCharacters ?? []).flat())],
+					retriggerCharacters: [...new Set(languageServicePlugins.map(({ capabilities }) => capabilities.signatureHelpProvider?.retriggerCharacters ?? []).flat())],
 				}
 				: undefined,
-			completionProvider: pluginCapabilities.some(data => data.completionProvider)
+			completionProvider: languageServicePlugins.some(({ capabilities }) => capabilities.completionProvider)
 				? {
-					resolveProvider: pluginCapabilities.some(data => data.completionProvider?.resolveProvider) || undefined,
-					triggerCharacters: [...new Set(pluginCapabilities.map(data => data.completionProvider?.triggerCharacters ?? []).flat())],
+					resolveProvider: languageServicePlugins.some(({ capabilities }) => capabilities.completionProvider?.resolveProvider) || undefined,
+					triggerCharacters: [...new Set(languageServicePlugins.map(({ capabilities }) => capabilities.completionProvider?.triggerCharacters ?? []).flat())],
 				}
 				: undefined,
-			semanticTokensProvider: pluginCapabilities.some(data => data.semanticTokensProvider)
+			semanticTokensProvider: languageServicePlugins.some(({ capabilities }) => capabilities.semanticTokensProvider)
 				? {
 					range: true,
 					full: false,
 					legend: {
-						tokenTypes: [...new Set(pluginCapabilities.map(data => data.semanticTokensProvider?.legend?.tokenTypes ?? []).flat())],
-						tokenModifiers: [...new Set(pluginCapabilities.map(data => data.semanticTokensProvider?.legend?.tokenModifiers ?? []).flat())],
+						tokenTypes: [...new Set(languageServicePlugins.map(({ capabilities }) => capabilities.semanticTokensProvider?.legend?.tokenTypes ?? []).flat())],
+						tokenModifiers: [...new Set(languageServicePlugins.map(({ capabilities }) => capabilities.semanticTokensProvider?.legend?.tokenModifiers ?? []).flat())],
 					},
 				}
 				: undefined,
-			codeActionProvider: pluginCapabilities.some(data => data.codeActionProvider)
+			codeActionProvider: languageServicePlugins.some(({ capabilities }) => capabilities.codeActionProvider)
 				? {
-					resolveProvider: pluginCapabilities.some(data => data.codeActionProvider?.resolveProvider) || undefined,
-					codeActionKinds: pluginCapabilities.some(data => data.codeActionProvider?.codeActionKinds)
-						? [...new Set(pluginCapabilities.map(data => data.codeActionProvider?.codeActionKinds ?? []).flat())]
+					resolveProvider: languageServicePlugins.some(({ capabilities }) => capabilities.codeActionProvider?.resolveProvider) || undefined,
+					codeActionKinds: languageServicePlugins.some(({ capabilities }) => capabilities.codeActionProvider?.codeActionKinds)
+						? [...new Set(languageServicePlugins.map(({ capabilities }) => capabilities.codeActionProvider?.codeActionKinds ?? []).flat())]
 						: undefined,
 				}
 				: undefined,
-			documentOnTypeFormattingProvider: pluginCapabilities.some(data => data.documentOnTypeFormattingProvider)
+			documentOnTypeFormattingProvider: languageServicePlugins.some(({ capabilities }) => capabilities.documentOnTypeFormattingProvider)
 				? {
-					firstTriggerCharacter: [...new Set(pluginCapabilities.map(data => data.documentOnTypeFormattingProvider?.triggerCharacters ?? []).flat())][0],
-					moreTriggerCharacter: [...new Set(pluginCapabilities.map(data => data.documentOnTypeFormattingProvider?.triggerCharacters ?? []).flat())].slice(1),
+					firstTriggerCharacter: [...new Set(languageServicePlugins.map(({ capabilities }) => capabilities.documentOnTypeFormattingProvider?.triggerCharacters ?? []).flat())][0],
+					moreTriggerCharacter: [...new Set(languageServicePlugins.map(({ capabilities }) => capabilities.documentOnTypeFormattingProvider?.triggerCharacters ?? []).flat())].slice(1),
 				}
 				: undefined,
-			executeCommandProvider: pluginCapabilities.some(data => data.executeCommandProvider)
+			executeCommandProvider: languageServicePlugins.some(({ capabilities }) => capabilities.executeCommandProvider)
 				? {
-					commands: [...new Set(pluginCapabilities.map(data => data.executeCommandProvider?.commands ?? []).flat())],
+					commands: [...new Set(languageServicePlugins.map(({ capabilities }) => capabilities.executeCommandProvider?.commands ?? []).flat())],
 				}
 				: undefined,
 		};
 
-		if (pluginCapabilities.some(data => data.diagnosticProvider)) {
+		if (languageServicePlugins.some(({ capabilities }) => capabilities.diagnosticProvider)) {
 			state.initializeResult.capabilities.diagnosticProvider = {
 				// Unreliable, see https://github.com/microsoft/vscode-languageserver-node/issues/848#issuecomment-2189521060
 				interFileDependencies: false,
-				workspaceDiagnostics: pluginCapabilities.some(data => data.diagnosticProvider?.workspaceDiagnostics),
+				workspaceDiagnostics: languageServicePlugins.some(({ capabilities }) => capabilities.diagnosticProvider?.workspaceDiagnostics),
 			};
 			const supportsDiagnosticPull = !!params.capabilities.workspace?.diagnostics;
 			if (!supportsDiagnosticPull) {
 				documents.onDidChangeContent(({ document }) => {
-					updateAllDiagnostics(project, document.uri);
+					const changedDocument = documents.get(document.uri);
+					if (!changedDocument) {
+						return;
+					}
+					if (languageServicePlugins.some(({ capabilities }) => capabilities.diagnosticProvider?.interFileDependencies)) {
+						const remainingDocuments = [...documents.all()].filter(doc => doc !== changedDocument);
+						updateDiagnosticsBatch(project, [changedDocument, ...remainingDocuments]);
+					}
+					else {
+						updateDiagnosticsBatch(project, [changedDocument]);
+					}
 				});
 				documents.onDidClose(({ document }) => {
 					connection.sendDiagnostics({ uri: document.uri, diagnostics: [] });
@@ -199,7 +207,7 @@ export function createServerBase(
 			onDidChangeConfiguration(() => refresh(project, false));
 		}
 
-		if (pluginCapabilities.some(data => data.autoInsertionProvider)) {
+		if (languageServicePlugins.some(({ capabilities }) => capabilities.autoInsertionProvider)) {
 			const triggerCharacterToConfigurationSections = new Map<string, Set<string>>();
 			const tryAdd = (char: string, section?: string) => {
 				let sectionSet = triggerCharacterToConfigurationSections.get(char);
@@ -210,9 +218,9 @@ export function createServerBase(
 					sectionSet.add(section);
 				}
 			};
-			for (const data of pluginCapabilities) {
-				if (data.autoInsertionProvider) {
-					const { triggerCharacters, configurationSections } = data.autoInsertionProvider;
+			for (const { capabilities } of languageServicePlugins) {
+				if (capabilities.autoInsertionProvider) {
+					const { triggerCharacters, configurationSections } = capabilities.autoInsertionProvider;
 					if (configurationSections) {
 						if (configurationSections.length !== triggerCharacters.length) {
 							throw new Error('configurationSections.length !== triggerCharacters.length');
@@ -245,12 +253,12 @@ export function createServerBase(
 			}
 		}
 
-		if (pluginCapabilities.some(data => data.fileRenameProvider)) {
+		if (languageServicePlugins.some(({ capabilities }) => capabilities.fileRenameProvider)) {
 			state.initializeResult.capabilities.experimental ??= {};
 			state.initializeResult.capabilities.experimental.fileRenameProvider = true;
 		}
 
-		if (pluginCapabilities.some(data => data.fileReferencesProvider)) {
+		if (languageServicePlugins.some(({ capabilities }) => capabilities.fileReferencesProvider)) {
 			state.initializeResult.capabilities.experimental ??= {};
 			state.initializeResult.capabilities.experimental.fileReferencesProvider = true;
 		}
@@ -446,7 +454,7 @@ export function createServerBase(
 					connection.sendDiagnostics({ uri: document.uri, diagnostics: [] });
 				}
 			}
-			await updateAllDiagnostics(project);
+			await updateDiagnosticsBatch(project, [...documents.all()]);
 		}
 
 		const delay = 250;
@@ -474,7 +482,7 @@ export function createServerBase(
 		}
 	}
 
-	async function updateAllDiagnostics(project: LanguageServerProject, changeDocUri?: string) {
+	async function updateDiagnosticsBatch(project: LanguageServerProject, documents: SnapshotDocument[]) {
 		const req = ++documentUpdatedReq;
 		const delay = 250;
 		const token: vscode.CancellationToken = {
@@ -483,10 +491,7 @@ export function createServerBase(
 			},
 			onCancellationRequested: vscode.Event.None,
 		};
-		const changedDocument = changeDocUri ? documents.get(changeDocUri) : undefined;
-		const remainingDocuments = [...documents.all()].filter(doc => doc !== changedDocument);
-
-		for (const doc of [changedDocument, ...remainingDocuments].filter(doc => !!doc)) {
+		for (const doc of documents) {
 			await sleep(delay);
 			if (token.isCancellationRequested) {
 				break;

--- a/packages/language-service/lib/types.ts
+++ b/packages/language-service/lib/types.ts
@@ -140,8 +140,8 @@ export interface LanguageServicePlugin<P = any> {
 			resolveProvider?: boolean;
 		};
 		diagnosticProvider?: {
-			// TODO: interFileDependencies
-			workspaceDiagnostics?: boolean;
+			interFileDependencies: boolean;
+			workspaceDiagnostics: boolean;
 		};
 		fileReferencesProvider?: boolean;
 		fileRenameProvider?: boolean;
@@ -186,7 +186,6 @@ export interface LanguageServicePluginInstance<P = any> {
 	provideDocumentSemanticTokens?(document: TextDocument, range: vscode.Range, legend: vscode.SemanticTokensLegend, token: vscode.CancellationToken): NullableProviderResult<SemanticToken[]>;
 	provideWorkspaceSymbols?(query: string, token: vscode.CancellationToken): NullableProviderResult<vscode.WorkspaceSymbol[]>;
 	provideDiagnostics?(document: TextDocument, token: vscode.CancellationToken): NullableProviderResult<vscode.Diagnostic[]>;
-	provideSemanticDiagnostics?(document: TextDocument, token: vscode.CancellationToken): NullableProviderResult<vscode.Diagnostic[]>;
 	provideWorkspaceDiagnostics?(token: vscode.CancellationToken): NullableProviderResult<vscode.WorkspaceDocumentDiagnosticReport[]>;
 	provideFileReferences?(document: TextDocument, token: vscode.CancellationToken): NullableProviderResult<vscode.Location[]>; // volar specific
 	provideReferencesCodeLensRanges?(document: TextDocument, token: vscode.CancellationToken): NullableProviderResult<vscode.Range[]>; // volar specific


### PR DESCRIPTION
- Removed the `provideSemanticDiagnostics` hook, LanguageServicePlugin should prompt that `provideDiagnostics` needs to be recalculated when other files change through `capabilities.diagnosticProvider.interFileDependencies = true`.

- The `pullModelDiagnostics` option has been removed. Volar will maintain its own logic to determine whether to enable pull model: when the language client supports pull diagnostics and no LanguageServicePlugin enables `interFileDependencies`, pull diagnostics will be used. Otherwise use push diagnostics. The reason is that according to the summary in https://github.com/microsoft/vscode-languageserver-node/issues/848#issuecomment-2189521060, the pull model is currently not reliable enough.