### PR TITLE
fix(typescript): fix issue with transpiled TypeScript files not being registered with a project at all

### DIFF
--- a/packages/language-core/index.ts
+++ b/packages/language-core/index.ts
@@ -22,7 +22,7 @@ export const defaultMapperFactory: MapperFactory = mappings => new SourceMap(map
 export function createLanguage<T>(
 	plugins: LanguagePlugin<T>[],
 	scriptRegistry: Map<T, SourceScript<T>>,
-	sync: (id: T, includeFsFiles: boolean) => void
+	sync: (id: T, includeFsFiles: boolean, shouldRegister: boolean) => void
 ) {
 	const virtualCodeToSourceScriptMap = new WeakMap<VirtualCode, SourceScript<T>>();
 	const virtualCodeToSourceMap = new WeakMap<IScriptSnapshot, WeakMap<IScriptSnapshot, Mapper>>();
@@ -34,8 +34,8 @@ export function createLanguage<T>(
 			fromVirtualCode(virtualCode) {
 				return virtualCodeToSourceScriptMap.get(virtualCode)!;
 			},
-			get(id, includeFsFiles = true) {
-				sync(id, includeFsFiles);
+			get(id, includeFsFiles = true, shouldRegister = false) {
+				sync(id, includeFsFiles, shouldRegister);
 				const result = scriptRegistry.get(id);
 				// The sync function provider may not always call the set function due to caching, so it is necessary to explicitly check isAssociationDirty.
 				if (result?.isAssociationDirty) {
@@ -220,7 +220,7 @@ export function createLanguage<T>(
 		sourceScript.isAssociationDirty = false;
 		return {
 			getAssociatedScript(id) {
-				sync(id, true);
+				sync(id, true, true);
 				const relatedSourceScript = scriptRegistry.get(id);
 				if (relatedSourceScript) {
 					relatedSourceScript.targetIds.add(sourceScript.id);

--- a/packages/language-core/lib/types.ts
+++ b/packages/language-core/lib/types.ts
@@ -15,7 +15,7 @@ export interface Language<T = unknown> {
 	mapperFactory: MapperFactory;
 	plugins: LanguagePlugin<T>[];
 	scripts: {
-		get(id: T, includeFsFiles?: boolean): SourceScript<T> | undefined;
+		get(id: T, includeFsFiles?: boolean, shouldRegister?: boolean): SourceScript<T> | undefined;
 		set(id: T, snapshot: IScriptSnapshot, languageId?: string, plugins?: LanguagePlugin<T>[]): SourceScript<T> | undefined;
 		delete(id: T): void;
 		fromVirtualCode(virtualCode: VirtualCode): SourceScript<T>;

--- a/packages/typescript/lib/node/decorateLanguageServiceHost.ts
+++ b/packages/typescript/lib/node/decorateLanguageServiceHost.ts
@@ -85,6 +85,10 @@ export function decorateLanguageServiceHost(
 	languageServiceHost.getScriptSnapshot = fileName => {
 		const virtualScript = updateVirtualScript(fileName);
 		if (virtualScript) {
+            if (fileName.endsWith('.ts') || fileName.endsWith(".tsx") || fileName.endsWith(".js") || fileName.endsWith(".jsx")) {
+                // We need to trigger registration of the script file with the project
+                getScriptSnapshot(fileName)
+            }
 			return virtualScript.snapshot;
 		}
 		return getScriptSnapshot(fileName);

--- a/packages/typescript/lib/node/decorateLanguageServiceHost.ts
+++ b/packages/typescript/lib/node/decorateLanguageServiceHost.ts
@@ -83,12 +83,8 @@ export function decorateLanguageServiceHost(
 	}
 
 	languageServiceHost.getScriptSnapshot = fileName => {
-		const virtualScript = updateVirtualScript(fileName);
+		const virtualScript = updateVirtualScript(fileName, true);
 		if (virtualScript) {
-			if (fileName.endsWith('.ts') || fileName.endsWith('.tsx') || fileName.endsWith('.js') || fileName.endsWith('.jsx')) {
-				// We need to trigger registration of the script file with the project
-				getScriptSnapshot(fileName);
-			}
 			return virtualScript.snapshot;
 		}
 		return getScriptSnapshot(fileName);
@@ -96,7 +92,7 @@ export function decorateLanguageServiceHost(
 
 	if (getScriptKind) {
 		languageServiceHost.getScriptKind = fileName => {
-			const virtualScript = updateVirtualScript(fileName);
+			const virtualScript = updateVirtualScript(fileName, false);
 			if (virtualScript) {
 				return virtualScript.scriptKind;
 			}
@@ -104,7 +100,7 @@ export function decorateLanguageServiceHost(
 		};
 	}
 
-	function updateVirtualScript(fileName: string) {
+	function updateVirtualScript(fileName: string, shouldRegister: boolean) {
 		if (crashFileNames.has(fileName)) {
 			return;
 		}
@@ -123,7 +119,7 @@ export function decorateLanguageServiceHost(
 		if (!script || script[0] !== version) {
 			script = [version];
 
-			const sourceScript = language.scripts.get(fileName);
+			const sourceScript = language.scripts.get(fileName, undefined, shouldRegister);
 			if (sourceScript?.generated) {
 				const serviceScript = sourceScript.generated.languagePlugin.typescript?.getServiceScript(sourceScript.generated.root);
 				if (serviceScript) {

--- a/packages/typescript/lib/node/decorateLanguageServiceHost.ts
+++ b/packages/typescript/lib/node/decorateLanguageServiceHost.ts
@@ -85,10 +85,10 @@ export function decorateLanguageServiceHost(
 	languageServiceHost.getScriptSnapshot = fileName => {
 		const virtualScript = updateVirtualScript(fileName);
 		if (virtualScript) {
-            if (fileName.endsWith('.ts') || fileName.endsWith(".tsx") || fileName.endsWith(".js") || fileName.endsWith(".jsx")) {
-                // We need to trigger registration of the script file with the project
-                getScriptSnapshot(fileName)
-            }
+			if (fileName.endsWith('.ts') || fileName.endsWith('.tsx') || fileName.endsWith('.js') || fileName.endsWith('.jsx')) {
+				// We need to trigger registration of the script file with the project
+				getScriptSnapshot(fileName);
+			}
 			return virtualScript.snapshot;
 		}
 		return getScriptSnapshot(fileName);


### PR DESCRIPTION
Angular plugin is transpiling the TS files. Within `getScriptSnapshot` there is a code which associated scrip info with a project. Without this call, scripts are orphaned and wrong config is used during highlighting. Not sure if this fix should apply to all types of files though