### PR TITLE
refactor(typescript): return patched typescript package

### DIFF
--- a/packages/typescript/lib/quickstart/runTsc.ts
+++ b/packages/typescript/lib/quickstart/runTsc.ts
@@ -55,7 +55,7 @@ export function runTsc(
 	};
 
 	try {
-		require(tscPath);
+		return require(tscPath);
 	} finally {
 		(fs as any).readFileSync = readFileSync;
 		delete require.cache[tscPath];


### PR DESCRIPTION
Hello, I tried to find a way to use `vue-tsc` programmatically to pass it into tools like `webpack/rspack-ts-checker`, but it is currently designed to simply invoke only `tsc` cli.
This PR in combination with a [same change on `vue-tsc` side](https://github.com/vuejs/language-tools/pull/5517) will allow to make use of not just `lib/tsc`, but also `lib/typescript` and pass it to any tool that expects the typescript API as simply as

```js
// vue-typescript.js
module.exports = require('vue-tsc').runTsc(require.resolve('typescript'))
```

```js
...
someCheckerPlugin({
  typescript: require.resolve('./vue-typescript')
})
...
```
