### PR TITLE
Updated @volar/source-map/README based on PR(#207)

### DIFF
--- a/packages/source-map/README.md
+++ b/packages/source-map/README.md
@@ -4,15 +4,22 @@ Provides functionality related to source maps.
 
 ## API
 
-This package exports a `SourceMap` class with the following methods:
+### This package exports a `SourceMap` class with the following methods:
 
-- `getSourceOffset(generatedOffset: number)`: Returns the source offset for a given generated offset.
+Params:
 
-- `getGeneratedOffset(sourceOffset: number)`: Returns the generated offset for a given source offset.
+- `fallbackToAnyMatch`(default: false): allow the start and end offsets to come from different mappings.
+- `filter?: (data: Data) => boolean)`(default: undefined):  according to mapping: Mapping<MyDataType>.data, filter out offsets that do not meet the custom conditions.
 
-- `getSourceOffsets(generatedOffset: number)`: Returns all source offsets for a given generated offset.
+Methods:
 
-- `getGeneratedOffsets(sourceOffset: number)`: Returns all generated offsets for a given source offset.
+- `toSourceRange(generatedStart: number, generatedEnd: number, fallbackToAnyMatch: boolean, filter?: (data: Data) => boolean)`: Returns all source start and end offsets for the given generated start and end offsets.
+
+- `toGeneratedRange(sourceStart: number, sourceEnd: number, fallbackToAnyMatch: boolean, filter?: (data: Data) => boolean) `: Returns all generated start and end offsets for the given source start and end offsets.
+
+- `toSourceLocation(generatedOffset: number, filter?: (data: Data) => boolean)`: Returns all source offsets for a given generated offset.
+
+- `toGeneratedLocation(sourceOffset: number, filter?: (data: Data) => boolean)`: Returns all generated offsets for a given source offset.
 
 ## Data Structures
 


### PR DESCRIPTION
Hello, I'm trying to develop a custom syntax lsp plugin based on ts recently, using volar.js, which is really great, saving me a lot of work and letting me learn a lot.

I'm learning about the functions of the code mapping related parts, and I found that the document description in

https://github.com/volarjs/volar.js/blob/master/packages/source-map/README.md

and the code implementation in

https://github.com/volarjs/volar.js/blob/master/packages/source-map/lib/sourceMap.ts are inconsistent, so I tried to synchronize this document

There is also a about

https://github.com/volarjs/volar.js/blob/03d1e8b07e1e64921b76b635c7064d7b4fcf63b5/packages/source-map/lib/sourceMap.ts#L71

`* findMatchingStartEnd` I am a little confused about this method. I see that in this method, when `fallbackToAnyMatch = true` is judged, it will break if it matches one, but the non-`fallbackToAnyMatch` code block above does not break. What is the reason?
I am also curious about the situation where there will be a start and end position of the source code, corresponding to the start and end positions of multiple generated codes.