### PR TITLE
fix(typescript): set original file's script kind to match the service script's in `proxyCreateProgram`

### DIFF
--- a/packages/typescript/lib/node/proxyCreateProgram.ts
+++ b/packages/typescript/lib/node/proxyCreateProgram.ts
@@ -180,6 +180,8 @@ export function proxyCreateProgram(
 							);
 							// @ts-expect-error
 							parsedSourceFile.version = originalSourceFile.version;
+							// @ts-expect-error
+              originalSourceFile.scriptKind = serviceScript.scriptKind;
 							parsedSourceFiles.set(originalSourceFile, parsedSourceFile);
 						}
 						if (getExtraServiceScripts) {


### PR DESCRIPTION
In https://github.com/flint-fyi/flint/pull/1179 I'm using `proxyCreateProgram` to patch the programs created by the Project Service. Parsed files are stored in TypeScript's document registry. When a file is parsed and later updated in the Project Service, it tries to reuse the old document, but the script kinds don't match, so TS fails with:

```
Error: Debug Failure. False expression: Script kind should match provided ScriptKind:4 and sourceFile.scriptKind: 3, !entry: false
 ❯ getDocumentRegistryEntry ../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/typescript.js:143966:11
 ❯ Object.releaseDocumentWithKey ../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/typescript.js:144060:19
 ❯ Object.getOrCreateSourceFileByPath [as getSourceFileByPath] ../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/typescript.js:152941:30
 ❯ tryReuseStructureFromOldProgram ../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/typescript.js:127648:59
 ❯ _createProgram ../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/typescript.js:127100:23
 ❯ Object.apply ../../node_modules/.pnpm/@volar+typescript@2.4.27/node_modules/@volar/typescript/lib/node/proxyCreateProgram.js:180:37
 ❯ Object.apply src/language.ts:111:47
    109|     });
    110|
    111|     const program: ProxiedTSProgram = Reflect.apply(proxied, thisArg, args);
       |                                               ^
    112|
    113|     if (volarLanguage == null) {
 ❯ createProgram ../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/typescript.js:126939:3
 ❯ synchronizeHostDataWorker ../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/typescript.js:152877:15
 ❯ synchronizeHostData ../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/typescript.js:152772:7
```

If we set the original file's script kind to match the service script's script kind, then everything works as expected: https://github.com/flint-fyi/flint/blob/75d19831b7476b89271989fbe25e9d1593d4e628/patches/%40volar__typescript%402.4.27.patch