### PR TITLE
fix(language-service): don't send data to client if LanguageServicePlugin do not support resolve

### DIFF
--- a/packages/language-service/lib/features/provideCodeActions.ts
+++ b/packages/language-service/lib/features/provideCodeActions.ts
@@ -79,15 +79,20 @@ export function register(context: LanguageServiceContext) {
 				}, token);
 
 				codeActions?.forEach(codeAction => {
-					codeAction.data = {
-						uri: uri.toString(),
-						version: document.version,
-						original: {
-							data: codeAction.data,
-							edit: codeAction.edit,
-						},
-						pluginIndex: context.plugins.indexOf(plugin),
-					} satisfies ServiceCodeActionData;
+					if (plugin[1].resolveCodeAction) {
+						codeAction.data = {
+							uri: uri.toString(),
+							version: document.version,
+							original: {
+								data: codeAction.data,
+								edit: codeAction.edit,
+							},
+							pluginIndex: context.plugins.indexOf(plugin),
+						} satisfies ServiceCodeActionData;
+					}
+					else {
+						delete codeAction.data;
+					}
 				});
 
 				if (codeActions && plugin[1].transformCodeAction) {

--- a/packages/language-service/lib/features/provideCodeLenses.ts
+++ b/packages/language-service/lib/features/provideCodeLenses.ts
@@ -37,14 +37,19 @@ export function register(context: LanguageServiceContext) {
 				const pluginIndex = context.plugins.indexOf(plugin);
 
 				codeLens?.forEach(codeLens => {
-					codeLens.data = {
-						kind: 'normal',
-						uri: uri.toString(),
-						original: {
-							data: codeLens.data,
-						},
-						pluginIndex,
-					} satisfies ServiceCodeLensData;
+					if (plugin[1].resolveCodeLens) {
+						codeLens.data = {
+							kind: 'normal',
+							uri: uri.toString(),
+							original: {
+								data: codeLens.data,
+							},
+							pluginIndex,
+						} satisfies ServiceCodeLensData;
+					}
+					else {
+						delete codeLens.data;
+					}
 				});
 
 				const ranges = await plugin[1].provideReferencesCodeLensRanges?.(document, token);

--- a/packages/language-service/lib/features/provideCompletionItems.ts
+++ b/packages/language-service/lib/features/provideCompletionItems.ts
@@ -94,16 +94,21 @@ export function register(context: LanguageServiceContext) {
 							}
 
 							for (const item of cacheData.list.items) {
-								item.data = {
-									uri: uri.toString(),
-									original: {
-										additionalTextEdits: item.additionalTextEdits,
-										textEdit: item.textEdit,
-										data: item.data,
-									},
-									pluginIndex: pluginIndex,
-									embeddedDocumentUri: embeddedDocument.uri,
-								} satisfies ServiceCompletionData;
+								if (cacheData.plugin.resolveCompletionItem) {
+									item.data = {
+										uri: uri.toString(),
+										original: {
+											additionalTextEdits: item.additionalTextEdits,
+											textEdit: item.textEdit,
+											data: item.data,
+										},
+										pluginIndex: pluginIndex,
+										embeddedDocumentUri: embeddedDocument.uri,
+									} satisfies ServiceCompletionData;
+								}
+								else {
+									delete item.data;
+								}
 							}
 
 							cacheData.list = transformCompletionList(
@@ -129,16 +134,21 @@ export function register(context: LanguageServiceContext) {
 					}
 
 					for (const item of cacheData.list.items) {
-						item.data = {
-							uri: uri.toString(),
-							original: {
-								additionalTextEdits: item.additionalTextEdits,
-								textEdit: item.textEdit,
-								data: item.data,
-							},
-							pluginIndex: pluginIndex,
-							embeddedDocumentUri: undefined,
-						} satisfies ServiceCompletionData;
+						if (cacheData.plugin.resolveCompletionItem) {
+							item.data = {
+								uri: uri.toString(),
+								original: {
+									additionalTextEdits: item.additionalTextEdits,
+									textEdit: item.textEdit,
+									data: item.data,
+								},
+								pluginIndex: pluginIndex,
+								embeddedDocumentUri: undefined,
+							} satisfies ServiceCompletionData;
+						}
+						else {
+							delete item.data;
+						}
 					}
 				}
 			}
@@ -211,16 +221,21 @@ export function register(context: LanguageServiceContext) {
 					const pluginIndex = context.plugins.indexOf(plugin);
 
 					for (const item of completionList.items) {
-						item.data = {
-							uri: uri.toString(),
-							original: {
-								additionalTextEdits: item.additionalTextEdits,
-								textEdit: item.textEdit,
-								data: item.data,
-							},
-							pluginIndex,
-							embeddedDocumentUri: docs ? document.uri : undefined,
-						} satisfies ServiceCompletionData;
+						if (plugin[1].resolveCompletionItem) {
+							item.data = {
+								uri: uri.toString(),
+								original: {
+									additionalTextEdits: item.additionalTextEdits,
+									textEdit: item.textEdit,
+									data: item.data,
+								},
+								pluginIndex,
+								embeddedDocumentUri: docs ? document.uri : undefined,
+							} satisfies ServiceCompletionData;
+						}
+						else {
+							delete item.data;
+						}
 					}
 
 					if (docs) {

--- a/packages/language-service/lib/features/provideDocumentLinks.ts
+++ b/packages/language-service/lib/features/provideDocumentLinks.ts
@@ -29,13 +29,18 @@ export function register(context: LanguageServiceContext) {
 				const links = await plugin[1].provideDocumentLinks?.(document, token);
 
 				for (const link of links ?? []) {
-					link.data = {
-						uri: uri.toString(),
-						original: {
-							data: link.data,
-						},
-						pluginIndex: context.plugins.indexOf(plugin),
-					} satisfies DocumentLinkData;
+					if (plugin[1].resolveDocumentLink) {
+						link.data = {
+							uri: uri.toString(),
+							original: {
+								data: link.data,
+							},
+							pluginIndex: context.plugins.indexOf(plugin),
+						} satisfies DocumentLinkData;
+					}
+					else {
+						delete link.data;
+					}
 				}
 
 				return links;

--- a/packages/language-service/lib/features/provideInlayHints.ts
+++ b/packages/language-service/lib/features/provideInlayHints.ts
@@ -45,13 +45,18 @@ export function register(context: LanguageServiceContext) {
 				}
 				const hints = await plugin[1].provideInlayHints?.(document, arg, token);
 				hints?.forEach(link => {
-					link.data = {
-						uri: uri.toString(),
-						original: {
-							data: link.data,
-						},
-						pluginIndex: context.plugins.indexOf(plugin),
-					} satisfies InlayHintData;
+					if (plugin[1].resolveInlayHint) {
+						link.data = {
+							uri: uri.toString(),
+							original: {
+								data: link.data,
+							},
+							pluginIndex: context.plugins.indexOf(plugin),
+						} satisfies InlayHintData;
+					}
+					else {
+						delete link.data;
+					}
 				});
 
 				return hints;

--- a/packages/language-service/lib/features/provideWorkspaceSymbols.ts
+++ b/packages/language-service/lib/features/provideWorkspaceSymbols.ts
@@ -59,12 +59,17 @@ export function register(context: LanguageServiceContext) {
 				.filter(symbol => !!symbol);
 
 			symbols?.forEach(symbol => {
-				symbol.data = {
-					original: {
-						data: symbol.data,
-					},
-					pluginIndex: context.plugins.indexOf(plugin),
-				} satisfies WorkspaceSymbolData;
+				if (plugin[1].resolveWorkspaceSymbol) {
+					symbol.data = {
+						original: {
+							data: symbol.data,
+						},
+						pluginIndex: context.plugins.indexOf(plugin),
+					} satisfies WorkspaceSymbolData;
+				}
+				else {
+					delete symbol.data;
+				}
 			});
 
 			symbolsList.push(symbols);


### PR DESCRIPTION
Some plugins like `volar-service-css`, `volar-service-html` do not support completion item resolve, so there is no need to set data for completion item, which can reduce LSP traffic.