### PR TITLE
refactor: replace setTimeout with setImmediate

### DIFF
--- a/packages/language-server/browser.ts
+++ b/packages/language-server/browser.ts
@@ -19,7 +19,13 @@ export function createConnection() {
 }
 
 export function createServer(connection: vscode.Connection) {
-	const server = createServerBase(connection);
+	const server = createServerBase(connection, {
+		timer: {
+			setImmediate: (callback: (...args: any[]) => void, ...args: any[]) => {
+				setTimeout(callback, 0, ...args);
+			},
+		},
+	});
 	server.fileSystem.install('http', httpFsProvider);
 	server.fileSystem.install('https', httpFsProvider);
 	server.onInitialized(() => listenEditorSettings(server));

--- a/packages/language-server/lib/features/languageFeatures.ts
+++ b/packages/language-server/lib/features/languageFeatures.ts
@@ -765,7 +765,7 @@ export function register(
 
 	function worker<T>(uri: URI, token: vscode.CancellationToken, cb: (languageService: LanguageService) => T) {
 		return new Promise<T | undefined>(resolve => {
-			setImmediate(async () => {
+			server.env.timer.setImmediate(async () => {
 				if (token.isCancellationRequested) {
 					resolve(undefined);
 					return;

--- a/packages/language-server/lib/features/languageFeatures.ts
+++ b/packages/language-server/lib/features/languageFeatures.ts
@@ -765,7 +765,7 @@ export function register(
 
 	function worker<T>(uri: URI, token: vscode.CancellationToken, cb: (languageService: LanguageService) => T) {
 		return new Promise<T | undefined>(resolve => {
-			setTimeout(async () => {
+			setImmediate(async () => {
 				if (token.isCancellationRequested) {
 					resolve(undefined);
 					return;
@@ -777,7 +777,7 @@ export function register(
 					return;
 				}
 				resolve(result);
-			}, 0);
+			});
 		});
 	}
 

--- a/packages/language-server/lib/server.ts
+++ b/packages/language-server/lib/server.ts
@@ -7,12 +7,13 @@ import { register as registerFileWatcher } from './features/fileWatcher.js';
 import { register as registerLanguageFeatures } from './features/languageFeatures.js';
 import { register as registerTextDocumentRegistry } from './features/textDocuments.js';
 import { register as registerWorkspaceFolderRegistry } from './features/workspaceFolders.js';
-import type { ExperimentalFeatures, LanguageServerProject, LanguageServerState } from './types.js';
+import type { ExperimentalFeatures, LanguageServerEnvironment, LanguageServerProject, LanguageServerState } from './types.js';
 
-export function createServerBase(connection: vscode.Connection) {
+export function createServerBase(connection: vscode.Connection, env: LanguageServerEnvironment) {
 	const onInitializeCallbacks: ((serverCapabilities: vscode.ServerCapabilities<ExperimentalFeatures>) => void)[] = [];
 	const onInitializedCallbacks: (() => void)[] = [];
 	const state: LanguageServerState = {
+		env,
 		connection,
 		initializeParams: undefined! as vscode.InitializeParams,
 		project: undefined! as LanguageServerProject,

--- a/packages/language-server/lib/types.ts
+++ b/packages/language-server/lib/types.ts
@@ -3,6 +3,12 @@ import { Connection } from 'vscode-languageserver';
 import type { URI } from 'vscode-uri';
 import { createServerBase } from './server';
 
+export interface LanguageServerEnvironment {
+	timer: {
+		setImmediate: (callback: (...args: any[]) => void, ...args: any[]) => void;
+	};
+}
+
 export interface LanguageServerProject {
 	setup(server: LanguageServer): void;
 	getLanguageService(uri: URI): ProviderResult<LanguageService>;
@@ -11,13 +17,14 @@ export interface LanguageServerProject {
 }
 
 export interface LanguageServerState {
+	env: LanguageServerEnvironment;
 	connection: Connection;
 	initializeParams: InitializeParams;
 	project: LanguageServerProject;
 	languageServicePlugins: LanguageServicePlugin[];
 	onInitialize(callback: (serverCapabilities: ServerCapabilities<ExperimentalFeatures>) => void): void;
 	onInitialized(callback: () => void): void;
-};
+}
 
 export type LanguageServer = ReturnType<typeof createServerBase>;
 

--- a/packages/language-server/node.ts
+++ b/packages/language-server/node.ts
@@ -14,7 +14,11 @@ export function createConnection() {
 }
 
 export function createServer(connection: vscode.Connection) {
-	const server = createServerBase(connection);
+	const server = createServerBase(connection, {
+		timer: {
+			setImmediate: setImmediate,
+		},
+	});
 	server.fileSystem.install('file', nodeFsProvider);
 	server.fileSystem.install('http', httpFsProvider);
 	server.fileSystem.install('https', httpFsProvider);


### PR DESCRIPTION
As mentioned in the [comment](https://github.com/vuejs/language-tools/issues/4593#issuecomment-2304245223), it 。seems more reasonable to replace `setTimeout` with `setImmediate`.

1. `volar` uses `vscode-languageserver-node`, [which uses setImmediate to process messages](https://github.com/microsoft/vscode-languageserver-node/blob/main/jsonrpc/src/common/connection.ts#L723).
2. [the built-in HTML plugin of vscode also uses setImmediate to wrap the runner].(https://github.com/microsoft/vscode/blob/main/extensions/html-language-features/server/src/utils/runner.ts#L21).
3. this ensures the order of message processing.

🤔