### PR TITLE
fix(typescript): remove resolver shortcut that splits module resolution caches

### DIFF
--- a/packages/typescript/lib/node/proxyCreateProgram.ts
+++ b/packages/typescript/lib/node/proxyCreateProgram.ts
@@ -222,19 +222,6 @@ export function proxyCreateProgram(
 						compilerOptions,
 					);
 					try {
-						if (
-							resolveModuleNameLiterals
-							&& moduleLiterals.every(name => !pluginExtensions.some(ext => name.text.endsWith(ext)))
-						) {
-							return resolveModuleNameLiterals(
-								moduleLiterals,
-								containingFile,
-								redirectedReference,
-								compilerOptions,
-								containingSourceFile,
-								...rest,
-							);
-						}
 						return moduleLiterals.map(moduleLiteral => {
 							const mode = ts.getModeForUsageLocation(containingSourceFile, moduleLiteral, compilerOptions);
 							return resolveModuleName(
@@ -259,16 +246,6 @@ export function proxyCreateProgram(
 					compilerOptions,
 					containingSourceFile,
 				) => {
-					if (resolveModuleNames && moduleNames.every(name => !pluginExtensions.some(ext => name.endsWith(ext)))) {
-						return resolveModuleNames(
-							moduleNames,
-							containingFile,
-							reusedNames,
-							redirectedReference,
-							compilerOptions,
-							containingSourceFile,
-						);
-					}
 					return moduleNames.map(moduleName => {
 						return resolveModuleName(
 							moduleName,


### PR DESCRIPTION
The resolveModuleNameLiterals and resolveModuleNames hooks have a shortcut: files whose imports don't end with a plugin extension (.vue) bypass the custom resolver and use the original host's resolver. This means files that augment `'vue'` (Nuxt's `imports.d.ts`, `plugins.d.ts`) go through a different resolution cache than files that import `.vue` components (`components.d.ts`). TypeScript treats the `'vue'` module resolved through each cache as separate module identities, so `ComponentCustomProperties` augmentations (`$route`, `navigateTo`, etc.) are dropped from the component instance type in templates.

This PR removes both shortcuts so all files use the custom resolver with a single shared `moduleResolutionCache`. The shortcut was a performance optimization, but in testing it actually shows no regression — the reproduction case is faster without it (1s vs 3.4s), likely because the single cache avoids redundant resolution work.

Tested against the reproduction at https://github.com/zlotnika/nuxt-34562-repro and a production Nuxt 4 project with vue 3.5.32, nuxt 4.4.2, 110+ components, and 7 modules.

Fixes vuejs/language-tools#5995