### PR TITLE
Use IterableIterator, not MapIterator

### DIFF
--- a/packages/language-core/lib/utils.ts
+++ b/packages/language-core/lib/utils.ts
@@ -6,7 +6,7 @@ export class FileMap<T> extends Map<string, T> {
 		super();
 	}
 
-	keys() {
+	keys(): IterableIterator<string> {
 		return this.originalFileNames.values();
 	}
 


### PR DESCRIPTION
Some reason the current volar package uses the non-existent `MapIterator` when it should be using `IterableIterator`. This is causing my local TS compilation to fail. I'm not sure why others aren't encountering it.

https://unpkg.com/@volar/language-core@2.4.11/lib/utils.d.ts

Perhaps this PR will fix it; then again, in my local of the Volar library, it correctly generates `IterableIterator`, so I don't have a way of testing this fix. 