### PR TITLE
fix(typescript): Fix interactive refactors

### DIFF
--- a/packages/typescript/lib/node/proxyLanguageService.ts
+++ b/packages/typescript/lib/node/proxyLanguageService.ts
@@ -485,7 +485,7 @@ function getApplicableRefactors(language: Language<string>, getApplicableRefacto
 	};
 }
 function getEditsForRefactor(language: Language<string>, getEditsForRefactor: ts.LanguageService['getEditsForRefactor']): ts.LanguageService['getEditsForRefactor'] {
-	return (filePath, formatOptions, positionOrRange, refactorName, actionName, preferences) => {
+	return (filePath, formatOptions, positionOrRange, refactorName, actionName, preferences, interactiveRefactorArguments) => {
 		let edits: ts.RefactorEditInfo | undefined;
 		const fileName = filePath.replace(windowsPathReg, '/');
 		const [serviceScript, targetScript, sourceScript] = getServiceScript(language, fileName);
@@ -496,17 +496,17 @@ function getEditsForRefactor(language: Language<string>, getEditsForRefactor: ts
 			if (typeof positionOrRange === 'number') {
 				const generatePosition = toGeneratedOffset(language, serviceScript, sourceScript, positionOrRange, isCodeActionsEnabled);
 				if (generatePosition !== undefined) {
-					edits = getEditsForRefactor(targetScript.id, formatOptions, generatePosition, refactorName, actionName, preferences);
+					edits = getEditsForRefactor(targetScript.id, formatOptions, generatePosition, refactorName, actionName, preferences, interactiveRefactorArguments);
 				}
 			}
 			else {
 				for (const [generatedStart, generatedEnd] of toGeneratedRanges(language, serviceScript, sourceScript, positionOrRange.pos, positionOrRange.end, isCodeActionsEnabled)) {
-					edits = getEditsForRefactor(targetScript.id, formatOptions, { pos: generatedStart, end: generatedEnd }, refactorName, actionName, preferences);
+					edits = getEditsForRefactor(targetScript.id, formatOptions, { pos: generatedStart, end: generatedEnd }, refactorName, actionName, preferences, interactiveRefactorArguments);
 				}
 			}
 		}
 		else {
-			edits = getEditsForRefactor(fileName, formatOptions, positionOrRange, refactorName, actionName, preferences);
+			edits = getEditsForRefactor(fileName, formatOptions, positionOrRange, refactorName, actionName, preferences, interactiveRefactorArguments);
 		}
 		if (edits) {
 			edits.edits = transformFileTextChanges(language, edits.edits, false, isCodeActionsEnabled);


### PR DESCRIPTION
Passing along this argument is required since you proxy `includeInteractiveActions` in `getApplicableRefactors`. Without this, VS Code’s “Move to File” refactor fails for all TypeScript users who have the extension installed:


https://github.com/user-attachments/assets/2e169eff-b220-4ae5-8d4e-1017b0d9eaa7

