### PR TITLE
fix: set module resolution cache

### DIFF
--- a/packages/typescript/lib/protocol/createProject.ts
+++ b/packages/typescript/lib/protocol/createProject.ts
@@ -15,6 +15,15 @@ export interface TypeScriptProjectHost extends Pick<
 	| 'getProjectVersion'
 > { }
 
+declare module 'typescript' {
+	interface LanguageServiceHost {
+		/**
+		 * @internal
+		 */
+		getModuleResolutionCache?(): ts.ModuleResolutionCache;
+	}
+}
+
 export function createLanguageServiceHost<T>(
 	ts: typeof import('typescript'),
 	sys: ReturnType<typeof createSys> | ts.System,
@@ -188,6 +197,8 @@ export function createLanguageServiceHost<T>(
 				return resolveModuleName(moduleName, containingFile, options, moduleCache, redirectedReference).resolvedModule;
 			});
 		};
+
+		languageServiceHost.getModuleResolutionCache = () => moduleCache;
 	}
 
 	return {


### PR DESCRIPTION
In TS 5.6, this method is called on the host to try to get the cache, unfortunately since we were not setting it, on every single keystroke TS would reload every single package json in the project, causing completions to take 200+ms to load every time.

TS 5.5:
![image](https://github.com/user-attachments/assets/f2410846-4fc3-4c38-a5cd-c36d1634bc76)

Before (TS 5.6):
![image](https://github.com/user-attachments/assets/8b830365-2e62-4d74-92cd-e83f80e376fa)

After (TS 5.6):
![image](https://github.com/user-attachments/assets/5004de30-3258-4af1-8b30-7178fa67194f)

I'll note that this is still slower than TS 5.5, there's probably more things that should be cached that aren't, not sure.