### PR TITLE
fix(typescript): shim `tryAddingExtensions` to evade ts2876

### DIFF
--- a/packages/typescript/lib/quickstart/runTsc.ts
+++ b/packages/typescript/lib/quickstart/runTsc.ts
@@ -153,6 +153,17 @@ export function transformTscContent(
 			+ s.replace('createProgram', '_createProgram'),
 	);
 
+	tsc = replace(tsc, /switch \(originalExtension\) {/, () => {
+		return [
+			'switch (originalExtension) {',
+			...extraSupportedExtensions.map(ext => [
+				'\x20'.repeat(4) + `case "${ext}":`,
+				'\x20'.repeat(6)
+				+ `return extensions & 1 /* TypeScript */ && tryExtension("${ext}", /* resolvedUsingTsExtension */ true) || void 0;`,
+			]).flat(),
+		].join('\n');
+	});
+
 	return tsc;
 }
 


### PR DESCRIPTION
Relate https://github.com/vuejs/language-tools/issues/5957

This PR only change the `resolvedModule.resolvedUsingTsExtension` to true.



When resolvedModule.resolvedUsingTsExtension is falsy, it will emit ts2876.

```ts
// https://github.com/microsoft/TypeScript/blob/main/src/compiler/checker.ts#L4730
function resolveExternalModule(...){
	...
	if (!resolvedModule.resolvedUsingTsExtension && shouldRewrite) {
	 	error(@ts2876);
	}
	...
}
```


### before:

resolve: 
[tryAddingExtensions](https://github.com/microsoft/TypeScript/blob/9059e5bda0bb603ae6b41eca09dcd2a071af45fd/src/compiler/moduleNameResolver.ts#L2131) -> switch.default -> tryExtension('.d${originalExtension}.ts') 
-> `return {..., resolvedUsingTsExtension: {someState} && undefined }` always falsy

### after: 

resolve: 
[tryAddingExtensions](https://github.com/microsoft/TypeScript/blob/9059e5bda0bb603ae6b41eca09dcd2a071af45fd/src/compiler/moduleNameResolver.ts#L2131) -> switch.case extraSupportedExtensions  -> tryExtension(extraSupportedExtension, true) 
-> `return {..., resolvedUsingTsExtension: {someState} && true }`