### PR TITLE
feat(language-server): support files that do not exist in FS but are open in the editor for TS project

### DIFF
--- a/packages/language-server/lib/project/typescriptProjectLs.ts
+++ b/packages/language-server/lib/project/typescriptProjectLs.ts
@@ -88,7 +88,7 @@ export async function createTypeScriptLS(
 		}),
 		server.documents.onDidOpen(async ({ document }) => {
 			const uri = URI.parse(document.uri);
-			const isWorkspaceFile = serviceEnv.workspaceFolders.some(folder => uri.scheme === folder.scheme);
+			const isWorkspaceFile = workspaceFolder.scheme === uri.scheme;
 			if (!isWorkspaceFile) {
 				return;
 			}
@@ -100,7 +100,7 @@ export async function createTypeScriptLS(
 		}),
 		server.documents.onDidClose(async ({ document }) => {
 			const uri = URI.parse(document.uri);
-			const isWorkspaceFile = serviceEnv.workspaceFolders.some(folder => uri.scheme === folder.scheme);
+			const isWorkspaceFile = workspaceFolder.scheme === uri.scheme;
 			if (!isWorkspaceFile) {
 				return;
 			}
@@ -255,7 +255,10 @@ export async function createTypeScriptLS(
 			fileNames: [],
 			options: {},
 		};
-		const maybeUnsavedFileNames = server.documents.all().map(document => uriConverter.asFileName(URI.parse(document.uri)));
+		const maybeUnsavedFileNames = server.documents.all()
+			.map(document => URI.parse(document.uri))
+			.filter(uri => uri.scheme === workspaceFolder.scheme)
+			.map(uri => uriConverter.asFileName(uri));
 		const host: ts.ParseConfigHost = {
 			..._host,
 			readDirectory(rootDir, extensions, excludes, includes, depth) {

--- a/packages/language-service/lib/features/resolveCodeAction.ts
+++ b/packages/language-service/lib/features/resolveCodeAction.ts
@@ -9,12 +9,11 @@ export function register(context: LanguageServiceContext) {
 	return async (item: vscode.CodeAction, token = NoneCancellationToken) => {
 
 		const data: ServiceCodeActionData | undefined = item.data;
-		delete item.data;
-
 		if (data) {
 
 			const plugin = context.plugins[data.pluginIndex];
 			if (!plugin[1].resolveCodeAction) {
+				delete item.data;
 				return item;
 			}
 
@@ -37,6 +36,7 @@ export function register(context: LanguageServiceContext) {
 				);
 		}
 
+		delete item.data;
 		return item;
 	};
 }

--- a/packages/language-service/lib/features/resolveCodeLens.ts
+++ b/packages/language-service/lib/features/resolveCodeLens.ts
@@ -12,12 +12,11 @@ export function register(context: LanguageServiceContext) {
 	return async (item: vscode.CodeLens, token = NoneCancellationToken) => {
 
 		const data: ServiceCodeLensData | ServiceReferencesCodeLensData | undefined = item.data;
-		delete item.data;
-
 		if (data?.kind === 'normal') {
 
 			const plugin = context.plugins[data.pluginIndex];
 			if (!plugin[1].resolveCodeLens) {
+				delete item.data;
 				return item;
 			}
 
@@ -26,14 +25,14 @@ export function register(context: LanguageServiceContext) {
 
 			// item.range already transformed in codeLens request
 		}
-
-		if (data?.kind === 'references') {
+		else if (data?.kind === 'references') {
 
 			const references = await findReferences(URI.parse(data.sourceFileUri), item.range.start, { includeDeclaration: false }, token) ?? [];
 
 			item.command = context.commands.showReferences.create(data.sourceFileUri, item.range.start, references);
 		}
 
+		delete item.data;
 		return item;
 	};
 }

--- a/packages/language-service/lib/features/resolveCompletionItem.ts
+++ b/packages/language-service/lib/features/resolveCompletionItem.ts
@@ -11,13 +11,12 @@ export function register(context: LanguageServiceContext) {
 	return async (item: vscode.CompletionItem, token = NoneCancellationToken) => {
 
 		const data: ServiceCompletionData | undefined = item.data;
-		delete item.data;
-
 		if (data) {
 
 			const plugin = context.plugins[data.pluginIndex];
 
 			if (!plugin[1].resolveCompletionItem) {
+				delete item.data;
 				return item;
 			}
 
@@ -59,6 +58,7 @@ export function register(context: LanguageServiceContext) {
 			item.detail = item.detail;
 		}
 
+		delete item.data;
 		return item;
 	};
 }

--- a/packages/language-service/lib/features/resolveDocumentLink.ts
+++ b/packages/language-service/lib/features/resolveDocumentLink.ts
@@ -9,11 +9,10 @@ export function register(context: LanguageServiceContext) {
 	return async (item: vscode.DocumentLink, token = NoneCancellationToken) => {
 
 		const data: DocumentLinkData | undefined = item.data;
-		delete item.data;
-
 		if (data) {
 			const plugin = context.plugins[data.pluginIndex];
 			if (!plugin[1].resolveDocumentLink) {
+				delete item.data;
 				return item;
 			}
 
@@ -25,6 +24,7 @@ export function register(context: LanguageServiceContext) {
 			}
 		}
 
+		delete item.data;
 		return item;
 	};
 }

--- a/packages/language-service/lib/features/resolveInlayHint.ts
+++ b/packages/language-service/lib/features/resolveInlayHint.ts
@@ -8,11 +8,10 @@ export function register(context: LanguageServiceContext) {
 	return async (item: vscode.InlayHint, token = NoneCancellationToken) => {
 
 		const data: InlayHintData | undefined = item.data;
-		delete item.data;
-
 		if (data) {
 			const plugin = context.plugins[data.pluginIndex];
 			if (!plugin[1].resolveInlayHint) {
+				delete item.data;
 				return item;
 			}
 
@@ -20,6 +19,7 @@ export function register(context: LanguageServiceContext) {
 			item = await plugin[1].resolveInlayHint(item, token);
 		}
 
+		delete item.data;
 		return item;
 	};
 }

--- a/packages/language-service/lib/features/resolveWorkspaceSymbol.ts
+++ b/packages/language-service/lib/features/resolveWorkspaceSymbol.ts
@@ -8,11 +8,10 @@ export function register(context: LanguageServiceContext) {
 	return async (item: vscode.WorkspaceSymbol, token = NoneCancellationToken) => {
 
 		const data: WorkspaceSymbolData | undefined = item.data;
-		delete item.data;
-
 		if (data) {
 			const plugin = context.plugins[data.pluginIndex];
 			if (!plugin[1].resolveWorkspaceSymbol) {
+				delete item.data;
 				return item;
 			}
 
@@ -20,6 +19,7 @@ export function register(context: LanguageServiceContext) {
 			item = await plugin[1].resolveWorkspaceSymbol(item, token);
 		}
 
+		delete item.data;
 		return item;
 	};
 }

--- a/packages/test-utils/README.md
+++ b/packages/test-utils/README.md
@@ -18,7 +18,7 @@ The returned server handle provides several methods to interact with the languag
 
 - `initialize(rootUri: string, initializationOptions: InitializationOptions)`: Initializes the language server.
 - `openTextDocument(fileName: string, languageId: string)`: Opens a text document.
-- `openUntitledDocument(content: string, languageId: string)`: Opens an untitled text document.
+- `openUntitledDocument(languageId: string, content: string)`: Opens an untitled text document.
 - `closeTextDocument(uri: string)`: Closes a text document.
 - Various `send*Request` methods: Send language-related requests to the server.
 

--- a/packages/test-utils/index.ts
+++ b/packages/test-utils/index.ts
@@ -107,7 +107,7 @@ export function startLanguageServer(serverModule: string, cwd?: string | URL) {
 			}
 			return openedDocuments.get(uri)!;
 		},
-		async openUntitledDocument(content: string, languageId: string) {
+		async openUntitledDocument(languageId: string, content: string) {
 			const uri = URI.from({ scheme: 'untitled', path: `Untitled-${untitledCounter++}` }).toString();
 			const document = TextDocument.create(
 				uri,

--- a/packages/test-utils/index.ts
+++ b/packages/test-utils/index.ts
@@ -409,6 +409,21 @@ export function startLanguageServer(serverModule: string, cwd?: string | URL) {
 				link satisfies _.DocumentLink
 			);
 		},
+		sendInlayHintRequest(uri: string, range: _.Range) {
+			return connection.sendRequest(
+				_.InlayHintRequest.type,
+				{
+					textDocument: { uri },
+					range,
+				} satisfies _.InlayHintParams
+			);
+		},
+		sendInlayHintResolveRequest(hint: _.InlayHint) {
+			return connection.sendRequest(
+				_.InlayHintResolveRequest.type,
+				hint satisfies _.InlayHint
+			);
+		},
 	};
 
 	function getConfiguration(section: string) {

--- a/packages/test-utils/index.ts
+++ b/packages/test-utils/index.ts
@@ -24,6 +24,7 @@ export function startLanguageServer(serverModule: string, cwd?: string | URL) {
 		childProcess.stdout!,
 		childProcess.stdin!
 	);
+	const documentVersions = new Map<string, number>();
 	const openedDocuments = new Map<string, TextDocument>();
 	const settings: any = {};
 
@@ -84,7 +85,13 @@ export function startLanguageServer(serverModule: string, cwd?: string | URL) {
 		async openTextDocument(fileName: string, languageId: string) {
 			const uri = URI.file(fileName).toString();
 			if (!openedDocuments.has(uri)) {
-				const document = TextDocument.create(uri, languageId, 0, fs.readFileSync(fileName, 'utf-8'));
+				const document = TextDocument.create(
+					uri,
+					languageId,
+					(documentVersions.get(uri) ?? 0) + 1,
+					fs.readFileSync(fileName, 'utf-8')
+				);
+				documentVersions.set(uri, document.version);
 				openedDocuments.set(uri, document);
 				await connection.sendNotification(
 					_.DidOpenTextDocumentNotification.type,
@@ -102,7 +109,13 @@ export function startLanguageServer(serverModule: string, cwd?: string | URL) {
 		},
 		async openUntitledDocument(content: string, languageId: string) {
 			const uri = URI.from({ scheme: 'untitled', path: `Untitled-${untitledCounter++}` }).toString();
-			const document = TextDocument.create(uri, languageId, 0, content);
+			const document = TextDocument.create(
+				uri,
+				languageId,
+				(documentVersions.get(uri) ?? 0) + 1,
+				content
+			);
+			documentVersions.set(uri, document.version);
 			openedDocuments.set(uri, document);
 			await connection.sendNotification(
 				_.DidOpenTextDocumentNotification.type,
@@ -122,7 +135,13 @@ export function startLanguageServer(serverModule: string, cwd?: string | URL) {
 			if (oldDocument) {
 				await this.closeTextDocument(uri);
 			}
-			const document = TextDocument.create(uri, languageId, (oldDocument?.version ?? 0) + 1, content);
+			const document = TextDocument.create(
+				uri,
+				languageId,
+				(documentVersions.get(uri) ?? 0) + 1,
+				content
+			);
+			documentVersions.set(uri, document.version);
 			openedDocuments.set(uri, document);
 			await connection.sendNotification(
 				_.DidOpenTextDocumentNotification.type,
@@ -152,6 +171,7 @@ export function startLanguageServer(serverModule: string, cwd?: string | URL) {
 			assert(document);
 			const newText = TextDocument.applyEdits(document, edits);
 			document = TextDocument.create(uri, document.languageId, document.version + 1, newText);
+			documentVersions.set(uri, document.version);
 			openedDocuments.set(uri, document);
 			await connection.sendNotification(
 				_.DidChangeTextDocumentNotification.type,

--- a/packages/typescript/lib/protocol/createSys.ts
+++ b/packages/typescript/lib/protocol/createSys.ts
@@ -24,7 +24,7 @@ let currentCwd = '';
 
 export function createSys(
 	sys: ts.System | undefined,
-	env: LanguageServiceEnvironment,
+	env: Pick<LanguageServiceEnvironment, 'onDidChangeWatchedFiles' | 'fs'>,
 	getCurrentDirectory: () => string,
 	uriConverter: {
 		asUri(fileName: string): URI;
@@ -252,7 +252,6 @@ export function createSys(
 			currentDirectory,
 			depth,
 			dirPath => {
-
 				dirPath = resolvePath(dirPath);
 				readDirectoryWorker(dirPath);
 				const dir = getDir(dirPath);


### PR DESCRIPTION
This is a change made for `test-utils`. The test code can make the TS language server think that a certain file exists through `openInMemoryDocument`, even if the file does not exist in FS.

Example: https://github.com/vuejs/language-tools/blob/13924d1d2fb8a6f11c267dd4612c366502c1cbc5/packages/language-server/tests/inlayHints.spec.ts#L232