### PR TITLE
fix(typescript): content-sensitive features are only allowed to return results in contiguous mapped ranges

### DIFF
--- a/packages/typescript/lib/node/proxyLanguageService.ts
+++ b/packages/typescript/lib/node/proxyLanguageService.ts
@@ -246,10 +246,10 @@ function prepareCallHierarchy(language: Language<string>, prepareCallHierarchy: 
 			if (generatePosition !== undefined) {
 				const item = prepareCallHierarchy(targetScript.id, generatePosition);
 				if (Array.isArray(item)) {
-					return item.map(item => transformCallHierarchyItem(language, item, isCallHierarchyEnabled));
+					return item.map(item => transformCallHierarchyItem(language, item, false, isCallHierarchyEnabled));
 				}
 				else if (item) {
-					return transformCallHierarchyItem(language, item, isCallHierarchyEnabled);
+					return transformCallHierarchyItem(language, item, false, isCallHierarchyEnabled);
 				}
 			}
 		}
@@ -277,7 +277,7 @@ function provideCallHierarchyIncomingCalls(language: Language<string>, provideCa
 		}
 		return calls
 			.map(call => {
-				const from = transformCallHierarchyItem(language, call.from, isCallHierarchyEnabled);
+				const from = transformCallHierarchyItem(language, call.from, false, isCallHierarchyEnabled);
 				const fromSpans = call.fromSpans
 					.map(span => transformSpan(language, call.from.file, span, false, isCallHierarchyEnabled)?.textSpan)
 					.filter(span => !!span);
@@ -307,7 +307,7 @@ function provideCallHierarchyOutgoingCalls(language: Language<string>, provideCa
 		}
 		return calls
 			.map(call => {
-				const to = transformCallHierarchyItem(language, call.to, isCallHierarchyEnabled);
+				const to = transformCallHierarchyItem(language, call.to, false, isCallHierarchyEnabled);
 				const fromSpans = call.fromSpans
 					.map(span => serviceScript
 						? transformTextSpan(sourceScript, language, serviceScript, span, false, isCallHierarchyEnabled)?.[1]

--- a/packages/typescript/lib/node/transform.ts
+++ b/packages/typescript/lib/node/transform.ts
@@ -11,10 +11,11 @@ const transformedSourceFile = new WeakSet<ts.SourceFile>();
 export function transformCallHierarchyItem(
 	language: Language<string>,
 	item: ts.CallHierarchyItem,
+	fallbackToAnyMatch: boolean,
 	filter: (data: CodeInformation) => boolean
 ): ts.CallHierarchyItem {
-	const span = transformSpan(language, item.file, item.span, false, filter);
-	const selectionSpan = transformSpan(language, item.file, item.selectionSpan, false, filter);
+	const span = transformSpan(language, item.file, item.span, fallbackToAnyMatch, filter);
+	const selectionSpan = transformSpan(language, item.file, item.selectionSpan, fallbackToAnyMatch, filter);
 	return {
 		...item,
 		file: span?.fileName ?? item.file,

--- a/packages/typescript/lib/node/transform.ts
+++ b/packages/typescript/lib/node/transform.ts
@@ -13,8 +13,8 @@ export function transformCallHierarchyItem(
 	item: ts.CallHierarchyItem,
 	filter: (data: CodeInformation) => boolean
 ): ts.CallHierarchyItem {
-	const span = transformSpan(language, item.file, item.span, filter);
-	const selectionSpan = transformSpan(language, item.file, item.selectionSpan, filter);
+	const span = transformSpan(language, item.file, item.span, false, filter);
+	const selectionSpan = transformSpan(language, item.file, item.selectionSpan, false, filter);
 	return {
 		...item,
 		file: span?.fileName ?? item.file,
@@ -54,6 +54,7 @@ export function transformDiagnostic<T extends ts.Diagnostic>(
 						start: diagnostic.start,
 						length: diagnostic.length
 					},
+					true,
 					data => shouldReportDiagnostics(data, String(diagnostic.source), String(diagnostic.code))
 				) ?? [];
 				const actualDiagnosticFile = sourceSpanFileName
@@ -101,6 +102,7 @@ export function fillSourceFileText(language: Language<string>, sourceFile: ts.So
 export function transformFileTextChanges(
 	language: Language<string>,
 	changes: readonly ts.FileTextChanges[],
+	fallbackToAnyMatch: boolean,
 	filter: (data: CodeInformation) => boolean
 ): ts.FileTextChanges[] {
 	const changesPerFile: { [fileName: string]: TextChange[]; } = {};
@@ -109,7 +111,7 @@ export function transformFileTextChanges(
 		const [_, source] = getServiceScript(language, fileChanges.fileName);
 		if (source) {
 			fileChanges.textChanges.forEach(c => {
-				const { fileName, textSpan } = transformSpan(language, fileChanges.fileName, c.span, filter) ?? {};
+				const { fileName, textSpan } = transformSpan(language, fileChanges.fileName, c.span, fallbackToAnyMatch, filter) ?? {};
 				if (fileName && textSpan) {
 					(changesPerFile[fileName] ?? (changesPerFile[fileName] = [])).push({ ...c, span: textSpan });
 				}
@@ -139,10 +141,11 @@ export function transformFileTextChanges(
 export function transformDocumentSpan<T extends ts.DocumentSpan>(
 	language: Language<string>,
 	documentSpan: T,
+	fallbackToAnyMatch: boolean,
 	filter: (data: CodeInformation) => boolean,
 	shouldFallback?: boolean
 ): T | undefined {
-	let textSpan = transformSpan(language, documentSpan.fileName, documentSpan.textSpan, filter);
+	let textSpan = transformSpan(language, documentSpan.fileName, documentSpan.textSpan, fallbackToAnyMatch, filter);
 	if (!textSpan && shouldFallback) {
 		textSpan = {
 			fileName: documentSpan.fileName,
@@ -152,9 +155,9 @@ export function transformDocumentSpan<T extends ts.DocumentSpan>(
 	if (!textSpan) {
 		return;
 	}
-	const contextSpan = transformSpan(language, documentSpan.fileName, documentSpan.contextSpan, filter);
-	const originalTextSpan = transformSpan(language, documentSpan.originalFileName, documentSpan.originalTextSpan, filter);
-	const originalContextSpan = transformSpan(language, documentSpan.originalFileName, documentSpan.originalContextSpan, filter);
+	const contextSpan = transformSpan(language, documentSpan.fileName, documentSpan.contextSpan, fallbackToAnyMatch, filter);
+	const originalTextSpan = transformSpan(language, documentSpan.originalFileName, documentSpan.originalTextSpan, fallbackToAnyMatch, filter);
+	const originalContextSpan = transformSpan(language, documentSpan.originalFileName, documentSpan.originalContextSpan, fallbackToAnyMatch, filter);
 	return {
 		...documentSpan,
 		fileName: textSpan.fileName,
@@ -170,6 +173,7 @@ export function transformSpan(
 	language: Language<string>,
 	fileName: string | undefined,
 	textSpan: ts.TextSpan | undefined,
+	fallbackToAnyMatch: boolean,
 	filter: (data: CodeInformation) => boolean
 ): {
 	fileName: string;
@@ -180,7 +184,7 @@ export function transformSpan(
 	}
 	const [serviceScript] = getServiceScript(language, fileName);
 	if (serviceScript) {
-		const [sourceSpanFileName, sourceSpan] = transformTextSpan(undefined, language, serviceScript, textSpan, filter) ?? [];
+		const [sourceSpanFileName, sourceSpan] = transformTextSpan(undefined, language, serviceScript, textSpan, fallbackToAnyMatch, filter) ?? [];
 		if (sourceSpan && sourceSpanFileName) {
 			return {
 				fileName: sourceSpanFileName,
@@ -201,9 +205,10 @@ export function transformTextChange(
 	language: Language<string>,
 	serviceScript: TypeScriptServiceScript,
 	textChange: ts.TextChange,
+	fallbackToAnyMatch: boolean,
 	filter: (data: CodeInformation) => boolean
 ): [string, ts.TextChange] | undefined {
-	const [sourceSpanFileName, sourceSpan] = transformTextSpan(sourceScript, language, serviceScript, textChange.span, filter) ?? [];
+	const [sourceSpanFileName, sourceSpan] = transformTextSpan(sourceScript, language, serviceScript, textChange.span, fallbackToAnyMatch, filter) ?? [];
 	if (sourceSpan && sourceSpanFileName) {
 		return [sourceSpanFileName, {
 			newText: textChange.newText,
@@ -218,11 +223,12 @@ export function transformTextSpan(
 	language: Language<string>,
 	serviceScript: TypeScriptServiceScript,
 	textSpan: ts.TextSpan,
+	fallbackToAnyMatch: boolean,
 	filter: (data: CodeInformation) => boolean
 ): [string, ts.TextSpan] | undefined {
 	const start = textSpan.start;
 	const end = textSpan.start + textSpan.length;
-	for (const [fileName, sourceStart, sourceEnd] of toSourceRanges(sourceScript, language, serviceScript, start, end, filter)) {
+	for (const [fileName, sourceStart, sourceEnd] of toSourceRanges(sourceScript, language, serviceScript, start, end, fallbackToAnyMatch, filter)) {
 		return [fileName, {
 			start: sourceStart,
 			length: sourceEnd - sourceStart,
@@ -248,6 +254,7 @@ export function* toSourceRanges(
 	serviceScript: TypeScriptServiceScript,
 	start: number,
 	end: number,
+	fallbackToAnyMatch: boolean,
 	filter: (data: CodeInformation) => boolean
 ): Generator<[fileName: string, start: number, end: number]> {
 	if (sourceScript) {
@@ -255,7 +262,7 @@ export function* toSourceRanges(
 		for (const [sourceStart, sourceEnd] of map.toSourceRange(
 			start - getMappingOffset(language, serviceScript),
 			end - getMappingOffset(language, serviceScript),
-			true,
+			fallbackToAnyMatch,
 			filter
 		)) {
 			yield [sourceScript.id, sourceStart, sourceEnd];
@@ -266,7 +273,7 @@ export function* toSourceRanges(
 			for (const [sourceStart, sourceEnd] of map.toSourceRange(
 				start - getMappingOffset(language, serviceScript),
 				end - getMappingOffset(language, serviceScript),
-				true,
+				fallbackToAnyMatch,
 				filter
 			)) {
 				yield [sourceScript.id, sourceStart, sourceEnd];


### PR DESCRIPTION
Fixes https://github.com/vuejs/language-tools/issues/4811, closes https://github.com/vuejs/language-tools/pull/4906

In the past we mapped results in discrete mapping regions for all TS features, however for content-sensitive features (such as autocomplete/formatting), results should only be returned in continuous mapping regions.

Affected features:

- getFormattingEditsForDocument
- getFormattingEditsForRange
- getFormattingEditsAfterKeystroke
- getEditsForFileRename
- getLinkedEditingRangeAtPosition
- organizeImports
- getDocumentHighlights
- getEditsForRefactor
- getCombinedCodeFix
- getRenameInfo
- getCodeFixesAtPosition
- getEncodedSemanticClassifications
- findRenameLocations
- getCompletionsAtPosition
- getCompletionEntryDetails

cc @piotrtomiak, @KazariEX