### PR TITLE
feat: supports `maximumLength` param of `getQuickInfoAtPosition`

### DIFF
--- a/packages/typescript/lib/node/proxyLanguageService.ts
+++ b/packages/typescript/lib/node/proxyLanguageService.ts
@@ -341,7 +341,7 @@ function organizeImports(language: Language<string>, organizeImports: ts.Languag
 	};
 }
 function getQuickInfoAtPosition(language: Language<string>, getQuickInfoAtPosition: ts.LanguageService['getQuickInfoAtPosition']): ts.LanguageService['getQuickInfoAtPosition'] {
-	return (filePath, position) => {
+	return (filePath, position, maximumLength) => {
 		const fileName = filePath.replace(windowsPathReg, '/');
 		const [serviceScript, targetScript, sourceScript] = getServiceScript(language, fileName);
 		if (targetScript?.associatedOnly) {
@@ -350,7 +350,7 @@ function getQuickInfoAtPosition(language: Language<string>, getQuickInfoAtPositi
 		if (serviceScript) {
 			const infos: ts.QuickInfo[] = [];
 			for (const [generatePosition] of toGeneratedOffsets(language, serviceScript, sourceScript, position, isHoverEnabled)) {
-				const info = getQuickInfoAtPosition(targetScript.id, generatePosition);
+				const info = getQuickInfoAtPosition(targetScript.id, generatePosition, maximumLength);
 				if (info) {
 					const textSpan = transformTextSpan(sourceScript, language, serviceScript, info.textSpan, true, isHoverEnabled)?.[1];
 					if (textSpan) {
@@ -401,7 +401,7 @@ function getQuickInfoAtPosition(language: Language<string>, getQuickInfoAtPositi
 			}
 		}
 		else {
-			return getQuickInfoAtPosition(fileName, position);
+			return getQuickInfoAtPosition(fileName, position, maximumLength);
 		}
 	};
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,10 +16,10 @@ importers:
         version: 4.6.2(@types/node@24.1.0)(conventional-commits-filter@5.0.0)
       '@tsslint/cli':
         specifier: latest
-        version: 1.5.18(typescript@5.8.3)
+        version: 1.5.18(typescript@5.9.2)
       typescript:
         specifier: latest
-        version: 5.8.3
+        version: 5.9.2
       vite:
         specifier: latest
         version: 7.0.6(@types/node@24.1.0)(yaml@2.8.0)
@@ -1018,17 +1018,17 @@ packages:
   '@vitest/utils@3.2.4':
     resolution: {integrity: sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==}
 
-  '@volar/language-core@2.4.21':
-    resolution: {integrity: sha512-wZwZR01AECsTJWl+dDG/z7OpQ6JX4Qvw03OhdrTB1UHm1xwrA5FeVPizjDS8oKWaO10x5wyGthkl5eZpFvRjqw==}
+  '@volar/language-core@2.4.22':
+    resolution: {integrity: sha512-gp4M7Di5KgNyIyO903wTClYBavRt6UyFNpc5LWfyZr1lBsTUY+QrVZfmbNF2aCyfklBOVk9YC4p+zkwoyT7ECg==}
 
   '@volar/language-hub@0.0.1':
     resolution: {integrity: sha512-2eOUnlMKTyjtlXIVd+6pfAtcuVugxCOgpNgcLWmlPuncQTG5C1E5mTDL/PUMw7aEnLySUOtMTIp8lT3vk/7w6Q==}
 
-  '@volar/source-map@2.4.21':
-    resolution: {integrity: sha512-75StdrLgYsu9Bi4WFrB21VlAwvfDiPEagvew1MiS5c47yQblSf8otvfDcVBquYaJ4Bp/9pg9swLyK5f/3+oggQ==}
+  '@volar/source-map@2.4.22':
+    resolution: {integrity: sha512-L2nVr/1vei0xKRgO2tYVXtJYd09HTRjaZi418e85Q+QdbbqA8h7bBjfNyPPSsjnrOO4l4kaAo78c8SQUAdHvgA==}
 
-  '@volar/typescript@2.4.21':
-    resolution: {integrity: sha512-Lz1Sw5kJtiBXlFzAyjILJCFsYbjHFGcBBlM6JPwygyXuAwcgbyxwA8NfUMMzJrQzlKbugbhRKk1WCydcBaOhzQ==}
+  '@volar/typescript@2.4.22':
+    resolution: {integrity: sha512-6ZczlJW1/GWTrNnkmZxJp4qyBt/SGVlcTuCWpI5zLrdPdCZsj66Aff9ZsfFaT3TyjG8zVYgBMYPuCm/eRkpcpQ==}
 
   '@vscode/vsce-sign-alpine-arm64@2.0.2':
     resolution: {integrity: sha512-E80YvqhtZCLUv3YAf9+tIbbqoinWLCO/B3j03yQPbjT3ZIHCliKZlsy1peNc4XNZ5uIb87Jn0HWx/ZbPXviuAQ==}
@@ -2886,6 +2886,11 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
+  typescript@5.9.2:
+    resolution: {integrity: sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
   uc.micro@2.1.0:
     resolution: {integrity: sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==}
 
@@ -4013,22 +4018,22 @@ snapshots:
     dependencies:
       '@textlint/ast-node-types': 14.8.4
 
-  '@tsslint/cli@1.5.18(typescript@5.8.3)':
+  '@tsslint/cli@1.5.18(typescript@5.9.2)':
     dependencies:
       '@clack/prompts': 0.8.2
-      '@tsslint/config': 1.5.18(typescript@5.8.3)
+      '@tsslint/config': 1.5.18(typescript@5.9.2)
       '@tsslint/core': 1.5.18
-      '@volar/language-core': 2.4.21
+      '@volar/language-core': 2.4.22
       '@volar/language-hub': 0.0.1
-      '@volar/typescript': 2.4.21
+      '@volar/typescript': 2.4.22
       glob: 10.4.5
       json5: 2.2.3
-      typescript: 5.8.3
+      typescript: 5.9.2
 
-  '@tsslint/config@1.5.18(typescript@5.8.3)':
+  '@tsslint/config@1.5.18(typescript@5.9.2)':
     dependencies:
       '@tsslint/types': 1.5.18
-      ts-api-utils: 2.0.1(typescript@5.8.3)
+      ts-api-utils: 2.0.1(typescript@5.9.2)
     transitivePeerDependencies:
       - typescript
 
@@ -4123,17 +4128,17 @@ snapshots:
       loupe: 3.1.4
       tinyrainbow: 2.0.0
 
-  '@volar/language-core@2.4.21':
+  '@volar/language-core@2.4.22':
     dependencies:
-      '@volar/source-map': 2.4.21
+      '@volar/source-map': 2.4.22
 
   '@volar/language-hub@0.0.1': {}
 
-  '@volar/source-map@2.4.21': {}
+  '@volar/source-map@2.4.22': {}
 
-  '@volar/typescript@2.4.21':
+  '@volar/typescript@2.4.22':
     dependencies:
-      '@volar/language-core': 2.4.21
+      '@volar/language-core': 2.4.22
       path-browserify: 1.0.1
       vscode-uri: 3.1.0
 
@@ -6092,9 +6097,9 @@ snapshots:
 
   treeverse@3.0.0: {}
 
-  ts-api-utils@2.0.1(typescript@5.8.3):
+  ts-api-utils@2.0.1(typescript@5.9.2):
     dependencies:
-      typescript: 5.8.3
+      typescript: 5.9.2
 
   tslib@2.8.1: {}
 
@@ -6130,6 +6135,8 @@ snapshots:
   typesafe-path@0.2.2: {}
 
   typescript@5.8.3: {}
+
+  typescript@5.9.2: {}
 
   uc.micro@2.1.0: {}
 


### PR DESCRIPTION
This PR:
- Updated typescript to 5.9.2
- Add `maximumLength` param support in `getQuickInfoAtPosition`

Fixed:
https://github.com/vuejs/language-tools/issues/5577

Reference:
https://devblogs.microsoft.com/typescript/announcing-typescript-5-9/
https://github.com/microsoft/TypeScript/pull/61662
https://github.com/microsoft/vscode/pull/248181
