### PR TITLE
fix(typescript): focus update target file version on association dirty

### DIFF
--- a/packages/language-core/index.ts
+++ b/packages/language-core/index.ts
@@ -22,7 +22,8 @@ export const defaultMapperFactory: MapperFactory = mappings => new SourceMap(map
 export function createLanguage<T>(
 	plugins: LanguagePlugin<T>[],
 	scriptRegistry: Map<T, SourceScript<T>>,
-	sync: (id: T, includeFsFiles: boolean, shouldRegister: boolean) => void
+	sync: (id: T, includeFsFiles: boolean, shouldRegister: boolean) => void,
+	onAssociationDirty?: (targetId: T) => void
 ) {
 	const virtualCodeToSourceScriptMap = new WeakMap<VirtualCode, SourceScript<T>>();
 	const virtualCodeToSourceMap = new WeakMap<IScriptSnapshot, WeakMap<IScriptSnapshot, Mapper>>();
@@ -213,6 +214,7 @@ export function createLanguage<T>(
 			const sourceScript = scriptRegistry.get(id);
 			if (sourceScript) {
 				sourceScript.isAssociationDirty = true;
+				onAssociationDirty?.(sourceScript.id);
 			}
 		});
 	}

--- a/packages/typescript/lib/quickstart/languageServicePluginCommon.ts
+++ b/packages/typescript/lib/quickstart/languageServicePluginCommon.ts
@@ -60,6 +60,17 @@ export function createLanguageCommon(
 			else {
 				language.scripts.delete(fileName);
 			}
+		},
+		targetFileName => {
+			// https://github.com/JetBrains/intellij-plugins/blob/6435723ad88fa296b41144162ebe3b8513f4949b/Angular/src-js/angular-service/src/ngCommands.ts#L88
+			(info.session as any).change({
+				file: targetFileName,
+				line: 1,
+				offset: 1,
+				endLine: 1,
+				endOffset: 1,
+				insertString: '',
+			});
 		}
 	);
 


### PR DESCRIPTION
In Glint, when the association script (.hbs) is updated and the target script (.ts) is not, the association script's diagnostics don't refresh correctly because the target script's getScriptVersion value hasn't changed.

We can't proxy getScriptVersion to deal with this, that would cause serious performance issues with the tsserver some how, so we send a change event to the tsserver session to force the target script to be considered new.

/cc @piotrtomiak, @machty